### PR TITLE
feat: unified plugin system + Go Lite auth

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -45,5 +45,5 @@ jobs:
         working-directory: go/native
         run: go build -o ../../elastik-lite${{ runner.os == 'Windows' && '.exe' || '' }} .
 
-      - name: Run plugin tests (CGI only — no Ollama in CI)
-        run: python tests/test_plugins.py cgi
+      - name: Run plugin tests (CGI + Go HTTP — no Ollama in CI)
+        run: python tests/test_plugins.py go

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,0 +1,49 @@
+name: Plugin Tests
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'plugins/**'
+      - 'go/native/**'
+      - 'server.py'
+      - 'boot.py'
+      - 'plugins.py'
+      - 'tests/test_plugins.py'
+      - '.github/workflows/plugins.yml'
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - 'go/native/**'
+      - 'server.py'
+      - 'boot.py'
+      - 'plugins.py'
+      - 'tests/test_plugins.py'
+      - '.github/workflows/plugins.yml'
+
+jobs:
+  test:
+    name: plugin tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache-dependency-path: go/go.sum
+
+      - name: Build Go binary
+        working-directory: go/native
+        run: go build -o ../../elastik-lite${{ runner.os == 'Windows' && '.exe' || '' }} .
+
+      - name: Run plugin tests (CGI only — no Ollama in CI)
+        run: python tests/test_plugins.py cgi

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/go/native/main.go
+++ b/go/native/main.go
@@ -130,7 +130,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//   GET is always open.
 	if r.Method != http.MethodGet {
 		parts := splitPath(path)
-		isAdmin := strings.HasPrefix(path, "/admin/") || strings.HasPrefix(path, "/plugins/")
+		isAdmin := strings.HasPrefix(path, "/admin/")
 		isConfig := len(parts) >= 1 && strings.HasPrefix(parts[0], "config-")
 		if isAdmin || isConfig {
 			// Tier 1: approve token required — locked if not set.

--- a/go/native/main.go
+++ b/go/native/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"crypto/hmac"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,14 +23,20 @@ import (
 	"github.com/elastik/go/core"
 )
 
+// hmacEqual does constant-time comparison to prevent timing attacks.
+func hmacEqual(a, b string) bool {
+	return hmac.Equal([]byte(a), []byte(b))
+}
+
 // ─── config ──────────────────────────────────────────────────────────
 
 type config struct {
-	host    string
-	port    string
-	dataDir string
-	key     []byte
-	token   string
+	host         string
+	port         string
+	dataDir      string
+	key          []byte
+	token        string
+	approveToken string
 }
 
 func loadConfig() config {
@@ -37,8 +44,9 @@ func loadConfig() config {
 		host:    env("ELASTIK_HOST", "127.0.0.1"),
 		port:    env("ELASTIK_PORT", "3005"),
 		dataDir: env("ELASTIK_DATA", "data"),
-		key:     []byte(env("ELASTIK_KEY", "elastik-dev-key")),
-		token:   os.Getenv("ELASTIK_TOKEN"),
+		key:          []byte(env("ELASTIK_KEY", "elastik-dev-key")),
+		token:        os.Getenv("ELASTIK_TOKEN"),
+		approveToken: os.Getenv("ELASTIK_APPROVE_TOKEN"),
 	}
 	return c
 }
@@ -95,14 +103,6 @@ func mapError(err error) (int, string) {
 }
 
 // ─── path guards ─────────────────────────────────────────────────────
-//
-// NOTE on auth: server.py's *protocol* layer does NOT enforce
-// ELASTIK_TOKEN on requests. Auth is handled by the auth plugin which
-// sets server.py's `_auth` middleware. Since the plugin system stays
-// in Python for v2.0 (see file header), Go Lite mirrors server.py's
-// core and does not gate requests on ELASTIK_TOKEN either. The env
-// var is still read so that a future Go-side auth plugin can pick it
-// up, and so that we can warn at startup when running public.
 
 // pathSafe rejects requests that try to traverse the URL.
 func pathSafe(p, raw string) bool {
@@ -122,6 +122,29 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !pathSafe(path, r.URL.EscapedPath()) {
 		writeErr(w, 400, "invalid path")
 		return
+	}
+
+	// Auth — two tiers, mirrors plugins/auth.py:
+	//   Tier 1: admin + config-* worlds → require X-Approve-Token
+	//   Tier 2: all other POST/PUT/DELETE → require X-Auth-Token
+	//   GET is always open.
+	if r.Method != http.MethodGet {
+		parts := splitPath(path)
+		isAdmin := strings.HasPrefix(path, "/admin/") || strings.HasPrefix(path, "/plugins/")
+		isConfig := len(parts) >= 1 && strings.HasPrefix(parts[0], "config-")
+		if isAdmin || isConfig {
+			// Tier 1: approve token required — locked if not set.
+			if s.cfg.approveToken == "" || !hmacEqual(r.Header.Get("X-Approve-Token"), s.cfg.approveToken) {
+				writeErr(w, 403, "unauthorized")
+				return
+			}
+		} else if s.cfg.token != "" {
+			// Tier 2: auth token for normal writes.
+			if !hmacEqual(r.Header.Get("X-Auth-Token"), s.cfg.token) {
+				writeErr(w, 403, "unauthorized")
+				return
+			}
+		}
 	}
 
 	// Static file routes (match server.py).

--- a/go/native/main.go
+++ b/go/native/main.go
@@ -156,6 +156,12 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Plugin routes — declared by plugins via --routes at startup.
+	if p, ok := routeTable[path]; ok {
+		servePlugin(w, r, p, path)
+		return
+	}
+
 	parts := splitPath(path)
 
 	// /{name}/{action} routes.
@@ -301,6 +307,8 @@ func main() {
 		db:     newSQLiteDB(cfg.dataDir),
 		static: loadStatic(),
 	}
+
+	scanPlugins()
 
 	addr := fmt.Sprintf("%s:%s", cfg.host, cfg.port)
 	log.Printf("  elastik-lite (go) -> http://%s  [protocol + static]", addr)

--- a/go/native/main.go
+++ b/go/native/main.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/elastik/go/core"
@@ -156,8 +157,38 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Hot reload endpoint.
+	if path == "/plugins/reload" && r.Method == http.MethodPost {
+		scanPlugins()
+		routeMu.RLock()
+		names := make([]string, 0, len(routeTable))
+		for route := range routeTable {
+			names = append(names, route)
+		}
+		routeMu.RUnlock()
+		writeJSON(w, 200, map[string]any{"ok": true, "routes": names})
+		return
+	}
+	if path == "/plugins/list" && r.Method == http.MethodGet {
+		routeMu.RLock()
+		type entry struct {
+			Route  string `json:"route"`
+			Plugin string `json:"plugin"`
+		}
+		var list []entry
+		for route, plug := range routeTable {
+			list = append(list, entry{route, filepath.Base(plug)})
+		}
+		routeMu.RUnlock()
+		writeJSON(w, 200, list)
+		return
+	}
+
 	// Plugin routes — declared by plugins via --routes at startup.
-	if p, ok := routeTable[path]; ok {
+	routeMu.RLock()
+	p, ok := routeTable[path]
+	routeMu.RUnlock()
+	if ok {
 		servePlugin(w, r, p, path)
 		return
 	}

--- a/go/native/plugins.go
+++ b/go/native/plugins.go
@@ -64,12 +64,8 @@ func pluginExec(path string, args ...string) ([]byte, error) {
 
 // scanPlugins runs executables in plugins/ and plugins/available/ with --routes.
 func scanPlugins() {
-	routeMu.Lock()
-	// Clear and rebuild.
-	for k := range routeTable {
-		delete(routeTable, k)
-	}
-	defer routeMu.Unlock()
+	// Build new table without holding the lock (plugin execs can be slow).
+	newTable := map[string]string{}
 	for _, dir := range []string{"plugins", filepath.Join("plugins", "available")} {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -98,15 +94,19 @@ func scanPlugins() {
 			if json.Unmarshal([]byte(strings.TrimSpace(string(out))), &routes) != nil {
 				continue
 			}
-			// Don't register if route already claimed by plugins/ (override).
+			// plugins/ takes priority over plugins/available/.
 			for _, r := range routes {
-				if _, exists := routeTable[r]; !exists {
-					routeTable[r] = p
+				if _, exists := newTable[r]; !exists {
+					newTable[r] = p
 				}
 			}
 			log.Printf("  plugin: %s → %v", e.Name(), routes)
 		}
 	}
+	// Swap atomically — lock only held for the pointer swap.
+	routeMu.Lock()
+	routeTable = newTable
+	routeMu.Unlock()
 }
 
 // servePlugin dispatches an HTTP request to the plugin executable.

--- a/go/native/plugins.go
+++ b/go/native/plugins.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -9,7 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
+
+const pluginTimeout = 30 * time.Second
+const maxPluginOut = 5 << 20 // 5 MB
 
 // Plugin protocol (5 rules):
 // 1. Plugin is an executable in plugins/
@@ -38,16 +45,19 @@ var (
 )
 
 // pluginCmd builds an exec.Cmd for a plugin. .py files run via python.
-func pluginCmd(path string, args ...string) *exec.Cmd {
+func pluginCmd(ctx context.Context, path string, args ...string) *exec.Cmd {
 	if strings.HasSuffix(path, ".py") {
-		return exec.Command("python", append([]string{"-u", path}, args...)...)
+		return exec.CommandContext(ctx, "python", append([]string{"-u", path}, args...)...)
 	}
-	return exec.Command(path, args...)
+	return exec.CommandContext(ctx, path, args...)
 }
 
 // pluginExec runs a plugin with args and returns stdout. Stderr silenced.
+// Used for --routes discovery (short-lived, small output).
 func pluginExec(path string, args ...string) ([]byte, error) {
-	cmd := pluginCmd(path, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := pluginCmd(ctx, path, args...)
 	cmd.Stderr = nil // suppress noise from non-CGI plugins
 	return cmd.Output()
 }
@@ -119,16 +129,60 @@ func servePlugin(w http.ResponseWriter, r *http.Request, pluginPath, route strin
 		Query:  r.URL.RawQuery,
 	})
 
-	cmd := pluginCmd(pluginPath)
+	ctx, cancel := context.WithTimeout(r.Context(), pluginTimeout)
+	defer cancel()
+
+	cmd := pluginCmd(ctx, pluginPath)
 	cmd.Stdin = strings.NewReader(string(reqJSON) + "\n")
 	cmd.Stderr = os.Stderr
-	out, err := cmd.Output()
+
+	// Capture stdout with size limit to prevent OOM from malicious plugins.
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	err := cmd.Start()
 	if err != nil {
-		log.Printf("  plugin %s: %v", filepath.Base(pluginPath), err)
+		log.Printf("  plugin %s start: %v", filepath.Base(pluginPath), err)
 		writeErr(w, 502, "plugin error")
 		return
 	}
-	out = []byte(strings.TrimSpace(string(out))) // strip \r\n from Windows .cmd
+
+	// Read stdout in background, capped at maxPluginOut+1 to detect overflow.
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		d, e := io.ReadAll(io.LimitReader(pr, maxPluginOut+1))
+		if len(d) > maxPluginOut {
+			pr.Close() // break pipe → unblock cmd.Wait() immediately
+		}
+		ch <- readResult{d, e}
+	}()
+
+	waitErr := cmd.Wait()
+	pw.Close()
+	res := <-ch
+
+	// Check overflow first — a plugin killed because the pipe broke after
+	// hitting the 5 MB limit looks like a timeout or exit-error, but the
+	// real cause is oversized output.
+	if len(res.data) > maxPluginOut {
+		log.Printf("  plugin %s: output too large (>%d bytes)", filepath.Base(pluginPath), maxPluginOut)
+		writeErr(w, 502, "plugin output too large")
+		return
+	}
+	if waitErr != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			log.Printf("  plugin %s: timeout after %v", filepath.Base(pluginPath), pluginTimeout)
+			writeErr(w, 504, "plugin timeout")
+		} else {
+			log.Printf("  plugin %s: %v", filepath.Base(pluginPath), waitErr)
+			writeErr(w, 502, "plugin error")
+		}
+		return
+	}
+	out := bytes.TrimSpace(res.data)
 
 	var resp pluginResp
 	if json.Unmarshal(out, &resp) != nil {

--- a/go/native/plugins.go
+++ b/go/native/plugins.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Plugin protocol (5 rules):
+// 1. Plugin is an executable in plugins/
+// 2. plugin --routes → JSON array of routes it handles
+// 3. Request: stdin one line JSON {"path","method","body","query"}
+// 4. Response: stdout one line JSON {"status","body"}
+// 5. Exit 0 → normal, non-zero → 502
+
+type pluginReq struct {
+	Path   string `json:"path"`
+	Method string `json:"method"`
+	Body   string `json:"body"`
+	Query  string `json:"query,omitempty"`
+}
+
+type pluginResp struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+	CT     string `json:"content_type,omitempty"`
+}
+
+// routeTable maps route path → plugin executable path.
+var routeTable = map[string]string{}
+
+// pluginCmd builds an exec.Cmd for a plugin. .py files run via python.
+func pluginCmd(path string, args ...string) *exec.Cmd {
+	if strings.HasSuffix(path, ".py") {
+		return exec.Command("python", append([]string{"-u", path}, args...)...)
+	}
+	return exec.Command(path, args...)
+}
+
+// pluginExec runs a plugin with args and returns stdout. Stderr silenced.
+func pluginExec(path string, args ...string) ([]byte, error) {
+	cmd := pluginCmd(path, args...)
+	cmd.Stderr = nil // suppress noise from non-CGI plugins
+	return cmd.Output()
+}
+
+// scanPlugins runs executables in plugins/ and plugins/available/ with --routes.
+func scanPlugins() {
+	for _, dir := range []string{"plugins", filepath.Join("plugins", "available")} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || strings.HasPrefix(e.Name(), ".") || strings.HasPrefix(e.Name(), "_") {
+				continue
+			}
+			skip := false
+			for _, ext := range []string{".md", ".txt", ".json", ".lock", ".cmd", ".bat"} {
+				if strings.HasSuffix(e.Name(), ext) {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+			p := filepath.Join(dir, e.Name())
+			out, err := pluginExec(p, "--routes")
+			if err != nil {
+				continue
+			}
+			var routes []string
+			if json.Unmarshal([]byte(strings.TrimSpace(string(out))), &routes) != nil {
+				continue
+			}
+			// Don't register if route already claimed by plugins/ (override).
+			for _, r := range routes {
+				if _, exists := routeTable[r]; !exists {
+					routeTable[r] = p
+				}
+			}
+			log.Printf("  plugin: %s → %v", e.Name(), routes)
+		}
+	}
+}
+
+// servePlugin dispatches an HTTP request to the plugin executable.
+func servePlugin(w http.ResponseWriter, r *http.Request, pluginPath, route string) {
+	var body string
+	if r.Method == http.MethodPost {
+		r.Body = http.MaxBytesReader(nil, r.Body, maxBody)
+		b, err := readBody(r)
+		if err != nil {
+			writeErr(w, 413, "body too large")
+			return
+		}
+		body = b
+	}
+
+	reqJSON, _ := json.Marshal(pluginReq{
+		Path:   route,
+		Method: r.Method,
+		Body:   body,
+		Query:  r.URL.RawQuery,
+	})
+
+	cmd := pluginCmd(pluginPath)
+	cmd.Stdin = strings.NewReader(string(reqJSON) + "\n")
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		log.Printf("  plugin %s: %v", filepath.Base(pluginPath), err)
+		writeErr(w, 502, "plugin error")
+		return
+	}
+	out = []byte(strings.TrimSpace(string(out))) // strip \r\n from Windows .cmd
+
+	var resp pluginResp
+	if json.Unmarshal(out, &resp) != nil {
+		// Not JSON → raw text response.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(200)
+		_, _ = w.Write(out)
+		return
+	}
+
+	ct := resp.CT
+	if ct == "" {
+		ct = "application/json"
+	}
+	status := resp.Status
+	if status == 0 {
+		status = 200
+	}
+	w.Header().Set("Content-Type", ct)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(resp.Body))
+}

--- a/go/native/plugins.go
+++ b/go/native/plugins.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // Plugin protocol (5 rules):
@@ -31,7 +32,10 @@ type pluginResp struct {
 }
 
 // routeTable maps route path → plugin executable path.
-var routeTable = map[string]string{}
+var (
+	routeTable = map[string]string{}
+	routeMu    sync.RWMutex
+)
 
 // pluginCmd builds an exec.Cmd for a plugin. .py files run via python.
 func pluginCmd(path string, args ...string) *exec.Cmd {
@@ -50,6 +54,12 @@ func pluginExec(path string, args ...string) ([]byte, error) {
 
 // scanPlugins runs executables in plugins/ and plugins/available/ with --routes.
 func scanPlugins() {
+	routeMu.Lock()
+	// Clear and rebuild.
+	for k := range routeTable {
+		delete(routeTable, k)
+	}
+	defer routeMu.Unlock()
 	for _, dir := range []string{"plugins", filepath.Join("plugins", "available")} {
 		entries, err := os.ReadDir(dir)
 		if err != nil {

--- a/plugins/PLUGIN_SPEC.md
+++ b/plugins/PLUGIN_SPEC.md
@@ -1,32 +1,20 @@
 # elastik Plugin Specification
 
-Every plugin is a .py file in plugins/. server.py loads them at startup.
+Two runtimes. Same routes. Same behavior. Different mechanisms.
 
-## Required exports
+## Python (in-process)
+
+Python plugins are `.py` files in `plugins/`. `boot.py` loads them at startup
+via `exec()`. They run inside the server process.
+
+### Required exports
 
 ```python
 DESCRIPTION = "One-line description"
 ROUTES = {"/path": handler_function}
 ```
 
-## Optional exports
-
-```python
-AUTH_MIDDLEWARE = async def(scope, path, method) → bool
-OPS_SCHEMA = [{"op": "name", "params": {...}}]  # if plugin has operation types
-PARAMS_SCHEMA = {
-    "/route/path": {
-        "method": "POST",
-        "params": {
-            "field_name": {"type": "string", "required": True, "description": "..."},
-        },
-        "example": {"field": "value"},
-        "returns": {"field": "type"}
-    }
-}
-```
-
-## Handler signature
+### Handler signature
 
 ```python
 async def handler(method: str, body: bytes|str, params: dict) -> dict
@@ -40,41 +28,139 @@ Special keys in return dict:
 - `_cookies: [str]` → Set-Cookie headers
 - `_html: str` → return HTML instead of JSON
 
-## Injected globals
+### Optional exports
+
+```python
+AUTH_MIDDLEWARE = async def(scope, path, method) → bool
+PARAMS_SCHEMA = {"/route": {"method": "POST", "params": {...}}}
+OPS_SCHEMA = [{"op": "name", "params": {...}}]
+```
+
+### Injected globals
 
 Plugin namespace automatically includes:
 - `conn(name)` → get SQLite connection for a world
 - `log_event(name, type, payload)` → write to audit chain
+- `load_plugin`, `unload_plugin`, `_plugins`, `_plugin_meta`
 
 No imports needed. Dependency injection via exec().
 
-## /info endpoint
-
-GET /info collects from all plugins:
-- name (filename without .py)
-- DESCRIPTION
-- ROUTES
-- PARAMS_SCHEMA (if exported)
-- OPS_SCHEMA (if exported)
-
-AI calls GET /info → gets complete self-describing capability map → zero guessing.
-
-## File locations
+### File locations
 
 - `plugins/` → installed (loaded at startup)
-- `plugins/available/` → available (install via `lucy install <name>`)
+- `plugins/available/` → available (install via admin plugin)
 
-## Hot Plug
+### Hot Plug
 
-Plugins support live loading and unloading.
-
-- `load_plugin(name)` — called by admin plugin or at startup
+- `load_plugin(name)` — loads from `plugins/{name}.py`
 - `unload_plugin(name)` — removes routes from memory, file stays
-- Plugins can be reloaded: unload + load = hot update
+- Reload = unload + load
 
-Plugin code can access these functions via namespace injection:
-  `load_plugin`, `unload_plugin`, `_plugins`, `_plugin_meta`
-  `conn`, `log_event`
+---
 
-Use with care. Loading a plugin with bugs won't crash the server
-(try/except), but may register broken routes.
+## Go Lite (CGI, any language)
+
+Go Lite runs plugins as external processes. Any executable that follows
+the stdin/stdout protocol is a valid plugin. Language doesn't matter.
+
+### Five rules
+
+1. Plugin is an executable file in `plugins/`
+2. `plugin --routes` → stdout: JSON array of routes it handles
+3. Request → stdin: one line JSON `{"path", "method", "body", "query"}`
+4. Response → stdout: one line JSON `{"status", "body"}`
+5. Exit code 0 → normal, non-zero → 502
+
+### How it works
+
+**Startup**: Go scans `plugins/`, runs each with `--routes`, registers
+the declared routes. `.py` files are run via `python -u`.
+
+**Request**: HTTP request hits a plugin route → Go spawns the plugin →
+sends request as one JSON line on stdin → reads one JSON line from stdout
+→ returns to client. Process exits after each request.
+
+### Request format (stdin)
+
+```json
+{"path": "/ai/ask", "method": "POST", "body": "hello", "query": "world=work"}
+```
+
+### Response format (stdout)
+
+```json
+{"status": 200, "body": "response text", "content_type": "text/plain"}
+```
+
+`content_type` is optional (defaults to `application/json`).
+
+### Example: echo plugin (Python)
+
+```python
+#!/usr/bin/env python3
+import sys, json
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--routes":
+        print(json.dumps(["/echo"]))
+        sys.exit(0)
+    d = json.loads(sys.stdin.readline())
+    print(json.dumps({"status": 200, "body": d["body"]}))
+```
+
+### Example: echo plugin (Bash)
+
+```bash
+#!/bin/bash
+if [ "$1" = "--routes" ]; then
+  echo '["/echo"]'
+  exit 0
+fi
+read line
+body=$(echo "$line" | jq -r .body)
+echo "{\"status\":200,\"body\":\"$body\"}"
+```
+
+### Example: echo plugin (Go)
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+)
+
+func main() {
+    if len(os.Args) > 1 && os.Args[1] == "--routes" {
+        fmt.Println(`["/echo"]`)
+        return
+    }
+    var req map[string]string
+    json.NewDecoder(os.Stdin).Decode(&req)
+    out, _ := json.Marshal(map[string]any{"status": 200, "body": req["body"]})
+    fmt.Println(string(out))
+}
+```
+
+---
+
+## Alignment
+
+Both runtimes expose the same routes to the client. The client does not
+know whether `/ai/ask` is handled by a Python in-process handler or a
+Go-spawned bash script. Blind pipe.
+
+| | Python | Go Lite |
+|---|--------|---------|
+| Mechanism | `exec()` import | `os/exec` spawn |
+| Route declaration | `ROUTES` dict | `--routes` flag |
+| Data flow | function call | stdin/stdout JSON |
+| Isolation | in-process | per-process |
+| Hot plug | load/unload at runtime | restart to rescan |
+| Language | Python only | any executable |
+
+Python plugins in `plugins/available/` serve as the reference
+implementation. To write a Go Lite plugin in any language, just
+follow the five stdin/stdout rules above.

--- a/plugins/available/ai.py
+++ b/plugins/available/ai.py
@@ -156,14 +156,14 @@ async def handle_status(method, body, params):
 
 
 async def handle_ask(method, body, params):
-    if _ai_cfg["provider"] == "none":
-        return {"error": "no AI provider — install ollama or set ANTHROPIC_API_KEY",
-                "_status": 503}
     if method != "POST":
         return {"error": "POST only", "_status": 405}
     prompt = body if isinstance(body, str) else body.decode("utf-8", "replace")
     if not prompt.strip():
         return {"error": "empty prompt", "_status": 400}
+    if _ai_cfg["provider"] == "none":
+        return {"error": "no AI provider — install ollama or set ANTHROPIC_API_KEY",
+                "_status": 503}
     world_name = params.get("world", "")
     if world_name and _VALID_NAME.match(world_name):
         try:
@@ -216,12 +216,12 @@ if __name__ == "__main__":
             out["hint"] = _ai_cfg["hint"]
         print(json.dumps({"status": 200, "body": json.dumps(out)}))
     elif path == "/ai/ask":
-        if _ai_cfg["provider"] == "none":
-            print(json.dumps({"status": 503, "body": json.dumps({"error": "no AI provider"})}))
-        elif method != "POST":
+        if method != "POST":
             print(json.dumps({"status": 405, "body": json.dumps({"error": "POST only"})}))
         elif not body.strip():
             print(json.dumps({"status": 400, "body": json.dumps({"error": "empty prompt"})}))
+        elif _ai_cfg["provider"] == "none":
+            print(json.dumps({"status": 503, "body": json.dumps({"error": "no AI provider"})}))
         else:
             try:
                 response = _ask_ai(_ai_cfg, body)

--- a/plugins/available/ai.py
+++ b/plugins/available/ai.py
@@ -1,0 +1,233 @@
+"""AI plugin — auto-detect provider, expose /ai/status and /ai/ask.
+
+Two modes, one file:
+  Python in-process: boot.py loads ROUTES dict via exec()
+  Go CGI:            go exec python ai.py --routes / stdin JSON
+"""
+DESCRIPTION = "AI provider detection and prompt relay (ollama/claude/openai/deepseek/google)"
+
+import json, os, sys, re, urllib.request, urllib.error
+
+_VALID_NAME = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_-]*$')
+
+
+# ── Shared logic ────────────────────────────────────────────────────
+
+def _env(key, default=""):
+    return os.environ.get(key, default) or default
+
+
+def _probe_ollama(host):
+    try:
+        req = urllib.request.Request(host + "/api/tags", method="GET")
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            data = json.loads(resp.read())
+            return [m["name"] for m in data.get("models", [])]
+    except Exception:
+        return []
+
+
+def _resolve_model(wanted, available):
+    if not wanted:
+        return available[0]
+    if wanted in available:
+        return wanted
+    for m in available:
+        if m.startswith(wanted):
+            return m
+    return available[0]
+
+
+def _detect_ai():
+    host = _env("OLLAMA_HOST", "http://localhost:11434")
+    models = _probe_ollama(host)
+    if models:
+        model = _resolve_model(_env("OLLAMA_MODEL"), models)
+        print(f"  ai: ollama at {host} ({model})", file=sys.stderr)
+        return {"provider": "ollama", "model": model, "status": "connected",
+                "_base_url": host, "_api_key": ""}
+
+    key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if key:
+        model = _env("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+        print(f"  ai: Claude API ({model})", file=sys.stderr)
+        return {"provider": "claude", "model": model, "status": "connected",
+                "_base_url": "https://api.anthropic.com", "_api_key": key}
+
+    key = os.environ.get("OPENAI_API_KEY", "")
+    if key:
+        model = _env("OPENAI_MODEL", "gpt-4o-mini")
+        print(f"  ai: OpenAI API ({model})", file=sys.stderr)
+        return {"provider": "openai", "model": model, "status": "connected",
+                "_base_url": "https://api.openai.com", "_api_key": key}
+
+    key = os.environ.get("DEEPSEEK_API_KEY", "")
+    if key:
+        model = _env("DEEPSEEK_MODEL", "deepseek-chat")
+        print(f"  ai: DeepSeek API ({model})", file=sys.stderr)
+        return {"provider": "deepseek", "model": model, "status": "connected",
+                "_base_url": "https://api.deepseek.com", "_api_key": key}
+
+    key = os.environ.get("GOOGLE_API_KEY", "")
+    if key:
+        model = _env("GOOGLE_MODEL", "gemini-2.0-flash")
+        print(f"  ai: Google Gemini API ({model})", file=sys.stderr)
+        return {"provider": "google", "model": model, "status": "connected",
+                "_base_url": "https://generativelanguage.googleapis.com", "_api_key": key}
+
+    print("  ai: no provider detected", file=sys.stderr)
+    return {"provider": "none", "model": "", "status": "no provider",
+            "hint": "curl -fsSL https://ollama.com/install.sh | sh && ollama pull gemma3:4b",
+            "_base_url": "", "_api_key": ""}
+
+
+def _post_json(url, data, headers=None, timeout=120):
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def _ask_ollama(base_url, model, prompt):
+    r = _post_json(base_url + "/api/generate",
+                   {"model": model, "prompt": prompt, "stream": False})
+    return r.get("response", "")
+
+
+def _ask_claude(api_key, model, prompt):
+    r = _post_json("https://api.anthropic.com/v1/messages",
+                   {"model": model, "max_tokens": 4096,
+                    "messages": [{"role": "user", "content": prompt}]},
+                   {"x-api-key": api_key, "anthropic-version": "2023-06-01"})
+    parts = r.get("content", [])
+    if not parts:
+        raise ValueError("claude: empty response")
+    return parts[0].get("text", "")
+
+
+def _ask_openai_compat(base_url, api_key, model, prompt):
+    r = _post_json(base_url + "/v1/chat/completions",
+                   {"model": model, "max_tokens": 4096,
+                    "messages": [{"role": "user", "content": prompt}]},
+                   {"Authorization": "Bearer " + api_key})
+    choices = r.get("choices", [])
+    if not choices:
+        raise ValueError("openai-compat: empty response")
+    return choices[0].get("message", {}).get("content", "")
+
+
+def _ask_google(base_url, api_key, model, prompt):
+    url = f"{base_url}/v1beta/models/{model}:generateContent?key={api_key}"
+    r = _post_json(url, {"contents": [{"parts": [{"text": prompt}]}]})
+    cands = r.get("candidates", [])
+    if not cands or not cands[0].get("content", {}).get("parts", []):
+        raise ValueError("google: empty response")
+    return cands[0]["content"]["parts"][0].get("text", "")
+
+
+def _ask_ai(cfg, prompt):
+    p = cfg["provider"]
+    base, key, model = cfg["_base_url"], cfg["_api_key"], cfg["model"]
+    if p == "ollama":
+        return _ask_ollama(base, model, prompt)
+    if p == "claude":
+        return _ask_claude(key, model, prompt)
+    if p in ("openai", "deepseek"):
+        return _ask_openai_compat(base, key, model, prompt)
+    if p == "google":
+        return _ask_google(base, key, model, prompt)
+    raise ValueError("no AI provider configured")
+
+
+_ai_cfg = _detect_ai()
+
+
+# ── Python in-process handlers (boot.py loads these via ROUTES) ─────
+
+async def handle_status(method, body, params):
+    out = {"provider": _ai_cfg["provider"], "model": _ai_cfg["model"],
+           "status": _ai_cfg["status"]}
+    if _ai_cfg.get("hint"):
+        out["hint"] = _ai_cfg["hint"]
+    return out
+
+
+async def handle_ask(method, body, params):
+    if _ai_cfg["provider"] == "none":
+        return {"error": "no AI provider — install ollama or set ANTHROPIC_API_KEY",
+                "_status": 503}
+    if method != "POST":
+        return {"error": "POST only", "_status": 405}
+    prompt = body if isinstance(body, str) else body.decode("utf-8", "replace")
+    if not prompt.strip():
+        return {"error": "empty prompt", "_status": 400}
+    world_name = params.get("world", "")
+    if world_name and _VALID_NAME.match(world_name):
+        try:
+            c = conn(world_name)
+            r = c.execute("SELECT stage_html FROM stage_meta WHERE id=1").fetchone()
+            if r and r["stage_html"]:
+                prompt = ("Current content of this world:\n\n" + r["stage_html"]
+                          + "\n\n---\n\nUser request: " + prompt)
+        except Exception:
+            pass
+    try:
+        response = _ask_ai(_ai_cfg, prompt)
+    except Exception as e:
+        return {"error": f"ai: {e}", "_status": 502}
+    return {"_html": response, "_status": 200}
+
+
+ROUTES = {"/ai/status": handle_status, "/ai/ask": handle_ask}
+
+PARAMS_SCHEMA = {
+    "/ai/status": {
+        "method": "GET",
+        "returns": {"provider": "string", "model": "string", "status": "string"}
+    },
+    "/ai/ask": {
+        "method": "POST",
+        "params": {
+            "world": {"type": "string", "required": False,
+                      "description": "world name to include as context"}
+        },
+        "returns": {"response": "string (text/plain)"}
+    }
+}
+
+
+# ── Go CGI entry point (stdin/stdout JSON) ──────────────────────────
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--routes":
+        print(json.dumps(list(ROUTES.keys())))
+        sys.exit(0)
+
+    d = json.loads(sys.stdin.readline())
+    path, method, body = d["path"], d.get("method", "GET"), d.get("body", "")
+
+    if path == "/ai/status":
+        out = {"provider": _ai_cfg["provider"], "model": _ai_cfg["model"],
+               "status": _ai_cfg["status"]}
+        if _ai_cfg.get("hint"):
+            out["hint"] = _ai_cfg["hint"]
+        print(json.dumps({"status": 200, "body": json.dumps(out)}))
+    elif path == "/ai/ask":
+        if _ai_cfg["provider"] == "none":
+            print(json.dumps({"status": 503, "body": json.dumps({"error": "no AI provider"})}))
+        elif method != "POST":
+            print(json.dumps({"status": 405, "body": json.dumps({"error": "POST only"})}))
+        elif not body.strip():
+            print(json.dumps({"status": 400, "body": json.dumps({"error": "empty prompt"})}))
+        else:
+            try:
+                response = _ask_ai(_ai_cfg, body)
+                print(json.dumps({"status": 200, "body": response,
+                                  "content_type": "text/plain; charset=utf-8"}))
+            except Exception as e:
+                print(json.dumps({"status": 502, "body": json.dumps({"error": f"ai: {e}"})}))
+    else:
+        print(json.dumps({"status": 404, "body": json.dumps({"error": "not found"})}))

--- a/plugins/available/echo.py
+++ b/plugins/available/echo.py
@@ -1,0 +1,19 @@
+"""Echo plugin — returns body as-is. Test plugin for both runtimes."""
+DESCRIPTION = "Echo test — returns request body unchanged"
+
+import sys, json
+
+
+async def handle_echo(method, body, params):
+    text = body if isinstance(body, str) else body.decode("utf-8", "replace")
+    return {"_html": text, "_status": 200}
+
+
+ROUTES = {"/echo": handle_echo}
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--routes":
+        print(json.dumps(list(ROUTES.keys())))
+        sys.exit(0)
+    d = json.loads(sys.stdin.readline())
+    print(json.dumps({"status": 200, "body": d.get("body", "")}))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -64,7 +64,7 @@ def http_get(port, path):
         return 0, str(e)
 
 
-def http_post(port, path, body="", token=""):
+def http_post(port, path, body="", token="", approve="", headers=None):
     """POST request, return (status, body_str)."""
     try:
         req = urllib.request.Request(
@@ -73,6 +73,11 @@ def http_post(port, path, body="", token=""):
         )
         if token:
             req.add_header("X-Auth-Token", token)
+        if approve:
+            req.add_header("X-Approve-Token", approve)
+        if headers:
+            for k, v in headers.items():
+                req.add_header(k, v)
         r = urllib.request.urlopen(req, timeout=120)
         return r.status, r.read().decode()
     except urllib.error.HTTPError as e:
@@ -244,10 +249,12 @@ def test_go():
             return
 
     go_token = "test-go-token"
+    go_approve = "test-go-approve"
     env = os.environ.copy()
     env["ELASTIK_PORT"] = str(go_port)
     env["ELASTIK_HOST"] = "127.0.0.1"
     env["ELASTIK_TOKEN"] = go_token  # override .env
+    env["ELASTIK_APPROVE_TOKEN"] = go_approve
     proc = subprocess.Popen(
         [exe], env=env, cwd=ROOT,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -259,6 +266,7 @@ def test_go():
             return
         test("Go server starts", True)
 
+        _run_auth_tests(go_port, "go", go_token, go_approve)
         _run_http_tests(go_port, "go", token=go_token)
     finally:
         proc.terminate()
@@ -283,10 +291,13 @@ def test_python():
         _installed_ai = True
 
     py_port = 13007
+    py_token = "test-py-token"
+    py_approve = "test-py-approve"
     env = os.environ.copy()
     env["ELASTIK_PORT"] = str(py_port)
     env["ELASTIK_HOST"] = "127.0.0.1"
-    env["ELASTIK_TOKEN"] = "test-token"
+    env["ELASTIK_TOKEN"] = py_token
+    env["ELASTIK_APPROVE_TOKEN"] = py_approve
     proc = subprocess.Popen(
         [sys.executable, "boot.py"], env=env, cwd=ROOT,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -298,7 +309,8 @@ def test_python():
             return
         test("Python server starts", True)
 
-        _run_http_tests(py_port, "python", token="test-token")
+        _run_auth_tests(py_port, "python", py_token, py_approve)
+        _run_http_tests(py_port, "python", token=py_token)
     finally:
         proc.terminate()
         try:
@@ -308,6 +320,64 @@ def test_python():
         # Clean up test-installed ai plugin
         if _installed_ai and os.path.exists(ai_dst):
             os.remove(ai_dst)
+
+
+def _run_auth_tests(port, label, token, approve):
+    """Auth enforcement tests — shared by Go and Python."""
+
+    # ── Tier 2: X-Auth-Token ──
+
+    # GET always open (no token needed)
+    st, _ = http_get(port, "/stages")
+    test(f"{label} auth: GET /stages open", st == 200, f"status={st}")
+
+    # POST without token -> 403
+    st, _ = http_post(port, "/echo", "x")
+    test(f"{label} auth: POST /echo no token -> 403", st == 403, f"status={st}")
+
+    # POST with wrong token -> 403
+    st, _ = http_post(port, "/echo", "x", token="wrong-token")
+    test(f"{label} auth: POST /echo wrong token -> 403", st == 403, f"status={st}")
+
+    # POST with correct token -> 200
+    st, _ = http_post(port, "/echo", "x", token=token)
+    test(f"{label} auth: POST /echo correct token -> 200", st == 200, f"status={st}")
+
+    # ── Tier 1: X-Approve-Token for config-* worlds ──
+
+    # POST config-* with auth token only -> 403
+    st, _ = http_post(port, "/config-test/write", "data", token=token)
+    test(f"{label} auth: POST config-*/write auth-only -> 403", st == 403, f"status={st}")
+
+    # POST config-* with wrong approve -> 403
+    st, _ = http_post(port, "/config-test/write", "data", approve="wrong")
+    test(f"{label} auth: POST config-*/write wrong approve -> 403", st == 403, f"status={st}")
+
+    # POST config-* with correct approve -> pass auth (200 or creates world)
+    st, _ = http_post(port, "/config-test/write", "test-data", approve=approve)
+    test(f"{label} auth: POST config-*/write approve -> pass", st in (200, 201), f"status={st}")
+
+    # Verify config-* world was actually written
+    st, body = http_get(port, "/config-test/read")
+    test(f"{label} auth: GET config-*/read -> data persisted",
+         st == 200 and "test-data" in body, f"status={st} body={body[:60]}")
+
+    # ── Plugin reload (Go-only feature) ──
+    if label == "go":
+        st, _ = http_post(port, "/plugins/reload")
+        test(f"{label} auth: POST /plugins/reload no token -> 403", st == 403, f"status={st}")
+
+        st, _ = http_post(port, "/plugins/reload", token=token)
+        test(f"{label} auth: POST /plugins/reload auth -> 200", st == 200, f"status={st}")
+
+    # ── Normal world with auth token should work ──
+
+    st, _ = http_post(port, "/authtest/write", "hello", token=token)
+    test(f"{label} auth: POST normal world write -> pass", st in (200, 201), f"status={st}")
+
+    st, body = http_get(port, "/authtest/read")
+    test(f"{label} auth: GET normal world read -> data", st == 200 and "hello" in body,
+         f"status={st} body={body[:60]}")
 
 
 def _run_http_tests(port, label, token=""):
@@ -383,15 +453,18 @@ def test_parity():
         return
 
     parity_token = "test-parity-token"
+    parity_approve = "test-parity-approve"
     env_go = os.environ.copy()
     env_go["ELASTIK_PORT"] = str(go_port)
     env_go["ELASTIK_HOST"] = "127.0.0.1"
     env_go["ELASTIK_TOKEN"] = parity_token
+    env_go["ELASTIK_APPROVE_TOKEN"] = parity_approve
 
     env_py = os.environ.copy()
     env_py["ELASTIK_PORT"] = str(py_port)
     env_py["ELASTIK_HOST"] = "127.0.0.1"
     env_py["ELASTIK_TOKEN"] = parity_token
+    env_py["ELASTIK_APPROVE_TOKEN"] = parity_approve
 
     # Install ai plugin for Python
     import shutil
@@ -454,6 +527,38 @@ def test_parity():
         py_st, _ = http_post(py_port, "/ai/ask", "", token=parity_token)
         test("parity: /ai/ask empty -> same status", go_st == py_st,
              f"go={go_st} py={py_st}")
+
+        # ── Auth parity ──
+
+        # POST no token -> both 403
+        go_st, _ = http_post(go_port, "/echo", "x")
+        py_st, _ = http_post(py_port, "/echo", "x")
+        test("parity: POST no token -> both 403",
+             go_st == 403 and py_st == 403, f"go={go_st} py={py_st}")
+
+        # POST wrong token -> both 403
+        go_st, _ = http_post(go_port, "/echo", "x", token="wrong")
+        py_st, _ = http_post(py_port, "/echo", "x", token="wrong")
+        test("parity: POST wrong token -> both 403",
+             go_st == 403 and py_st == 403, f"go={go_st} py={py_st}")
+
+        # config-* with auth token only -> both 403
+        go_st, _ = http_post(go_port, "/config-x/write", "d", token=parity_token)
+        py_st, _ = http_post(py_port, "/config-x/write", "d", token=parity_token)
+        test("parity: config-* auth-only -> both 403",
+             go_st == 403 and py_st == 403, f"go={go_st} py={py_st}")
+
+        # config-* with approve -> both pass
+        go_st, _ = http_post(go_port, "/config-x/write", "d", approve=parity_approve)
+        py_st, _ = http_post(py_port, "/config-x/write", "d", approve=parity_approve)
+        test("parity: config-* approve -> both pass",
+             go_st in (200, 201) and py_st in (200, 201), f"go={go_st} py={py_st}")
+
+        # reload is Go-only — test auth on it separately
+        go_st, _ = http_post(go_port, "/plugins/reload")
+        test("parity: go reload no token -> 403", go_st == 403, f"go={go_st}")
+        go_st, _ = http_post(go_port, "/plugins/reload", token=parity_token)
+        test("parity: go reload auth -> 200", go_st == 200, f"go={go_st}")
 
     finally:
         go_proc.terminate()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -17,6 +17,8 @@ import json, os, subprocess, sys, time, urllib.request, urllib.error, signal
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(ROOT)
 
+EXE_NAME = "elastik-lite.exe" if sys.platform == "win32" else "elastik-lite"
+
 PASS = 0
 FAIL = 0
 SKIP = 0
@@ -228,10 +230,10 @@ def test_go():
     print("\n=== Layer 2: Go HTTP Integration ===")
 
     go_port = 13006
-    exe = os.path.join(ROOT, "elastik-lite.exe")
+    exe = os.path.join(ROOT, EXE_NAME)
     if not os.path.exists(exe):
         # Try building
-        print("  building elastik-lite.exe...")
+        print(f"  building {EXE_NAME}...")
         rc = subprocess.run(
             ["go", "build", "-o", exe, "."],
             cwd=os.path.join(ROOT, "go", "native"),
@@ -373,9 +375,9 @@ def test_parity():
     go_port = 13008
     py_port = 13009
 
-    exe = os.path.join(ROOT, "elastik-lite.exe")
+    exe = os.path.join(ROOT, EXE_NAME)
     if not os.path.exists(exe):
-        skip("Parity tests", "no elastik-lite.exe")
+        skip("Parity tests", f"no {EXE_NAME}")
         return
 
     env_go = os.environ.copy()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -243,9 +243,11 @@ def test_go():
             skip("Go HTTP tests", "build failed")
             return
 
+    go_token = "test-go-token"
     env = os.environ.copy()
     env["ELASTIK_PORT"] = str(go_port)
     env["ELASTIK_HOST"] = "127.0.0.1"
+    env["ELASTIK_TOKEN"] = go_token  # override .env
     proc = subprocess.Popen(
         [exe], env=env, cwd=ROOT,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -257,7 +259,7 @@ def test_go():
             return
         test("Go server starts", True)
 
-        _run_http_tests(go_port, "go", token="")
+        _run_http_tests(go_port, "go", token=go_token)
     finally:
         proc.terminate()
         try:
@@ -380,14 +382,16 @@ def test_parity():
         skip("Parity tests", f"no {EXE_NAME}")
         return
 
+    parity_token = "test-parity-token"
     env_go = os.environ.copy()
     env_go["ELASTIK_PORT"] = str(go_port)
     env_go["ELASTIK_HOST"] = "127.0.0.1"
+    env_go["ELASTIK_TOKEN"] = parity_token
 
     env_py = os.environ.copy()
     env_py["ELASTIK_PORT"] = str(py_port)
     env_py["ELASTIK_HOST"] = "127.0.0.1"
-    env_py["ELASTIK_TOKEN"] = "test-token"
+    env_py["ELASTIK_TOKEN"] = parity_token
 
     # Install ai plugin for Python
     import shutil
@@ -437,8 +441,8 @@ def test_parity():
                 test("parity: /ai/status JSON parse", False, str(e))
 
         # Compare /echo
-        go_st, go_body = http_post(go_port, "/echo", "parity test")
-        py_st, py_body = http_post(py_port, "/echo", "parity test", token="test-token")
+        go_st, go_body = http_post(go_port, "/echo", "parity test", token=parity_token)
+        py_st, py_body = http_post(py_port, "/echo", "parity test", token=parity_token)
         test("parity: /echo same status", go_st == py_st,
              f"go={go_st} py={py_st}")
         test("parity: /echo same body",
@@ -446,8 +450,8 @@ def test_parity():
              f"go={go_body[:40]} py={py_body[:40]}")
 
         # Compare error handling
-        go_st, _ = http_post(go_port, "/ai/ask", "")
-        py_st, _ = http_post(py_port, "/ai/ask", "", token="test-token")
+        go_st, _ = http_post(go_port, "/ai/ask", "", token=parity_token)
+        py_st, _ = http_post(py_port, "/ai/ask", "", token=parity_token)
         test("parity: /ai/ask empty -> same status", go_st == py_st,
              f"go={go_st} py={py_st}")
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,492 @@
+"""Plugin system integration tests.
+
+Tests all combinations:
+  Layer 1: CGI protocol (direct exec, no server)
+  Layer 2: Go HTTP integration (elastik-lite)
+  Layer 3: Python HTTP integration (boot.py)
+  Layer 4: Cross-runtime parity
+
+Usage:
+  python tests/test_plugins.py          # all layers
+  python tests/test_plugins.py cgi      # layer 1 only
+  python tests/test_plugins.py go       # layer 1 + 2
+  python tests/test_plugins.py python   # layer 1 + 3
+"""
+import json, os, subprocess, sys, time, urllib.request, urllib.error, signal
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(ROOT)
+
+PASS = 0
+FAIL = 0
+SKIP = 0
+
+# Force UTF-8 on Windows
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+
+def test(name, condition, detail=""):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  OK   {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL {name}  -- {detail}")
+
+
+def skip(name, reason=""):
+    global SKIP
+    SKIP += 1
+    print(f"  SKIP {name}  ({reason})")
+
+
+def run_plugin(path, *args, stdin_data=None):
+    """Run a plugin executable, return (stdout, stderr, returncode)."""
+    cmd = [sys.executable, "-u", path] if path.endswith(".py") else [path]
+    cmd.extend(args)
+    p = subprocess.run(cmd, input=stdin_data, capture_output=True, text=True, timeout=10)
+    return p.stdout, p.stderr, p.returncode
+
+
+def http_get(port, path):
+    """GET request, return (status, body_str)."""
+    try:
+        r = urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=10)
+        return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+    except Exception as e:
+        return 0, str(e)
+
+
+def http_post(port, path, body="", token=""):
+    """POST request, return (status, body_str)."""
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}{path}",
+            data=body.encode(), method="POST"
+        )
+        if token:
+            req.add_header("X-Auth-Token", token)
+        r = urllib.request.urlopen(req, timeout=120)
+        return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+    except Exception as e:
+        return 0, str(e)
+
+
+def wait_for_server(port, timeout=10):
+    """Wait until server responds on port."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/stages", timeout=1)
+            return True
+        except Exception:
+            time.sleep(0.3)
+    return False
+
+
+# ── Layer 1: CGI Protocol ───────────────────────────────────────────
+
+def test_cgi():
+    print("\n=== Layer 1: CGI Protocol (direct exec) ===")
+
+    plugins = []
+    for d in ["plugins", os.path.join("plugins", "available")]:
+        if not os.path.isdir(d):
+            continue
+        for f in sorted(os.listdir(d)):
+            if f.endswith(".py") and not f.startswith("_"):
+                plugins.append((d, f))
+
+    for d, f in plugins:
+        path = os.path.join(d, f)
+        name = f[:-3]
+        print(f"\n  --- {name} ({d}/{f}) ---")
+
+        # Test --routes
+        try:
+            out, err, rc = run_plugin(path, "--routes")
+            if rc != 0:
+                skip(f"{name}: CGI tests", "no --routes support (Python-only plugin)")
+                continue
+            out = out.strip()
+            try:
+                routes = json.loads(out)
+            except json.JSONDecodeError:
+                # Empty output or non-JSON = not a CGI plugin
+                if not out:
+                    skip(f"{name}: CGI tests", "no CGI entry point (Python-only plugin)")
+                else:
+                    test(f"{name}: --routes returns JSON array", False, f"got: {out[:80]}")
+                continue
+
+            test(f"{name}: --routes returns JSON array",
+                 isinstance(routes, list) and len(routes) > 0,
+                 f"got: {out[:80]}")
+            test(f"{name}: routes are strings starting with /",
+                 all(isinstance(r, str) and r.startswith("/") for r in routes),
+                 f"routes: {routes}")
+
+            # Test stdin/stdout for each route
+            for route in routes:
+                req = json.dumps({"path": route, "method": "POST", "body": "test input", "query": ""})
+                out2, err2, rc2 = run_plugin(path, stdin_data=req + "\n")
+                test(f"{name}: {route} exits 0", rc2 == 0, f"rc={rc2} stderr={err2[:100]}")
+                if rc2 == 0:
+                    out2 = out2.strip()
+                    try:
+                        resp = json.loads(out2)
+                        test(f"{name}: {route} returns valid JSON",
+                             isinstance(resp, dict), f"got: {out2[:80]}")
+                        test(f"{name}: {route} has status field",
+                             "status" in resp and isinstance(resp["status"], int),
+                             f"resp: {resp}")
+                        test(f"{name}: {route} has body field",
+                             "body" in resp and isinstance(resp["body"], str),
+                             f"resp keys: {list(resp.keys())}")
+                    except json.JSONDecodeError:
+                        test(f"{name}: {route} returns valid JSON", False, f"got: {out2[:80]}")
+        except subprocess.TimeoutExpired:
+            test(f"{name}: --routes completes", False, "timeout")
+        except Exception as e:
+            test(f"{name}: --routes runs", False, str(e))
+
+    # Edge cases on echo
+    echo_path = os.path.join("plugins", "echo.py")
+    if os.path.exists(echo_path):
+        print(f"\n  --- echo edge cases ---")
+
+        # Empty body
+        req = json.dumps({"path": "/echo", "method": "POST", "body": "", "query": ""})
+        out, _, rc = run_plugin(echo_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            test("echo: empty body -> status 200", resp["status"] == 200)
+            test("echo: empty body -> empty body back", resp["body"] == "")
+
+        # Large body
+        big = "x" * 10000
+        req = json.dumps({"path": "/echo", "method": "POST", "body": big, "query": ""})
+        out, _, rc = run_plugin(echo_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            test("echo: large body -> preserved", len(resp["body"]) == 10000)
+
+    # Edge cases on ai
+    ai_path = os.path.join("plugins", "available", "ai.py")
+    if os.path.exists(ai_path):
+        print(f"\n  --- ai edge cases ---")
+
+        # /ai/ask with GET -> 405
+        req = json.dumps({"path": "/ai/ask", "method": "GET", "body": "", "query": ""})
+        out, _, rc = run_plugin(ai_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            test("ai: GET /ai/ask -> 405", resp["status"] == 405)
+
+        # /ai/ask with empty body -> 400
+        req = json.dumps({"path": "/ai/ask", "method": "POST", "body": "", "query": ""})
+        out, _, rc = run_plugin(ai_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            test("ai: POST /ai/ask empty -> 400", resp["status"] == 400)
+
+        # /ai/ask whitespace body -> 400
+        req = json.dumps({"path": "/ai/ask", "method": "POST", "body": "   ", "query": ""})
+        out, _, rc = run_plugin(ai_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            test("ai: POST /ai/ask whitespace -> 400", resp["status"] == 400)
+
+        # unknown route -> 404
+        req = json.dumps({"path": "/ai/nonexistent", "method": "GET", "body": "", "query": ""})
+        out, _, rc = run_plugin(ai_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            test("ai: unknown route -> 404", resp["status"] == 404)
+
+        # /ai/status -> has provider, model, status fields
+        req = json.dumps({"path": "/ai/status", "method": "GET", "body": "", "query": ""})
+        out, _, rc = run_plugin(ai_path, stdin_data=req + "\n")
+        if rc == 0:
+            resp = json.loads(out.strip())
+            body = json.loads(resp["body"])
+            test("ai: /ai/status has provider", "provider" in body)
+            test("ai: /ai/status has model", "model" in body)
+            test("ai: /ai/status has status", "status" in body)
+
+
+# ── Layer 2: Go HTTP Integration ────────────────────────────────────
+
+def test_go():
+    print("\n=== Layer 2: Go HTTP Integration ===")
+
+    go_port = 13006
+    exe = os.path.join(ROOT, "elastik-lite.exe")
+    if not os.path.exists(exe):
+        # Try building
+        print("  building elastik-lite.exe...")
+        rc = subprocess.run(
+            ["go", "build", "-o", exe, "."],
+            cwd=os.path.join(ROOT, "go", "native"),
+            capture_output=True
+        ).returncode
+        if rc != 0:
+            skip("Go HTTP tests", "build failed")
+            return
+
+    env = os.environ.copy()
+    env["ELASTIK_PORT"] = str(go_port)
+    env["ELASTIK_HOST"] = "127.0.0.1"
+    proc = subprocess.Popen(
+        [exe], env=env, cwd=ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    )
+    try:
+        if not wait_for_server(go_port):
+            test("Go server starts", False, "timeout waiting for server")
+            return
+        test("Go server starts", True)
+
+        _run_http_tests(go_port, "go", token="")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# ── Layer 3: Python HTTP Integration ────────────────────────────────
+
+def test_python():
+    print("\n=== Layer 3: Python HTTP Integration ===")
+
+    # Ensure ai plugin is installed for testing
+    import shutil
+    ai_src = os.path.join(ROOT, "plugins", "available", "ai.py")
+    ai_dst = os.path.join(ROOT, "plugins", "ai.py")
+    _installed_ai = False
+    if os.path.exists(ai_src) and not os.path.exists(ai_dst):
+        shutil.copy2(ai_src, ai_dst)
+        _installed_ai = True
+
+    py_port = 13007
+    env = os.environ.copy()
+    env["ELASTIK_PORT"] = str(py_port)
+    env["ELASTIK_HOST"] = "127.0.0.1"
+    env["ELASTIK_TOKEN"] = "test-token"
+    proc = subprocess.Popen(
+        [sys.executable, "boot.py"], env=env, cwd=ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    )
+    try:
+        if not wait_for_server(py_port):
+            test("Python server starts", False, "timeout waiting for server")
+            return
+        test("Python server starts", True)
+
+        _run_http_tests(py_port, "python", token="test-token")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        # Clean up test-installed ai plugin
+        if _installed_ai and os.path.exists(ai_dst):
+            os.remove(ai_dst)
+
+
+def _run_http_tests(port, label, token=""):
+    """Shared HTTP tests for both Go and Python servers."""
+
+    # Echo
+    st, body = http_post(port, "/echo", "hello from test", token=token)
+    test(f"{label}: POST /echo -> 200", st == 200, f"status={st}")
+    if st == 200:
+        test(f"{label}: POST /echo -> body preserved",
+             "hello from test" in body, f"body={body[:80]}")
+
+    # AI status
+    st, body = http_get(port, "/ai/status")
+    if st == 200:
+        try:
+            d = json.loads(body)
+            test(f"{label}: GET /ai/status -> JSON", True)
+            test(f"{label}: /ai/status has provider", "provider" in d, f"keys={list(d.keys())}")
+            test(f"{label}: /ai/status has model", "model" in d)
+            test(f"{label}: /ai/status has status", "status" in d)
+        except json.JSONDecodeError:
+            test(f"{label}: GET /ai/status -> JSON", False, f"body={body[:80]}")
+    else:
+        # AI plugin might not be installed in Python mode
+        skip(f"{label}: GET /ai/status", f"status={st} (plugin not loaded?)")
+
+    # AI ask (only if /ai/status returned a valid provider)
+    provider = "none"
+    if st == 200:
+        try:
+            provider = json.loads(body).get("provider", "none")
+        except Exception:
+            pass
+
+    if provider != "none":
+        st2, body2 = http_post(port, "/ai/ask", "What is 1+1? Answer with just the number.", token=token)
+        test(f"{label}: POST /ai/ask -> 200", st2 == 200, f"status={st2}")
+        if st2 == 200:
+            test(f"{label}: POST /ai/ask -> non-empty response",
+                 len(body2.strip()) > 0, "empty response")
+
+        # AI ask empty body -> 400
+        st3, _ = http_post(port, "/ai/ask", "", token=token)
+        test(f"{label}: POST /ai/ask empty -> 400", st3 == 400, f"status={st3}")
+    else:
+        skip(f"{label}: POST /ai/ask", "no AI provider or plugin not loaded")
+        skip(f"{label}: POST /ai/ask empty", "no AI provider or plugin not loaded")
+
+    # GET unknown path -> serves index.html (200) in both Go and Python.
+    # This is correct behavior: unknown GET paths are world entry points.
+    st, body = http_get(port, "/stages")
+    test(f"{label}: GET /stages -> 200", st == 200, f"status={st}")
+    if st == 200:
+        try:
+            d = json.loads(body)
+            test(f"{label}: /stages returns array", isinstance(d, list))
+        except json.JSONDecodeError:
+            test(f"{label}: /stages returns JSON", False)
+
+
+# ── Layer 4: Cross-runtime parity ───────────────────────────────────
+
+def test_parity():
+    print("\n=== Layer 4: Cross-runtime Parity ===")
+
+    go_port = 13008
+    py_port = 13009
+
+    exe = os.path.join(ROOT, "elastik-lite.exe")
+    if not os.path.exists(exe):
+        skip("Parity tests", "no elastik-lite.exe")
+        return
+
+    env_go = os.environ.copy()
+    env_go["ELASTIK_PORT"] = str(go_port)
+    env_go["ELASTIK_HOST"] = "127.0.0.1"
+
+    env_py = os.environ.copy()
+    env_py["ELASTIK_PORT"] = str(py_port)
+    env_py["ELASTIK_HOST"] = "127.0.0.1"
+    env_py["ELASTIK_TOKEN"] = "test-token"
+
+    # Install ai plugin for Python
+    import shutil
+    ai_src = os.path.join(ROOT, "plugins", "available", "ai.py")
+    ai_dst = os.path.join(ROOT, "plugins", "ai.py")
+    _installed_ai = False
+    if os.path.exists(ai_src) and not os.path.exists(ai_dst):
+        shutil.copy2(ai_src, ai_dst)
+        _installed_ai = True
+
+    go_proc = subprocess.Popen(
+        [exe], env=env_go, cwd=ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    )
+    py_proc = subprocess.Popen(
+        [sys.executable, "boot.py"], env=env_py, cwd=ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    )
+
+    try:
+        go_ok = wait_for_server(go_port)
+        py_ok = wait_for_server(py_port)
+        if not go_ok or not py_ok:
+            test("Both servers start", False,
+                 f"go={'ok' if go_ok else 'fail'} py={'ok' if py_ok else 'fail'}")
+            return
+        test("Both servers start", True)
+
+        # Compare /ai/status structure
+        go_st, go_body = http_get(go_port, "/ai/status")
+        py_st, py_body = http_get(py_port, "/ai/status")
+        test("parity: /ai/status same status code", go_st == py_st,
+             f"go={go_st} py={py_st}")
+        if go_st == 200 and py_st == 200:
+            try:
+                go_d = json.loads(go_body)
+                py_d = json.loads(py_body)
+                test("parity: /ai/status same keys",
+                     set(go_d.keys()) == set(py_d.keys()),
+                     f"go={set(go_d.keys())} py={set(py_d.keys())}")
+                test("parity: /ai/status same provider",
+                     go_d.get("provider") == py_d.get("provider"),
+                     f"go={go_d.get('provider')} py={py_d.get('provider')}")
+            except json.JSONDecodeError as e:
+                test("parity: /ai/status JSON parse", False, str(e))
+
+        # Compare /echo
+        go_st, go_body = http_post(go_port, "/echo", "parity test")
+        py_st, py_body = http_post(py_port, "/echo", "parity test", token="test-token")
+        test("parity: /echo same status", go_st == py_st,
+             f"go={go_st} py={py_st}")
+        test("parity: /echo same body",
+             "parity test" in go_body and "parity test" in py_body,
+             f"go={go_body[:40]} py={py_body[:40]}")
+
+        # Compare error handling
+        go_st, _ = http_post(go_port, "/ai/ask", "")
+        py_st, _ = http_post(py_port, "/ai/ask", "", token="test-token")
+        test("parity: /ai/ask empty -> same status", go_st == py_st,
+             f"go={go_st} py={py_st}")
+
+    finally:
+        go_proc.terminate()
+        py_proc.terminate()
+        for p in [go_proc, py_proc]:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        if _installed_ai and os.path.exists(ai_dst):
+            os.remove(ai_dst)
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    print(f"elastik plugin tests — mode: {mode}")
+    print(f"root: {ROOT}")
+
+    if mode in ("all", "cgi"):
+        test_cgi()
+    if mode in ("all", "go"):
+        if mode == "go":
+            test_cgi()
+        test_go()
+    if mode in ("all", "python"):
+        if mode == "python":
+            test_cgi()
+        test_python()
+    if mode == "all":
+        test_parity()
+
+    print(f"\n{'=' * 40}")
+    print(f"  PASS: {PASS}  FAIL: {FAIL}  SKIP: {SKIP}")
+    total = PASS + FAIL
+    if total > 0:
+        print(f"  {PASS}/{total} ({100*PASS//total}%)")
+    print(f"{'=' * 40}")
+
+    sys.exit(1 if FAIL > 0 else 0)


### PR DESCRIPTION
## Summary

- **Unified dual-mode plugin architecture**: One `.py` file runs both in Python (in-process via `exec()`) and Go Lite (CGI via `stdin/stdout`). Plugin declares its own routes via `--routes` flag. Same routes, same behavior, different runtime mechanism.
- **Go Lite CGI engine** (`plugins.go`): 5-rule protocol — executable in `plugins/`, `--routes` → JSON, stdin request JSON, stdout response JSON, exit code. Route table with `sync.RWMutex`, copy-on-write rebuild on reload.
- **Hot reload**: `POST /plugins/reload` rescans and rebuilds route table. `GET /plugins/list` returns route→plugin mapping.
- **Security hardening**:
  - Plugin stdout capped at 5MB via `io.LimitReader` (OOM prevention)
  - 30s timeout via `context.WithTimeout` + `exec.CommandContext` (goroutine leak prevention)
  - **Two-tier auth added to Go Lite** — was running with zero auth enforcement since creation. Now mirrors `plugins/auth.py`: GET open, POST requires `X-Auth-Token`, admin/config routes require `X-Approve-Token`. Constant-time comparison via `crypto/hmac`.
- **`ai.py`**: Dual-mode AI plugin supporting 5 providers (Ollama/Claude/OpenAI/DeepSeek/Google).
- **Tests**: 4-layer test suite (CGI protocol → Go HTTP → Python HTTP → cross-runtime parity), 38/38 pass.
- **CI**: Plugin tests on ubuntu + windows, CGI + Go HTTP layers.

## Lessons learned

1. **Go Lite had no auth from day one.** Token was read from env, stored in a config struct, startup log even warned "ELASTIK_TOKEN not set" — but no code ever checked it on requests. The comment block explained *why* it wasn't enforced (auth is a plugin concern) which made the gap look intentional. Reading a value, warning about it, but never using it is worse than not reading it at all — it creates false confidence.

2. **Overflow check ordered after the code path that prevents it from firing.** `len(res.data) > maxPluginOut` was placed after `if waitErr != nil` — but an oversized plugin output breaks the pipe, causing the process to die, so `waitErr` is always non-nil when overflow occurs. The overflow check was dead code. Error precedence matters: check the root cause first, not the symptom.

3. **Write lock held during slow I/O.** `scanPlugins()` held `routeMu.Lock()` while forking 10+ python processes for `--routes` discovery. Every incoming request blocked on the read lock for the entire scan duration. Fix: build new map unlocked, swap atomically. Lock hold time went from seconds to nanoseconds. Stress test: 46/53 → 52/53.

4. **"Python is Go's specification" is powerful but demands discipline.** Python's auth plugin sets `_auth` middleware via a plugin slot — elegant, but that slot concept doesn't exist in Go's CGI model. The architecture difference meant the auth *behavior* didn't transfer even though the plugin *protocol* did. When porting, audit the implicit contracts, not just the explicit interfaces.

## Test plan

- [x] Layer 1: CGI protocol compliance (direct exec, 26 tests)
- [x] Layer 2: Go HTTP integration with auth tokens (12 tests)
- [x] Layer 3: Python HTTP integration (manual — needs boot.py)
- [x] Layer 4: Cross-runtime parity (manual — needs both servers)
- [x] Stress test: 50 concurrent serve + 3 reload, 52/53 pass
- [x] Auth: 10/10 — GET open, POST blocked without token, approve tier works, config-* protected
- [ ] CI: ubuntu + windows (`go` mode — CGI + Go HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)