### PR TITLE
fix: canonicalize encoded paths for capability scopes

### DIFF
--- a/server.py
+++ b/server.py
@@ -308,8 +308,10 @@ def _path_in_scope(path, prefix):
     without this step, '/home/dreams/../etc/shadow' would pass a naive
     startswith on '/home/dreams'. Boundary-sensitive: '/home/dre' must
     not match '/home/dreams'."""
-    import posixpath
-    cleaned = posixpath.normpath("/" + path.lstrip("/"))
+    import posixpath, unicodedata
+    from urllib.parse import unquote
+    cleaned = unicodedata.normalize("NFC", unquote(path or "/"))
+    cleaned = posixpath.normpath("/" + cleaned.lstrip("/"))
     p = prefix.rstrip("/") or "/"
     if p == "/":
         return True  # root scope covers everything


### PR DESCRIPTION
## Summary
- canonicalize request paths before capability scope checks
- treat encoded and decoded Unicode paths as the same URL-space
- fix unicode capability tokens minted via /auth/mint for direct world reads and writes

## Validation
- python tests/test_plugins.py python
- python tests/test_router.py
- python tests/test_semantic.py
