### PR TITLE
feat(core): add native SCoAP UDP surface

### DIFF
--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -54,19 +54,19 @@ impl Tokens {
         };
         let credentials = credentials.trim();
         if scheme.eq_ignore_ascii_case("Bearer") {
-            return self.check_token(credentials.as_bytes());
+            return self.check_token_bytes(credentials.as_bytes());
         }
         if scheme.eq_ignore_ascii_case("Basic") {
             if let Ok(decoded) = B64.decode(credentials) {
                 if let Some(idx) = decoded.iter().position(|&b| b == b':') {
-                    return self.check_token(&decoded[idx + 1..]);
+                    return self.check_token_bytes(&decoded[idx + 1..]);
                 }
             }
         }
         Tier::Anon
     }
 
-    fn check_token(&self, candidate: &[u8]) -> Tier {
+    pub(crate) fn check_token_bytes(&self, candidate: &[u8]) -> Tier {
         // Defense in depth: even if a configured token is somehow
         // empty (config drift, test fixture, future cap-token bug),
         // never let a zero-length candidate match. The empty string

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -8,7 +8,8 @@
 //! In elastik terms, core owns protocol truth, not protocol politics:
 //!
 //! - Truth we keep here: v1 header, method code, Uri-Path, Content-Format,
-//!   payload marker, token echo, response code, CON->ACK / NON->NON.
+//!   payload marker, token echo, response code, CON->ACK / NON->NON, and the
+//!   minimal identity signal needed to map a packet to an elastik auth tier.
 //! - Politics we intentionally do not keep here: retransmission, dedup cache,
 //!   block-wise transfer, DTLS/OSCORE, Observe, .well-known/core, Max-Age,
 //!   multicast discovery, congestion knobs, and strict critical-option lawyering.
@@ -21,9 +22,16 @@ use axum::http::StatusCode;
 use tokio::net::UdpSocket;
 use tokio::sync::watch;
 
-use crate::{auth, canonicalize_path, valid_world_name, Core};
+use crate::{auth, can_read, canonicalize_path, valid_world_name, Core};
 
 const MAX_DATAGRAM: usize = 1152;
+/// Experimental critical CoAP option carrying the raw elastik token bytes.
+///
+/// This is not encryption and not a CoAPS replacement. It is the UDP equivalent
+/// of "Authorization: Bearer ..." for the playground adapter: absent means Anon,
+/// matching a configured token yields Read/Auth/Approve. Use CoAPS/DTLS-PSK at
+/// the edge if the token should not be visible on the wire.
+const ELASTIK_AUTH_OPTION: u16 = 65001;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MsgType {
@@ -49,6 +57,7 @@ struct Packet<'a> {
     token: &'a [u8],
     path: Vec<String>,
     content_format: Option<u16>,
+    auth_token: Option<&'a [u8]>,
     payload: &'a [u8],
 }
 
@@ -82,7 +91,7 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
     };
     let socket = std::sync::Arc::new(socket);
     eprintln!("scoap: listening on coap://{bind}/");
-    eprintln!("scoap: UDP curl surface; CoAP PUT maps to local write tier");
+    eprintln!("scoap: UDP curl surface; auth option {ELASTIK_AUTH_OPTION} maps to token tier");
     let mut buf = [0_u8; MAX_DATAGRAM];
     loop {
         tokio::select! {
@@ -128,27 +137,29 @@ async fn handle(core: &Core, request: &Packet<'_>) -> Vec<u8> {
     if !valid_world_name(&world_name) {
         return encode_response(request, 128, None, b"bad world name\n");
     }
+    let tier = request
+        .auth_token
+        .map(|token| core.tokens.check_token_bytes(token))
+        .unwrap_or(auth::Tier::Anon);
     match method {
-        Method::Get => match core.read_world(&world_name) {
-            Some(stage) => encode_response(
-                request,
-                69,
-                media_type_to_cf(&stage.content_type),
-                &stage.body,
-            ),
-            None => encode_response(request, 132, Some(0), b"not found\n"),
-        },
+        Method::Get => {
+            if !can_read(core, tier) {
+                return encode_response(request, 129, Some(0), b"unauthorized\n");
+            }
+            match core.read_world(&world_name) {
+                Some(stage) => encode_response(
+                    request,
+                    69,
+                    media_type_to_cf(&stage.content_type),
+                    &stage.body,
+                ),
+                None => encode_response(request, 132, Some(0), b"not found\n"),
+            }
+        }
         Method::Put => {
             let content_type = cf_to_media_type(request.content_format);
             match core
-                .put_bytes(
-                    &world_name,
-                    request.payload,
-                    content_type,
-                    &[],
-                    auth::Tier::Auth,
-                    None,
-                )
+                .put_bytes(&world_name, request.payload, content_type, &[], tier, None)
                 .await
             {
                 Ok(outcome) => {
@@ -213,6 +224,7 @@ fn parse_packet(data: &[u8]) -> Result<Packet<'_>, String> {
     let mut option_number = 0_u16;
     let mut path = Vec::new();
     let mut content_format = None;
+    let mut auth_token = None;
     while i < data.len() {
         if data[i] == 0xff {
             i += 1;
@@ -223,6 +235,7 @@ fn parse_packet(data: &[u8]) -> Result<Packet<'_>, String> {
                 token,
                 path,
                 content_format,
+                auth_token,
                 payload: &data[i..],
             });
         }
@@ -244,6 +257,7 @@ fn parse_packet(data: &[u8]) -> Result<Packet<'_>, String> {
         match option_number {
             11 => path.push(String::from_utf8_lossy(value).to_string()),
             12 => content_format = Some(parse_uint(value)?),
+            ELASTIK_AUTH_OPTION => auth_token = Some(value),
             _ => {}
         }
     }
@@ -254,6 +268,7 @@ fn parse_packet(data: &[u8]) -> Result<Packet<'_>, String> {
         token,
         path,
         content_format,
+        auth_token,
         payload: b"",
     })
 }
@@ -410,9 +425,9 @@ mod tests {
             Core {
                 data: dir.clone(),
                 tokens: auth::Tokens {
-                    read: None,
-                    auth: None,
-                    approve: None,
+                    read: Some(b"reader".to_vec()),
+                    auth: Some(b"writer".to_vec()),
+                    approve: Some(b"approve".to_vec()),
                 },
                 hmac_key: b"test-key".to_vec(),
                 mem: Arc::new(store::MemoryStore::new()),
@@ -452,18 +467,80 @@ mod tests {
         assert_eq!(&out[7..], b"ok");
     }
 
+    fn coap_put_packet(path: &[&[u8]], payload: &[u8], token: Option<&[u8]>) -> Vec<u8> {
+        let mut out = vec![0x41, 0x03, 0x12, 0x34, 0xaa];
+        let mut prev = 0_u16;
+        for segment in path {
+            write_option(&mut out, &mut prev, 11, segment);
+        }
+        write_option(&mut out, &mut prev, 12, &[]);
+        if let Some(token) = token {
+            write_option(&mut out, &mut prev, ELASTIK_AUTH_OPTION, token);
+        }
+        out.push(0xff);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn coap_get_packet(path: &[&[u8]], token: Option<&[u8]>) -> Vec<u8> {
+        let mut out = vec![0x41, 0x01, 0x12, 0x35, 0xbb];
+        let mut prev = 0_u16;
+        for segment in path {
+            write_option(&mut out, &mut prev, 11, segment);
+        }
+        if let Some(token) = token {
+            write_option(&mut out, &mut prev, ELASTIK_AUTH_OPTION, token);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn coap_put_without_auth_token_is_rejected() {
+        let (core, dir) = test_core("auth-reject");
+        let put_bytes = coap_put_packet(&[b"home", b"sensor", b"kitchen", b"temp"], b"23.5", None);
+        let put = packet(&put_bytes);
+
+        let response = handle(&core, &put).await;
+
+        assert_eq!(response[1], 129); // 4.01 Unauthorized
+        assert!(core.read_world("home/sensor/kitchen/temp").is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn coap_get_honors_read_token_when_enabled() {
+        let (core, dir) = test_core("read-auth");
+        core.write_world("home/secret", b"ok", "text/plain; charset=utf-8", &[])
+            .unwrap();
+
+        let denied = handle(
+            &core,
+            &packet(&coap_get_packet(&[b"home", b"secret"], None)),
+        )
+        .await;
+        assert_eq!(denied[1], 129); // 4.01 Unauthorized
+
+        let allowed = handle(
+            &core,
+            &packet(&coap_get_packet(&[b"home", b"secret"], Some(b"reader"))),
+        )
+        .await;
+        assert_eq!(allowed[1], 69); // 2.05 Content
+        assert_eq!(&allowed[7..], b"ok");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     #[tokio::test]
     async fn coap_put_and_get_share_the_core_world_store() {
         let (core, dir) = test_core("dual-transport");
-        let put = packet(&[
-            0x41, 0x03, 0x12, 0x34, 0xaa, // CON PUT, mid, token
-            0xb4, b'h', b'o', b'm', b'e', // Uri-Path: home
-            0x06, b's', b'e', b'n', b's', b'o', b'r', // Uri-Path: sensor
-            0x07, b'k', b'i', b't', b'c', b'h', b'e', b'n', // Uri-Path: kitchen
-            0x04, b't', b'e', b'm', b'p', // Uri-Path: temp
-            0x10, // Content-Format: text/plain
-            0xff, b'2', b'3', b'.', b'5',
-        ]);
+        let put_bytes = coap_put_packet(
+            &[b"home", b"sensor", b"kitchen", b"temp"],
+            b"23.5",
+            Some(b"writer"),
+        );
+        let put = packet(&put_bytes);
         let put_response = handle(&core, &put).await;
         assert_eq!(put_response[1], 65); // 2.01 Created
 
@@ -471,11 +548,9 @@ mod tests {
         assert_eq!(stage.body, b"23.5");
         assert_eq!(stage.content_type, "text/plain; charset=utf-8");
 
-        let get = packet(&[
-            0x41, 0x01, 0x12, 0x35, 0xbb, // CON GET, mid, token
-            0xb4, b'h', b'o', b'm', b'e', 0x06, b's', b'e', b'n', b's', b'o', b'r', 0x07, b'k',
-            b'i', b't', b'c', b'h', b'e', b'n', 0x04, b't', b'e', b'm', b'p',
-        ]);
+        let get_bytes =
+            coap_get_packet(&[b"home", b"sensor", b"kitchen", b"temp"], Some(b"reader"));
+        let get = packet(&get_bytes);
         let get_response = handle(&core, &get).await;
         assert_eq!(get_response[1], 69); // 2.05 Content
         assert_eq!(get_response[6], 0xff);

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -95,7 +95,11 @@ impl Packet<'_> {
     }
 }
 
-pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receiver<bool>) {
+pub(crate) async fn serve(
+    core: std::sync::Arc<Core>,
+    bind: String,
+    mut shutdown: watch::Receiver<bool>,
+) {
     let socket = match UdpSocket::bind(&bind).await {
         Ok(socket) => socket,
         Err(e) => {
@@ -124,7 +128,7 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
                 };
                 if n > MAX_DATAGRAM {
                     eprintln!("scoap: oversized datagram from {peer}: {n} bytes");
-                    let reset = [0x70, 0x80, buf[2], buf[3]];
+                    let reset = [0x70, 0x00, buf[2], buf[3]];
                     if let Err(e) = socket.send_to(&reset, peer).await {
                         eprintln!("scoap: send_to {peer}: {e}");
                     }
@@ -434,7 +438,8 @@ fn cf_to_media_type(cf: Option<u16>) -> &'static str {
         Some(42) => "application/octet-stream",
         Some(50) => "application/json",
         Some(60) => "application/cbor",
-        None | _ => "application/octet-stream",
+        None => "application/octet-stream",
+        _ => "application/octet-stream",
     }
 }
 

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -5,6 +5,18 @@
 //! payload and content type, then calls the same Core storage operations as
 //! HTTP. TCP and UDP become two doors into the same world store.
 //!
+//! CoAP is allowed inside core because it has semantic zero distance from HTTP:
+//! method code is method, Uri-Path is path, Content-Format is Content-Type,
+//! response code is status, payload is body. That is why this file can stay
+//! small. It is not translating a foreign object model; it is putting HTTP
+//! semantics in a UDP envelope.
+//!
+//! Other protocols must stop at the edge unless they first collapse into that
+//! tuple. MQTT topics, AMQP exchanges, Modbus registers, SMTP transactions,
+//! FTP sessions, gRPC method calls and WebDAV file-system politics are useful
+//! adapter material, not core material. They can knock after an SDK/sidecar has
+//! turned them into method + path + representation bytes + content type.
+//!
 //! In elastik terms, core owns protocol truth, not protocol politics:
 //!
 //! - Truth we keep here: v1 header, method code, Uri-Path, Content-Format,

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -178,12 +178,27 @@ async fn handle(core: &Core, request: &Packet<'_>) -> Vec<u8> {
                 return encode_response(request, 129, Some(0), b"unauthorized\n");
             }
             match core.read_world(&world_name) {
-                Some(stage) => encode_response(
-                    request,
-                    69,
-                    media_type_to_cf(&stage.content_type),
-                    &stage.body,
-                ),
+                Some(stage) => {
+                    if encoded_len(
+                        request,
+                        media_type_to_cf(&stage.content_type),
+                        stage.body.len(),
+                    ) > MAX_DATAGRAM
+                    {
+                        return encode_response(
+                            request,
+                            141,
+                            Some(0),
+                            b"world too large for coap\n",
+                        );
+                    }
+                    encode_response(
+                        request,
+                        69,
+                        media_type_to_cf(&stage.content_type),
+                        &stage.body,
+                    )
+                }
                 None => encode_response(request, 132, Some(0), b"not found\n"),
             }
         }
@@ -358,6 +373,17 @@ fn encode_response(
     out
 }
 
+fn encoded_len(request: &Packet<'_>, content_format: Option<u16>, payload_len: usize) -> usize {
+    let mut len = 4 + request.token.len();
+    if let Some(cf) = content_format {
+        len += option_len(12, &uint_bytes(cf));
+    }
+    if payload_len > 0 {
+        len += 1 + payload_len;
+    }
+    len
+}
+
 fn write_option(out: &mut Vec<u8>, prev: &mut u16, number: u16, value: &[u8]) {
     let delta = number - *prev;
     let (delta_nibble, mut delta_ext) = option_ext(delta);
@@ -367,6 +393,18 @@ fn write_option(out: &mut Vec<u8>, prev: &mut u16, number: u16, value: &[u8]) {
     out.append(&mut len_ext);
     out.extend_from_slice(value);
     *prev = number;
+}
+
+fn option_len(delta: u16, value: &[u8]) -> usize {
+    1 + option_ext_len(delta) + option_ext_len(value.len() as u16) + value.len()
+}
+
+fn option_ext_len(value: u16) -> usize {
+    match value {
+        0..=12 => 0,
+        13..=268 => 1,
+        _ => 2,
+    }
 }
 
 fn option_ext(value: u16) -> (u8, Vec<u8>) {
@@ -392,11 +430,11 @@ fn uint_bytes(value: u16) -> Vec<u8> {
 
 fn cf_to_media_type(cf: Option<u16>) -> &'static str {
     match cf {
-        Some(0) | None => "text/plain; charset=utf-8",
+        Some(0) => "text/plain; charset=utf-8",
         Some(42) => "application/octet-stream",
         Some(50) => "application/json",
         Some(60) => "application/cbor",
-        _ => "application/octet-stream",
+        None | _ => "application/octet-stream",
     }
 }
 
@@ -531,6 +569,12 @@ mod tests {
     }
 
     #[test]
+    fn missing_content_format_defaults_to_octet_stream() {
+        assert_eq!(cf_to_media_type(None), "application/octet-stream");
+        assert_eq!(cf_to_media_type(Some(0)), "text/plain; charset=utf-8");
+    }
+
+    #[test]
     fn invalid_utf8_uri_path_is_rejected() {
         let err = parse_packet(&[0x40, 0x01, 0x12, 0x34, 0xb1, 0xff]).unwrap_err();
         assert_eq!(err, "invalid utf-8 in Uri-Path option");
@@ -597,6 +641,28 @@ mod tests {
         .await;
         assert_eq!(allowed[1], 69); // 2.05 Content
         assert_eq!(&allowed[7..], b"ok");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn coap_get_rejects_worlds_too_large_for_one_datagram() {
+        let (core, dir) = test_core("large-get");
+        core.write_world(
+            "home/large",
+            &vec![b'x'; MAX_DATAGRAM],
+            "application/octet-stream",
+            &[],
+        )
+        .unwrap();
+
+        let get_bytes = coap_get_packet(&[b"home", b"large"], Some(b"reader"));
+        let response = handle(&core, &packet(&get_bytes)).await;
+
+        assert_eq!(response[1], 141); // 4.13 Request Entity Too Large
+        assert_eq!(response[5], 0xc0); // Content-Format: text/plain
+        assert_eq!(response[6], 0xff);
+        assert_eq!(&response[7..], b"world too large for coap\n");
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -37,6 +37,7 @@ use tokio::sync::watch;
 use crate::{auth, can_read, canonicalize_path, valid_world_name, Core};
 
 const MAX_DATAGRAM: usize = 1152;
+const RECV_BUF: usize = MAX_DATAGRAM + 1;
 /// Experimental critical CoAP option carrying the raw elastik token bytes.
 ///
 /// This is not encryption and not a CoAPS replacement. It is the UDP equivalent
@@ -104,7 +105,7 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
     let socket = std::sync::Arc::new(socket);
     eprintln!("scoap: listening on coap://{bind}/");
     eprintln!("scoap: UDP curl surface; auth option {ELASTIK_AUTH_OPTION} maps to token tier");
-    let mut buf = [0_u8; MAX_DATAGRAM];
+    let mut buf = [0_u8; RECV_BUF];
     loop {
         tokio::select! {
             _ = shutdown.changed() => {
@@ -119,6 +120,14 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
                         continue;
                     }
                 };
+                if n > MAX_DATAGRAM {
+                    eprintln!("scoap: oversized datagram from {peer}: {n} bytes");
+                    let reset = [0x70, 0x80, buf[2], buf[3]];
+                    if let Err(e) = socket.send_to(&reset, peer).await {
+                        eprintln!("scoap: send_to {peer}: {e}");
+                    }
+                    continue;
+                }
                 let data = Vec::from(&buf[..n]);
                 let socket = socket.clone();
                 let core = core.clone();
@@ -296,7 +305,11 @@ fn read_ext(nibble: u8, rest: &[u8]) -> Result<(u16, usize), String> {
             if rest.len() < 2 {
                 return Err("truncated extended option".to_owned());
             }
-            Ok((u16::from_be_bytes([rest[0], rest[1]]) + 269, 2))
+            let value = u16::from_be_bytes([rest[0], rest[1]]);
+            value
+                .checked_add(269)
+                .map(|v| (v, 2))
+                .ok_or_else(|| "extended option overflow".to_owned())
         }
         _ => Err("reserved option nibble".to_owned()),
     }
@@ -477,6 +490,17 @@ mod tests {
         assert_eq!(out[5], 0xc0); // delta 12, len 0 -> Content-Format: text/plain
         assert_eq!(out[6], 0xff);
         assert_eq!(&out[7..], b"ok");
+    }
+
+    #[test]
+    fn receive_buffer_can_detect_one_byte_oversize_datagrams() {
+        assert_eq!(RECV_BUF, MAX_DATAGRAM + 1);
+    }
+
+    #[test]
+    fn extended_option_overflow_is_rejected() {
+        let err = read_ext(14, &[0xff, 0xff]).unwrap_err();
+        assert_eq!(err, "extended option overflow");
     }
 
     fn coap_put_packet(path: &[&[u8]], payload: &[u8], token: Option<&[u8]>) -> Vec<u8> {

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -32,12 +32,13 @@
 
 use axum::http::StatusCode;
 use tokio::net::UdpSocket;
-use tokio::sync::watch;
+use tokio::sync::{watch, Semaphore};
 
 use crate::{auth, can_read, canonicalize_path, valid_world_name, Core};
 
 const MAX_DATAGRAM: usize = 1152;
 const RECV_BUF: usize = MAX_DATAGRAM + 1;
+const MAX_IN_FLIGHT: usize = 1024;
 /// Experimental critical CoAP option carrying the raw elastik token bytes.
 ///
 /// This is not encryption and not a CoAPS replacement. It is the UDP equivalent
@@ -103,6 +104,7 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
         }
     };
     let socket = std::sync::Arc::new(socket);
+    let permits = std::sync::Arc::new(Semaphore::new(MAX_IN_FLIGHT));
     eprintln!("scoap: listening on coap://{bind}/");
     eprintln!("scoap: UDP curl surface; auth option {ELASTIK_AUTH_OPTION} maps to token tier");
     let mut buf = [0_u8; RECV_BUF];
@@ -129,9 +131,17 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
                     continue;
                 }
                 let data = Vec::from(&buf[..n]);
+                let permit = match permits.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        eprintln!("scoap: dropping datagram from {peer}: in-flight limit reached");
+                        continue;
+                    }
+                };
                 let socket = socket.clone();
                 let core = core.clone();
                 tokio::spawn(async move {
+                    let _permit = permit;
                     let request = match parse_packet(&data) {
                         Ok(p) => p,
                         Err(e) => {
@@ -151,12 +161,12 @@ pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receive
 
 async fn handle(core: &Core, request: &Packet<'_>) -> Vec<u8> {
     let Some(method) = request.method() else {
-        return encode_response(request, 133, None, b"method not allowed\n");
+        return encode_response(request, 133, Some(0), b"method not allowed\n");
     };
     let path = request_path(request);
     let world_name = canonicalize_path(&path);
     if !valid_world_name(&world_name) {
-        return encode_response(request, 128, None, b"bad world name\n");
+        return encode_response(request, 128, Some(0), b"bad world name\n");
     }
     let tier = request
         .auth_token
@@ -276,7 +286,11 @@ fn parse_packet(data: &[u8]) -> Result<Packet<'_>, String> {
         let value = &data[i..i + len];
         i += len;
         match option_number {
-            11 => path.push(String::from_utf8_lossy(value).to_string()),
+            11 => {
+                let segment = std::str::from_utf8(value)
+                    .map_err(|_| "invalid utf-8 in Uri-Path option".to_owned())?;
+                path.push(segment.to_owned());
+            }
             12 => content_format = Some(parse_uint(value)?),
             ELASTIK_AUTH_OPTION => auth_token = Some(value),
             _ => {}
@@ -492,6 +506,19 @@ mod tests {
         assert_eq!(&out[7..], b"ok");
     }
 
+    #[tokio::test]
+    async fn textual_errors_carry_text_plain_content_format() {
+        let (core, dir) = test_core("error-format");
+        let p = packet(&[0x41, 0x63, 0x12, 0x34, 0xaa]); // unknown method code
+        let out = handle(&core, &p).await;
+        assert_eq!(out[1], 133);
+        assert_eq!(out[5], 0xc0); // Content-Format: text/plain
+        assert_eq!(out[6], 0xff);
+        assert_eq!(&out[7..], b"method not allowed\n");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     #[test]
     fn receive_buffer_can_detect_one_byte_oversize_datagrams() {
         assert_eq!(RECV_BUF, MAX_DATAGRAM + 1);
@@ -501,6 +528,12 @@ mod tests {
     fn extended_option_overflow_is_rejected() {
         let err = read_ext(14, &[0xff, 0xff]).unwrap_err();
         assert_eq!(err, "extended option overflow");
+    }
+
+    #[test]
+    fn invalid_utf8_uri_path_is_rejected() {
+        let err = parse_packet(&[0x40, 0x01, 0x12, 0x34, 0xb1, 0xff]).unwrap_err();
+        assert_eq!(err, "invalid utf-8 in Uri-Path option");
     }
 
     fn coap_put_packet(path: &[&[u8]], payload: &[u8], token: Option<&[u8]>) -> Vec<u8> {

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -1,0 +1,486 @@
+//! Native SCoAP/UDP surface for elastik-core.
+//!
+//! This is not a general CoAP stack. It is "UDP curl": a deliberately small
+//! adapter that parses enough CoAP-shaped wire truth to derive method, path,
+//! payload and content type, then calls the same Core storage operations as
+//! HTTP. TCP and UDP become two doors into the same world store.
+//!
+//! In elastik terms, core owns protocol truth, not protocol politics:
+//!
+//! - Truth we keep here: v1 header, method code, Uri-Path, Content-Format,
+//!   payload marker, token echo, response code, CON->ACK / NON->NON.
+//! - Politics we intentionally do not keep here: retransmission, dedup cache,
+//!   block-wise transfer, DTLS/OSCORE, Observe, .well-known/core, Max-Age,
+//!   multicast discovery, congestion knobs, and strict critical-option lawyering.
+//!
+//! Need reliability or large bodies? Use HTTP or retry at the client. Need
+//! crypto/discovery/strict RFC behavior? Put a CoAP runtime gateway at the edge.
+//! The core stays a disk-shaped bus: packet in, core op, packet out.
+
+use axum::http::StatusCode;
+use tokio::net::UdpSocket;
+use tokio::sync::watch;
+
+use crate::{auth, canonicalize_path, valid_world_name, Core};
+
+const MAX_DATAGRAM: usize = 1152;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MsgType {
+    Con = 0,
+    Non = 1,
+    Ack = 2,
+    Rst = 3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Method {
+    Get,
+    Post,
+    Put,
+    Delete,
+}
+
+#[derive(Debug)]
+struct Packet<'a> {
+    typ: MsgType,
+    code: u8,
+    mid: u16,
+    token: &'a [u8],
+    path: Vec<String>,
+    content_format: Option<u16>,
+    payload: &'a [u8],
+}
+
+impl Packet<'_> {
+    fn method(&self) -> Option<Method> {
+        match self.code {
+            1 => Some(Method::Get),
+            2 => Some(Method::Post),
+            3 => Some(Method::Put),
+            4 => Some(Method::Delete),
+            _ => None,
+        }
+    }
+
+    fn response_type(&self) -> MsgType {
+        match self.typ {
+            MsgType::Con => MsgType::Ack,
+            MsgType::Non => MsgType::Non,
+            _ => MsgType::Non,
+        }
+    }
+}
+
+pub(crate) async fn serve(core: Core, bind: String, mut shutdown: watch::Receiver<bool>) {
+    let socket = match UdpSocket::bind(&bind).await {
+        Ok(socket) => socket,
+        Err(e) => {
+            eprintln!("scoap: failed to bind coap://{bind}/: {e}");
+            return;
+        }
+    };
+    let socket = std::sync::Arc::new(socket);
+    eprintln!("scoap: listening on coap://{bind}/");
+    eprintln!("scoap: UDP curl surface; CoAP PUT maps to local write tier");
+    let mut buf = [0_u8; MAX_DATAGRAM];
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                eprintln!("scoap: shutdown signal received");
+                return;
+            }
+            received = socket.recv_from(&mut buf) => {
+                let (n, peer) = match received {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("scoap: recv_from: {e}");
+                        continue;
+                    }
+                };
+                let data = Vec::from(&buf[..n]);
+                let socket = socket.clone();
+                let core = core.clone();
+                tokio::spawn(async move {
+                    let request = match parse_packet(&data) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            eprintln!("scoap: bad packet from {peer}: {e}");
+                            return;
+                        }
+                    };
+                    let response = handle(&core, &request).await;
+                    if let Err(e) = socket.send_to(&response, peer).await {
+                        eprintln!("scoap: send_to {peer}: {e}");
+                    }
+                });
+            }
+        }
+    }
+}
+
+async fn handle(core: &Core, request: &Packet<'_>) -> Vec<u8> {
+    let Some(method) = request.method() else {
+        return encode_response(request, 133, None, b"method not allowed\n");
+    };
+    let path = request_path(request);
+    let world_name = canonicalize_path(&path);
+    if !valid_world_name(&world_name) {
+        return encode_response(request, 128, None, b"bad world name\n");
+    }
+    match method {
+        Method::Get => match core.read_world(&world_name) {
+            Some(stage) => encode_response(
+                request,
+                69,
+                media_type_to_cf(&stage.content_type),
+                &stage.body,
+            ),
+            None => encode_response(request, 132, Some(0), b"not found\n"),
+        },
+        Method::Put => {
+            let content_type = cf_to_media_type(request.content_format);
+            match core
+                .put_bytes(
+                    &world_name,
+                    request.payload,
+                    content_type,
+                    &[],
+                    auth::Tier::Auth,
+                    None,
+                )
+                .await
+            {
+                Ok(outcome) => {
+                    let code = if outcome.status == StatusCode::CREATED {
+                        65
+                    } else {
+                        68
+                    };
+                    encode_response(request, code, None, b"")
+                }
+                Err(resp) => {
+                    encode_response(request, status_to_coap(resp.status()), Some(0), b"error\n")
+                }
+            }
+        }
+        Method::Post => encode_response(
+            request,
+            133,
+            Some(0),
+            b"post not implemented over coap yet\n",
+        ),
+        Method::Delete => encode_response(
+            request,
+            133,
+            Some(0),
+            b"delete not implemented over coap yet\n",
+        ),
+    }
+}
+
+fn request_path(request: &Packet<'_>) -> String {
+    let mut path = String::from("/");
+    path.push_str(&request.path.join("/"));
+    path
+}
+
+fn parse_packet(data: &[u8]) -> Result<Packet<'_>, String> {
+    if data.len() < 4 {
+        return Err("short header".to_owned());
+    }
+    let ver = data[0] >> 6;
+    if ver != 1 {
+        return Err(format!("unsupported version {ver}"));
+    }
+    let typ = match (data[0] >> 4) & 0b11 {
+        0 => MsgType::Con,
+        1 => MsgType::Non,
+        2 => MsgType::Ack,
+        _ => MsgType::Rst,
+    };
+    let tkl = (data[0] & 0x0f) as usize;
+    if tkl > 8 {
+        return Err("token too long".to_owned());
+    }
+    if data.len() < 4 + tkl {
+        return Err("truncated token".to_owned());
+    }
+    let code = data[1];
+    let mid = u16::from_be_bytes([data[2], data[3]]);
+    let token = &data[4..4 + tkl];
+    let mut i = 4 + tkl;
+    let mut option_number = 0_u16;
+    let mut path = Vec::new();
+    let mut content_format = None;
+    while i < data.len() {
+        if data[i] == 0xff {
+            i += 1;
+            return Ok(Packet {
+                typ,
+                code,
+                mid,
+                token,
+                path,
+                content_format,
+                payload: &data[i..],
+            });
+        }
+        let first = data[i];
+        i += 1;
+        let (delta, used_delta) = read_ext(first >> 4, &data[i..])?;
+        i += used_delta;
+        let (len, used_len) = read_ext(first & 0x0f, &data[i..])?;
+        i += used_len;
+        option_number = option_number
+            .checked_add(delta)
+            .ok_or_else(|| "option number overflow".to_owned())?;
+        let len = len as usize;
+        if i + len > data.len() {
+            return Err("truncated option".to_owned());
+        }
+        let value = &data[i..i + len];
+        i += len;
+        match option_number {
+            11 => path.push(String::from_utf8_lossy(value).to_string()),
+            12 => content_format = Some(parse_uint(value)?),
+            _ => {}
+        }
+    }
+    Ok(Packet {
+        typ,
+        code,
+        mid,
+        token,
+        path,
+        content_format,
+        payload: b"",
+    })
+}
+
+fn read_ext(nibble: u8, rest: &[u8]) -> Result<(u16, usize), String> {
+    match nibble {
+        n @ 0..=12 => Ok((n as u16, 0)),
+        13 => rest
+            .first()
+            .map(|b| ((*b as u16) + 13, 1))
+            .ok_or_else(|| "truncated extended option".to_owned()),
+        14 => {
+            if rest.len() < 2 {
+                return Err("truncated extended option".to_owned());
+            }
+            Ok((u16::from_be_bytes([rest[0], rest[1]]) + 269, 2))
+        }
+        _ => Err("reserved option nibble".to_owned()),
+    }
+}
+
+fn parse_uint(value: &[u8]) -> Result<u16, String> {
+    if value.len() > 2 {
+        return Err("uint option too large".to_owned());
+    }
+    Ok(value.iter().fold(0_u16, |n, b| (n << 8) | (*b as u16)))
+}
+
+fn encode_response(
+    request: &Packet<'_>,
+    code: u8,
+    content_format: Option<u16>,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + request.token.len() + 8 + payload.len());
+    out.push((1 << 6) | ((request.response_type() as u8) << 4) | (request.token.len() as u8));
+    out.push(code);
+    out.extend_from_slice(&request.mid.to_be_bytes());
+    out.extend_from_slice(request.token);
+    let mut prev = 0_u16;
+    if let Some(cf) = content_format {
+        write_option(&mut out, &mut prev, 12, &uint_bytes(cf));
+    }
+    if !payload.is_empty() {
+        out.push(0xff);
+        out.extend_from_slice(payload);
+    }
+    out
+}
+
+fn write_option(out: &mut Vec<u8>, prev: &mut u16, number: u16, value: &[u8]) {
+    let delta = number - *prev;
+    let (delta_nibble, mut delta_ext) = option_ext(delta);
+    let (len_nibble, mut len_ext) = option_ext(value.len() as u16);
+    out.push((delta_nibble << 4) | len_nibble);
+    out.append(&mut delta_ext);
+    out.append(&mut len_ext);
+    out.extend_from_slice(value);
+    *prev = number;
+}
+
+fn option_ext(value: u16) -> (u8, Vec<u8>) {
+    match value {
+        0..=12 => (value as u8, Vec::new()),
+        13..=268 => (13, vec![(value - 13) as u8]),
+        _ => {
+            let n = value - 269;
+            (14, n.to_be_bytes().to_vec())
+        }
+    }
+}
+
+fn uint_bytes(value: u16) -> Vec<u8> {
+    if value == 0 {
+        Vec::new()
+    } else if value <= 0xff {
+        vec![value as u8]
+    } else {
+        value.to_be_bytes().to_vec()
+    }
+}
+
+fn cf_to_media_type(cf: Option<u16>) -> &'static str {
+    match cf {
+        Some(0) | None => "text/plain; charset=utf-8",
+        Some(42) => "application/octet-stream",
+        Some(50) => "application/json",
+        Some(60) => "application/cbor",
+        _ => "application/octet-stream",
+    }
+}
+
+fn media_type_to_cf(value: &str) -> Option<u16> {
+    match value
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "text/plain" => Some(0),
+        "application/octet-stream" => Some(42),
+        "application/json" => Some(50),
+        "application/cbor" => Some(60),
+        _ => None,
+    }
+}
+
+fn status_to_coap(status: StatusCode) -> u8 {
+    match status.as_u16() {
+        400 => 128,
+        401 => 129,
+        403 => 131,
+        404 => 132,
+        405 => 133,
+        409 => 137,
+        412 => 140,
+        413 => 141,
+        415 => 143,
+        500..=599 => 160,
+        _ => 128,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        auth, store, Core, DEFAULT_MAX_MEMORY_BYTES, DEFAULT_MAX_WORLD_BYTES, LISTEN_REPLAY_MAX,
+    };
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+    use std::sync::{atomic::AtomicU64, Arc, Mutex as StdMutex};
+    use tokio::sync::{broadcast, watch, Mutex};
+
+    fn packet(bytes: &[u8]) -> Packet<'_> {
+        parse_packet(bytes).unwrap()
+    }
+
+    fn test_core(label: &str) -> (Core, PathBuf) {
+        let mut dir = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        dir.push(format!(
+            "elastik-coap-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let (events, _) = broadcast::channel(16);
+        (
+            Core {
+                data: dir.clone(),
+                tokens: auth::Tokens {
+                    read: None,
+                    auth: None,
+                    approve: None,
+                },
+                hmac_key: b"test-key".to_vec(),
+                mem: Arc::new(store::MemoryStore::new()),
+                max_world_bytes: DEFAULT_MAX_WORLD_BYTES,
+                max_memory_bytes: DEFAULT_MAX_MEMORY_BYTES,
+                events,
+                event_log: Arc::new(StdMutex::new(VecDeque::with_capacity(LISTEN_REPLAY_MAX))),
+                shutdown: watch::channel(false).1,
+                next_event: Arc::new(AtomicU64::new(0)),
+                write_lock: Arc::new(Mutex::new(())),
+            },
+            dir,
+        )
+    }
+
+    #[test]
+    fn parses_get_path() {
+        // Ver=1, CON, TKL=1, GET, mid=0x1234, token=0xaa,
+        // Uri-Path "home", Uri-Path "x".
+        let p = packet(&[
+            0x41, 0x01, 0x12, 0x34, 0xaa, 0xb4, b'h', b'o', b'm', b'e', 0x01, b'x',
+        ]);
+        assert_eq!(p.method(), Some(Method::Get));
+        assert_eq!(p.mid, 0x1234);
+        assert_eq!(p.token, &[0xaa]);
+        assert_eq!(p.path, vec!["home", "x"]);
+        assert_eq!(request_path(&p), "/home/x");
+    }
+
+    #[test]
+    fn encodes_ack_content_response() {
+        let p = packet(&[0x41, 0x01, 0x12, 0x34, 0xaa]);
+        let out = encode_response(&p, 69, Some(0), b"ok");
+        assert_eq!(&out[..5], &[0x61, 69, 0x12, 0x34, 0xaa]);
+        assert_eq!(out[5], 0xc0); // delta 12, len 0 -> Content-Format: text/plain
+        assert_eq!(out[6], 0xff);
+        assert_eq!(&out[7..], b"ok");
+    }
+
+    #[tokio::test]
+    async fn coap_put_and_get_share_the_core_world_store() {
+        let (core, dir) = test_core("dual-transport");
+        let put = packet(&[
+            0x41, 0x03, 0x12, 0x34, 0xaa, // CON PUT, mid, token
+            0xb4, b'h', b'o', b'm', b'e', // Uri-Path: home
+            0x06, b's', b'e', b'n', b's', b'o', b'r', // Uri-Path: sensor
+            0x07, b'k', b'i', b't', b'c', b'h', b'e', b'n', // Uri-Path: kitchen
+            0x04, b't', b'e', b'm', b'p', // Uri-Path: temp
+            0x10, // Content-Format: text/plain
+            0xff, b'2', b'3', b'.', b'5',
+        ]);
+        let put_response = handle(&core, &put).await;
+        assert_eq!(put_response[1], 65); // 2.01 Created
+
+        let stage = core.read_world("home/sensor/kitchen/temp").unwrap();
+        assert_eq!(stage.body, b"23.5");
+        assert_eq!(stage.content_type, "text/plain; charset=utf-8");
+
+        let get = packet(&[
+            0x41, 0x01, 0x12, 0x35, 0xbb, // CON GET, mid, token
+            0xb4, b'h', b'o', b'm', b'e', 0x06, b's', b'e', b'n', b's', b'o', b'r', 0x07, b'k',
+            b'i', b't', b'c', b'h', b'e', b'n', 0x04, b't', b'e', b'm', b'p',
+        ]);
+        let get_response = handle(&core, &get).await;
+        assert_eq!(get_response[1], 69); // 2.05 Content
+        assert_eq!(get_response[6], 0xff);
+        assert_eq!(&get_response[7..], b"23.5");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,9 +1,9 @@
 //! elastik-core — bedrock HTTP+SQLite+HMAC.
 //!
-//! The core has exactly one interface: HTTP requests in, HTTP responses
-//! out. It does not know or care whether a request came from curl, a
-//! browser, WebDAV, SMTP, an AI agent, or an SDK bridge. Translation is
-//! external; the core only sees HTTP.
+//! The core has one semantic interface: method + path + representation bytes.
+//! HTTP is the first-class surface. SCoAP is a small UDP-curl surface because
+//! CoAP has semantic zero distance from HTTP. Everything else must arrive
+//! through SDK/client adapters that collapse it into the same tuple.
 //!
 //! v5.0 grammar:
 //!
@@ -29,6 +29,8 @@
 //! Env:
 //!   ELASTIK_HOST           default 127.0.0.1
 //!   ELASTIK_PORT           default 3105
+//!   ELASTIK_COAP_HOST      default 127.0.0.1
+//!   ELASTIK_COAP_PORT      default 5683
 //!   ELASTIK_DATA           default ./data
 //!   ELASTIK_READ_TOKEN     T1 token  (optional read gate)
 //!   ELASTIK_TOKEN          T2 token  (writes to /home/*, includes read)

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -36,6 +36,7 @@
 //!   ELASTIK_KEY            HMAC key for the audit chain (required)
 mod audit;
 mod auth;
+mod coap;
 mod http_semantics;
 mod listen;
 mod store;
@@ -61,6 +62,11 @@ use tokio::sync::{broadcast, watch, Mutex};
 
 use crate::http_semantics as hs;
 use crate::world::{AppendResult, Stage};
+
+pub(crate) struct WriteOutcome {
+    pub status: StatusCode,
+    pub etag: String,
+}
 
 #[derive(Clone)]
 struct Core {
@@ -151,6 +157,60 @@ impl Core {
         }
         let _ = self.events.send(change);
     }
+
+    async fn put_bytes(
+        &self,
+        world_name: &str,
+        body: &[u8],
+        content_type: &str,
+        headers: &[(String, String)],
+        tier: auth::Tier,
+        preconditions: Option<&HeaderMap>,
+    ) -> Result<WriteOutcome, Response> {
+        if !can_write(world_name, tier) {
+            return Err(unauthorized(
+                "write requires token; system worlds need approve token",
+            ));
+        }
+        if body.len() > self.max_world_bytes {
+            return Err(payload_too_large(self.max_world_bytes));
+        }
+        let _write_guard = self.write_lock.lock().await;
+        if let Some(req_headers) = preconditions {
+            hs::check_write_preconditions(self, world_name, req_headers)?;
+        }
+        let existed = self.read_world(world_name).is_some();
+        let new_etag = if store::is_persistent(world_name) {
+            match world::write_with_audit(
+                &self.data,
+                world_name,
+                body,
+                content_type,
+                headers,
+                &self.hmac_key,
+            ) {
+                Ok(h) => hs::hmac_etag(&h),
+                Err(e) => return Err(server_error(format!("storage/audit: {e}"))),
+            }
+        } else {
+            if memory_write_projected_bytes(self, world_name, body.len()) > self.max_memory_bytes {
+                return Err(payload_too_large(self.max_memory_bytes));
+            }
+            match self.write_world(world_name, body, content_type, headers) {
+                Ok(()) => hs::body_etag(body),
+                Err(e) => return Err(server_error(format!("storage: {e}"))),
+            }
+        };
+        self.notify("PUT", world_name, &new_etag);
+        Ok(WriteOutcome {
+            status: if existed {
+                StatusCode::OK
+            } else {
+                StatusCode::CREATED
+            },
+            etag: new_etag,
+        })
+    }
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -168,6 +228,11 @@ async fn main() {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(3105);
+    let coap_host = std::env::var("ELASTIK_COAP_HOST").unwrap_or_else(|_| "127.0.0.1".into());
+    let coap_port: u16 = std::env::var("ELASTIK_COAP_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5683);
     let data = PathBuf::from(std::env::var("ELASTIK_DATA").unwrap_or_else(|_| "./data".into()));
     let max_world_bytes = env_usize("ELASTIK_MAX_WORLD_BYTES", DEFAULT_MAX_WORLD_BYTES);
     let max_memory_bytes = env_usize("ELASTIK_MAX_MEMORY_BYTES", DEFAULT_MAX_MEMORY_BYTES);
@@ -187,7 +252,7 @@ async fn main() {
         max_memory_bytes,
         events,
         event_log: Arc::new(StdMutex::new(VecDeque::new())),
-        shutdown: shutdown_rx,
+        shutdown: shutdown_rx.clone(),
         next_event: Arc::new(AtomicU64::new(0)),
         write_lock: Arc::new(Mutex::new(())),
     };
@@ -196,6 +261,12 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(&addr).await.expect("bind");
     eprintln!("elastik-core v{VERSION} on http://{addr}/");
     print_auth_summary(&state.tokens);
+    let coap_addr = listen_addr(&coap_host, coap_port);
+    let coap_state = state.clone();
+    let coap_shutdown = shutdown_rx.clone();
+    tokio::spawn(async move {
+        coap::serve(coap_state, coap_addr, coap_shutdown).await;
+    });
     let app = Router::new()
         .route("/", any(root_hint))
         .route("/listen/*pattern", any(listen::handler))
@@ -594,56 +665,34 @@ async fn handle_put(
     body: Bytes,
     tier: auth::Tier,
 ) -> Response {
-    if !can_write(world_name, tier) {
-        return unauthorized("write requires token; system worlds need approve token");
-    }
-    if body.len() > core.max_world_bytes {
-        return payload_too_large(core.max_world_bytes);
-    }
-    let _write_guard = core.write_lock.lock().await;
-    if let Err(resp) = hs::check_write_preconditions(core, world_name, req_headers) {
-        return resp;
-    }
-    let existed = core.read_world(world_name).is_some();
     let content_type = hs::request_content_type(req_headers);
 
     let meta = hs::request_meta_headers(req_headers);
 
-    let new_etag = if store::is_persistent(world_name) {
-        match world::write_with_audit(
-            &core.data,
+    let outcome = match core
+        .put_bytes(
             world_name,
             &body,
             &content_type,
             &meta,
-            &core.hmac_key,
-        ) {
-            Ok(h) => hs::hmac_etag(&h),
-            Err(e) => return server_error(format!("storage/audit: {e}")),
-        }
-    } else {
-        if memory_write_projected_bytes(core, world_name, body.len()) > core.max_memory_bytes {
-            return payload_too_large(core.max_memory_bytes);
-        }
-        match core.write_world(world_name, &body, &content_type, &meta) {
-            Ok(()) => hs::body_etag(&body),
-            Err(e) => return server_error(format!("storage: {e}")),
-        }
+            tier,
+            Some(req_headers),
+        )
+        .await
+    {
+        Ok(outcome) => outcome,
+        Err(resp) => return resp,
     };
 
-    let mut resp_headers = vec![(header::ETAG, hs::etag_header(&new_etag))];
-    let status = if existed {
-        StatusCode::OK
-    } else {
+    let mut resp_headers = vec![(header::ETAG, hs::etag_header(&outcome.etag))];
+    if outcome.status == StatusCode::CREATED {
         resp_headers.push((
             header::LOCATION,
             HeaderValue::from_str(&hs::world_url(world_name))
                 .unwrap_or_else(|_| HeaderValue::from_static("/")),
         ));
-        StatusCode::CREATED
-    };
-    core.notify("PUT", world_name, &new_etag);
-    (status, to_header_map(resp_headers), "").into_response()
+    }
+    (outcome.status, to_header_map(resp_headers), "").into_response()
 }
 
 /// POST — append body bytes to existing world. 404 if world absent

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -245,7 +245,7 @@ async fn main() {
 
     let (events, _) = broadcast::channel(1024);
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let state = Core {
+    let state = Arc::new(Core {
         data,
         tokens: auth::Tokens::from_env(),
         hmac_key,
@@ -257,7 +257,7 @@ async fn main() {
         shutdown: shutdown_rx.clone(),
         next_event: Arc::new(AtomicU64::new(0)),
         write_lock: Arc::new(Mutex::new(())),
-    };
+    });
 
     let addr = listen_addr(&host, port);
     let listener = tokio::net::TcpListener::bind(&addr).await.expect("bind");
@@ -277,7 +277,7 @@ async fn main() {
         .route("/proc", any(proc_reserved))
         .route("/proc/*reserved", any(proc_reserved))
         .route("/*world", any(world_handler))
-        .with_state(Arc::new(state))
+        .with_state(state)
         .layer(DefaultBodyLimit::max(max_world_bytes));
 
     axum::serve(listener, app)


### PR DESCRIPTION
## Summary

- add a native SCoAP/UDP surface inside `elastik-core`, bound separately via `ELASTIK_COAP_HOST`/`ELASTIK_COAP_PORT`
- route CoAP-shaped GET/PUT through the same core storage path as HTTP (`read_world` / `put_bytes`)
- require experimental CoAP option `65001` to carry elastik token bytes, so UDP writes no longer bypass auth tiers
- document the semantic boundary: CoAP is admitted because it is HTTP semantics in a UDP envelope, while non-isomorphic protocols stay at SDK/edge adapters

## Verification

- `cargo test --manifest-path core\Cargo.toml -- --nocapture` -> 64 passed / 0 failed
- `git diff --check`

## Notes

This is intentionally not a full RFC 7252 stack. It is a playground `UDP curl` surface: single datagram GET/PUT, Uri-Path, Content-Format, payload, token echo, response code. Retransmit, dedup, Block-Wise, DTLS/OSCORE, Observe, discovery, Max-Age and multicast remain edge/client politics.