### PR TITLE
feat(sdk): add opt-in debug sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,60 @@ If you pass `Authorization` explicitly in `headers=`, it takes precedence over
 the client's `bearer_token`. That is intentional: `headers=` is the escape
 hatch, so it wins.
 
+### SDK Debug Sink
+
+The core stamps every response with `X-Request-Id` and `X-Elapsed-Us`.
+The Python SDK can turn those headers into a temporary request journal under
+`/tmp/debug/*`:
+
+```python
+e.enable_debug(level="slow", slow_ms=100, record=True)
+# prints: debug panel: http://127.0.0.1:3105/tmp/debug-panel.html
+
+e.put("/home/note", "hello")
+print(e.debug_history[-1])
+print(e.debug_stats())
+```
+
+Levels are borrowed from the usual Python debugging instincts:
+
+- `level="all"` records every request.
+- `level="slow"` records slow requests and 4xx/5xx responses.
+- `level="errors"` records only 4xx/5xx responses.
+- `level="off"` disables the sink.
+
+`verbose=0/1/2/3` maps to errors/slow/all/all-with-redacted-headers. A hook can
+observe each request without changing normal control flow:
+
+```python
+def alert(method, path, status, ms, rid):
+    if ms > 200:
+        print(f"slow request {rid}: {method} {path} {ms:.0f}ms")
+
+e.enable_debug(level="all", hook=alert, break_on=412)
+```
+
+The default sink is `/tmp/debug/requests`, with convenience mirrors for
+`/tmp/debug/errors` and `/tmp/debug/slow`. Debug writes are best-effort and do
+not recursively log themselves. Because `/tmp` is memory-backed, these records
+are supposed to disappear when the core restarts.
+
+`panel=True` is the default. It writes a tiny HTML panel to
+`/tmp/debug-panel.html`. The panel uses `/listen/tmp/debug/requests` only as a
+wakeup signal, then reads `/tmp/debug/requests` over normal `GET`, preserving
+the core rule that SSE events are control-plane only and do not embed bodies.
+If your core requires read auth, your browser still needs to send the same
+Bearer token, for example through a header extension during local debugging.
+
+You can also launch a child core with tracing already enabled:
+
+```python
+e = elastik.start(key="...", write_token="...", debug=True)
+```
+
+No framework is hidden here. The panel is just bytes in `/tmp`; overwrite it
+with your own HTML if you want a different dashboard.
+
 The core keyspace is flat. A path like `home/sensor/kitchen/temp` is one stored
 world, not three real directories. The Python SDK gives you a virtual hierarchy
 when that is the human-shaped view you want:

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -244,6 +244,7 @@ def start(
     approve_token: str | None = None,
     data_dir: str | None = None,
     quiet: bool = True,
+    debug: bool | str = False,
 ) -> Elastik:
     client = _spawn_start(
         port=port,
@@ -254,6 +255,7 @@ def start(
         approve_token=approve_token,
         data_dir=data_dir,
         quiet=quiet,
+        debug=debug,
     )
     _set_default(client)
     return client

--- a/sdk/src/elastik/_spawn.py
+++ b/sdk/src/elastik/_spawn.py
@@ -208,6 +208,7 @@ def start(
     approve_token: str | None = None,
     data_dir: Optional[str] = None,
     quiet: bool = True,
+    debug: bool | str = False,
 ):
     """Launch the bundled elastik-core. Returns a pre-bound Elastik client.
 
@@ -215,7 +216,8 @@ def start(
     required, either as an argument, in ELASTIK_KEY, or in .env. Token
     arguments are optional capability gates: no read_token means public reads,
     no write_token means ordinary writes are disabled, and no approve_token means
-    delete/system writes are disabled.
+    delete/system writes are disabled. `debug=True` enables the returned
+    client's SDK-side /tmp/debug request sink; it does not change core behavior.
     """
     global _proc, _live_url, _live_data_dir, _last_live_url, _last_live_data_dir
     if _proc is not None and _proc.poll() is None:
@@ -311,7 +313,11 @@ def start(
     _live_data_dir = str(data_dir) if data_dir else None
     _last_live_url = _live_url
     _last_live_data_dir = _live_data_dir
-    return Elastik(_live_url, bearer_token=approve_token or write_token or read_token)
+    return Elastik(
+        _live_url,
+        bearer_token=approve_token or write_token or read_token,
+        debug=debug,
+    )
 
 
 def stop() -> None:

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -1160,12 +1160,15 @@ class Elastik(MutableMapping[str, bytes]):
         if self._debug_record:
             self.debug_history.append(dict(event))
         line = json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
+        if not self._debug_sink:
+            if _debug_break_matches(self._debug_break_on, response.status):
+                breakpoint()
+            return
         self._debug_append(self._debug_sink, line)
-        if self._debug_sink:
-            if response.status >= 400:
-                self._debug_append("/tmp/debug/errors", line)
-            if elapsed_ms >= self._debug_slow_ms:
-                self._debug_append("/tmp/debug/slow", line)
+        if response.status >= 400:
+            self._debug_append("/tmp/debug/errors", line)
+        if elapsed_ms >= self._debug_slow_ms:
+            self._debug_append("/tmp/debug/slow", line)
         if _debug_break_matches(self._debug_break_on, response.status):
             breakpoint()
 

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -1161,10 +1161,11 @@ class Elastik(MutableMapping[str, bytes]):
             self.debug_history.append(dict(event))
         line = json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
         self._debug_append(self._debug_sink, line)
-        if response.status >= 400:
-            self._debug_append("/tmp/debug/errors", line)
-        if elapsed_ms >= self._debug_slow_ms:
-            self._debug_append("/tmp/debug/slow", line)
+        if self._debug_sink:
+            if response.status >= 400:
+                self._debug_append("/tmp/debug/errors", line)
+            if elapsed_ms >= self._debug_slow_ms:
+                self._debug_append("/tmp/debug/slow", line)
         if _debug_break_matches(self._debug_break_on, response.status):
             breakpoint()
 
@@ -1558,14 +1559,7 @@ def _etag_value(value: str | None) -> str | None:
 
 
 def _is_debug_path(path: str) -> bool:
-    normalized = path.strip("/")
-    if not normalized:
-        return False
-    if normalized.startswith("tmp/debug/"):
-        return True
-    if "/" not in normalized:
-        normalized = f"home/{normalized}"
-    return normalized.startswith("tmp/debug/")
+    return path.strip("/").startswith("tmp/debug/")
 
 
 def _int_header(headers: dict[str, str], name: str) -> int | None:

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -11,6 +11,8 @@ import json
 import logging
 import os
 import secrets
+import sys
+import threading
 import time
 import csv
 import difflib
@@ -27,7 +29,7 @@ from collections.abc import MutableMapping
 from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Iterator, TypedDict
+from typing import Any, Callable, Iterator, TypedDict
 
 
 _NAMESPACES = {"home", "tmp", "dev", "sys", "proc", "etc", "lib", "boot", "usr", "var"}
@@ -122,6 +124,97 @@ _NON_PERSISTED_RESPONSE_HEADERS = {
 }
 _log = logging.getLogger("elastik")
 
+DebugHook = Callable[[str, str, int, float, str], None]
+_DEBUG_LEVELS = {"all", "slow", "errors", "off"}
+_DEBUG_SECRET_HEADERS = {
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+}
+_DEBUG_SECRET_SUFFIXES = ("-token", "-key", "-secret")
+_DEBUG_PANEL_PATH = "/tmp/debug-panel.html"
+_DEBUG_PANEL_HTML = """<!DOCTYPE html>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'">
+<title>elastik debug</title>
+<style>
+  :root { color-scheme: dark; }
+  body { background: #10130f; color: #7cff70; font: 14px ui-monospace, Consolas, monospace; margin: 20px; }
+  h1 { color: #d8ffd2; font-size: 18px; font-weight: 600; margin: 0 0 12px; }
+  #stats, #hint { color: #7f987b; margin-bottom: 10px; }
+  #log { border-top: 1px solid #263322; padding-top: 12px; white-space: pre-wrap; }
+  .slow { color: #ffb347; }
+  .error { color: #ff5c5c; }
+  .muted { color: #7f987b; }
+</style>
+<h1>elastik debug</h1>
+<div id="stats">waiting...</div>
+<div id="hint">source: /tmp/debug/requests</div>
+<div id="log"></div>
+<script>
+const SINK = "/tmp/debug/requests";
+const LIMIT = 500;
+const stats = document.getElementById("stats");
+const log = document.getElementById("log");
+let seen = 0, total = 0, errors = 0, slow = 0;
+
+function lineFor(r) {
+  const ms = Number(r.client_ms || 0);
+  const core = r.core_us == null ? "?" : r.core_us + "us";
+  return `${r.rid || "?"} ${r.method || "?"} ${r.path || "?"} -> ${r.status || "?"} ${ms.toFixed(1)}ms core=${core}`;
+}
+
+function appendRecord(r) {
+  total++;
+  const ms = Number(r.client_ms || 0);
+  const status = Number(r.status || 0);
+  if (status >= 400) errors++;
+  if (ms >= 100) slow++;
+  stats.textContent = `total: ${total} | errors: ${errors} | slow: ${slow}`;
+  const row = document.createElement("div");
+  row.className = status >= 400 ? "error" : ms >= 100 ? "slow" : "";
+  row.textContent = lineFor(r);
+  log.appendChild(row);
+  while (log.children.length > LIMIT) log.removeChild(log.firstChild);
+}
+
+async function refresh() {
+  try {
+    const res = await fetch(SINK, { cache: "no-store" });
+    if (res.status === 404) {
+      stats.textContent = "waiting for first debug record...";
+      return;
+    }
+    if (res.status === 401 || res.status === 403) {
+      stats.textContent = `auth required (${res.status}); set an Authorization header for this browser`;
+      return;
+    }
+    if (!res.ok) {
+      stats.textContent = `debug sink read failed: HTTP ${res.status}`;
+      return;
+    }
+    const text = await res.text();
+    const lines = text.trimEnd() ? text.trimEnd().split("\\n") : [];
+    for (const line of lines.slice(seen)) {
+      try { appendRecord(JSON.parse(line)); } catch (_) {}
+    }
+    seen = lines.length;
+  } catch (err) {
+    stats.textContent = "debug panel disconnected; retrying...";
+  }
+}
+
+refresh();
+setInterval(refresh, 3000);
+const es = new EventSource("/listen/tmp/debug/requests");
+es.onmessage = refresh;
+es.addEventListener("put", refresh);
+es.addEventListener("post", refresh);
+es.addEventListener("lag", refresh);
+</script>
+"""
+
 
 WorldMeta = TypedDict(
     "WorldMeta",
@@ -154,16 +247,33 @@ WorldMeta = TypedDict(
 
 
 class ElastikError(Exception):
-    def __init__(self, status: int, body: bytes, *, method: str = "", path: str = ""):
+    def __init__(
+        self,
+        status: int,
+        body: bytes,
+        *,
+        method: str = "",
+        path: str = "",
+        headers: dict[str, str] | None = None,
+    ):
         self.status = status
         self.body = body
         self.method = method
         self.path = path
+        self.headers = dict(headers or {})
+        self.request_id = self.headers.get("x-request-id", "")
+        self.core_elapsed_us = self.headers.get("x-elapsed-us", "")
         super().__init__(str(self))
 
     def __str__(self) -> str:
         route = f" {self.method} {self.path}" if self.method or self.path else ""
-        return f"elastik {self.status}{route}: {self.body[:200]!r}"
+        details = []
+        if self.request_id:
+            details.append(f"request-id={self.request_id}")
+        if self.core_elapsed_us:
+            details.append(f"core-elapsed={self.core_elapsed_us}us")
+        suffix = f" ({', '.join(details)})" if details else ""
+        return f"elastik {self.status}{route}: {self.body[:200]!r}{suffix}"
 
 
 class Unauthorized(ElastikError):
@@ -226,7 +336,13 @@ class Elastik(MutableMapping[str, bytes]):
     >>> e.list_paths()                   # GET /proc/worlds
     """
 
-    def __init__(self, url: str | None = None, bearer_token: str | None = None):
+    def __init__(
+        self,
+        url: str | None = None,
+        bearer_token: str | None = None,
+        *,
+        debug: bool | str = False,
+    ):
         if url is None:
             from elastik._spawn import default_url
             url = default_url()
@@ -235,6 +351,18 @@ class Elastik(MutableMapping[str, bytes]):
         self.url = url.rstrip("/")
         self.bearer_token = bearer_token
         self._etag_cache: dict[str, tuple[str, bytes]] = {}
+        self._debug_enabled = False
+        self._debug_level = "off"
+        self._debug_slow_ms = 100.0
+        self._debug_hook: DebugHook | None = None
+        self._debug_record = False
+        self._debug_verbose = 1
+        self._debug_break_on: int | set[int] | None = None
+        self._debug_sink: str | None = "/tmp/debug/requests"
+        self._debug_local = threading.local()
+        self.debug_history: list[dict[str, Any]] = []
+        if debug:
+            self.enable_debug(level="all" if debug is True else str(debug))
 
     def __repr__(self) -> str:
         status = "external"
@@ -253,6 +381,112 @@ class Elastik(MutableMapping[str, bytes]):
         except Exception:
             pass
         return f"<Elastik {self.url} [{status}] {count} paths>"
+
+    def enable_debug(
+        self,
+        *,
+        level: str | None = "all",
+        slow_ms: float = 100,
+        hook: DebugHook | None = None,
+        record: bool = False,
+        verbose: int | None = None,
+        break_on: int | set[int] | list[int] | tuple[int, ...] | None = None,
+        sink: str | None = "/tmp/debug/requests",
+        panel: bool = True,
+        panel_path: str = _DEBUG_PANEL_PATH,
+    ) -> "Elastik":
+        """Enable opt-in SDK request tracing.
+
+        Debug records are observations of this client, not core logs. When
+        `sink` is set, matching events are appended as JSON lines to `/tmp`
+        memory worlds, so a core restart clears them. The sink is best-effort:
+        debug write failures never break the original request.
+
+        Levels:
+          all    - record every request
+          slow   - record slow requests and errors
+          errors - record only 4xx/5xx responses
+          off    - disable debug
+
+        `verbose=0/1/2/3` maps to errors/slow/all/all+redacted headers.
+        `panel=True` writes a tiny browser panel to `/tmp/debug-panel.html`.
+        """
+        if verbose is not None:
+            if verbose <= 0:
+                level = "errors"
+            elif verbose == 1:
+                level = "slow"
+            else:
+                level = "all"
+            self._debug_verbose = int(verbose)
+        else:
+            self._debug_verbose = 1
+        level = (level or "all").lower()
+        if level not in _DEBUG_LEVELS:
+            raise ValueError(f"debug level must be one of {sorted(_DEBUG_LEVELS)}, got {level!r}")
+        self._debug_enabled = level != "off"
+        self._debug_level = level
+        self._debug_slow_ms = float(slow_ms)
+        self._debug_hook = hook
+        self._debug_record = bool(record)
+        self._debug_break_on = set(break_on) if isinstance(break_on, (list, tuple)) else break_on
+        self._debug_sink = sink
+        if record:
+            self.debug_history = []
+        if self._debug_enabled and panel:
+            self._debug_install_panel(panel_path)
+        return self
+
+    def disable_debug(self) -> "Elastik":
+        """Disable SDK request tracing."""
+        self._debug_enabled = False
+        self._debug_level = "off"
+        return self
+
+    def debug_stats(self) -> dict[str, Any]:
+        """Summarize `debug_history` collected with enable_debug(record=True)."""
+        history = list(self.debug_history)
+        if not history:
+            return {
+                "total_requests": 0,
+                "total_ms": 0,
+                "avg_ms": 0,
+                "p99_ms": 0,
+                "by_method": {},
+                "by_status": {},
+                "slowest": None,
+            }
+        durations = sorted(float(row.get("client_ms", 0)) for row in history)
+        total_ms = sum(durations)
+        p99_index = min(len(durations) - 1, int(len(durations) * 0.99))
+        by_method: dict[str, int] = {}
+        by_status: dict[int, int] = {}
+        for row in history:
+            method = str(row.get("method", ""))
+            status = int(row.get("status", 0))
+            by_method[method] = by_method.get(method, 0) + 1
+            by_status[status] = by_status.get(status, 0) + 1
+        slowest = max(history, key=lambda row: float(row.get("client_ms", 0)))
+        return {
+            "total_requests": len(history),
+            "total_ms": round(total_ms, 3),
+            "avg_ms": round(total_ms / len(history), 3),
+            "p99_ms": round(durations[p99_index], 3),
+            "by_method": by_method,
+            "by_status": by_status,
+            "slowest": slowest,
+        }
+
+    def _debug_install_panel(self, path: str) -> None:
+        prior = self._debug_is_in_progress()
+        self._debug_set_in_progress(True)
+        try:
+            self.put(path, _DEBUG_PANEL_HTML, content_type="text/html; charset=utf-8")
+            print(f"\n  debug panel: {self.url}{_quote_path(path)}\n", file=sys.stderr)
+        except Exception:
+            _log.debug("failed to install elastik debug panel", exc_info=True)
+        finally:
+            self._debug_set_in_progress(prior)
 
     def put(
         self,
@@ -888,6 +1122,84 @@ class Elastik(MutableMapping[str, bytes]):
     def __truediv__(self, path: str) -> "WorldRef":
         return WorldRef(self, path.strip("/"))
 
+    def _debug_after_response(
+        self,
+        method: str,
+        path: str,
+        request_headers: dict[str, str],
+        response: Response,
+        elapsed_ms: float,
+    ) -> None:
+        if not self._debug_enabled or self._debug_is_in_progress():
+            return
+        if _is_debug_path(path):
+            return
+        rid = response.headers.get("x-request-id", "?")
+        event: dict[str, Any] = {
+            "rid": rid,
+            "method": method.upper(),
+            "path": path,
+            "status": response.status,
+            "client_ms": round(elapsed_ms, 3),
+            "core_us": _int_header(response.headers, "x-elapsed-us"),
+            "bytes": len(response.body),
+            "ts": time.time(),
+        }
+        if self._debug_verbose >= 3:
+            event["request_headers"] = _redact_headers(request_headers)
+            event["response_headers"] = _redact_headers(response.headers)
+        if self._debug_hook is not None:
+            try:
+                self._debug_hook(method.upper(), path, response.status, elapsed_ms, rid)
+            except Exception:
+                _log.exception("elastik debug hook failed")
+        if not self._debug_should_log(response.status, elapsed_ms):
+            if _debug_break_matches(self._debug_break_on, response.status):
+                breakpoint()
+            return
+        if self._debug_record:
+            self.debug_history.append(dict(event))
+        line = json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
+        self._debug_append(self._debug_sink, line)
+        if response.status >= 400:
+            self._debug_append("/tmp/debug/errors", line)
+        if elapsed_ms >= self._debug_slow_ms:
+            self._debug_append("/tmp/debug/slow", line)
+        if _debug_break_matches(self._debug_break_on, response.status):
+            breakpoint()
+
+    def _debug_should_log(self, status: int, elapsed_ms: float) -> bool:
+        if self._debug_level == "all":
+            return True
+        if self._debug_level == "errors":
+            return status >= 400
+        if self._debug_level == "slow":
+            return status >= 400 or elapsed_ms >= self._debug_slow_ms
+        return False
+
+    def _debug_append(self, path: str | None, line: str) -> None:
+        if not path:
+            return
+        prior = self._debug_is_in_progress()
+        self._debug_set_in_progress(True)
+        try:
+            body = line.encode("utf-8")
+            try:
+                self.post(path, body)
+            except NotFound:
+                self.put(path, b"", content_type="application/x-ndjson")
+                self.post(path, body)
+        except Exception:
+            _log.debug("failed to append elastik debug record", exc_info=True)
+        finally:
+            self._debug_set_in_progress(prior)
+
+    def _debug_is_in_progress(self) -> bool:
+        return bool(getattr(self._debug_local, "in_progress", False))
+
+    def _debug_set_in_progress(self, value: bool) -> None:
+        self._debug_local.in_progress = value
+
     def request(
         self,
         method: str,
@@ -910,14 +1222,16 @@ class Elastik(MutableMapping[str, bytes]):
                     {k.lower(): v for k, v in r.headers.items()},
                     r.read(),
                 )
+                elapsed_ms = (time.perf_counter() - start) * 1000
                 _log.debug(
                     "%s %s -> %d %dB %.1fms",
                     method,
                     path,
                     response.status,
                     len(response.body),
-                    (time.perf_counter() - start) * 1000,
+                    elapsed_ms,
                 )
+                self._debug_after_response(method, path, h, response, elapsed_ms)
                 return response
         except urllib.error.HTTPError as e:
             response = Response(
@@ -925,14 +1239,16 @@ class Elastik(MutableMapping[str, bytes]):
                 {k.lower(): v for k, v in (e.headers or {}).items()},
                 e.read() if e.fp else b"",
             )
+            elapsed_ms = (time.perf_counter() - start) * 1000
             _log.debug(
                 "%s %s -> %d %dB %.1fms",
                 method,
                 path,
                 response.status,
                 len(response.body),
-                (time.perf_counter() - start) * 1000,
+                elapsed_ms,
             )
+            self._debug_after_response(method, path, h, response, elapsed_ms)
             return response
 
     def _raw(
@@ -1241,11 +1557,59 @@ def _etag_value(value: str | None) -> str | None:
     return f'"{v}"'
 
 
+def _is_debug_path(path: str) -> bool:
+    normalized = path.strip("/")
+    if not normalized:
+        return False
+    if normalized.startswith("tmp/debug/"):
+        return True
+    if "/" not in normalized:
+        normalized = f"home/{normalized}"
+    return normalized.startswith("tmp/debug/")
+
+
+def _int_header(headers: dict[str, str], name: str) -> int | None:
+    value = headers.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    redacted: dict[str, str] = {}
+    for name, value in headers.items():
+        lower = str(name).lower()
+        redacted[lower] = "<redacted>" if _is_debug_secret_header(lower) else str(value)
+    return redacted
+
+
+def _is_debug_secret_header(name: str) -> bool:
+    return name in _DEBUG_SECRET_HEADERS or name.endswith(_DEBUG_SECRET_SUFFIXES)
+
+
+def _debug_break_matches(break_on: int | set[int] | None, status: int) -> bool:
+    if break_on is None:
+        return False
+    if isinstance(break_on, set):
+        return status in break_on
+    return status == int(break_on)
+
+
 def _raise_for_response(resp: Response, method: str, path: str) -> None:
-    _raise_error(resp.status, resp.body, method=method, path=path)
+    _raise_error(resp.status, resp.body, method=method, path=path, headers=resp.headers)
 
 
-def _raise_error(status: int, body: bytes, *, method: str = "", path: str = "") -> None:
+def _raise_error(
+    status: int,
+    body: bytes,
+    *,
+    method: str = "",
+    path: str = "",
+    headers: dict[str, str] | None = None,
+) -> None:
     cls: type[ElastikError]
     if status == 401:
         cls = Unauthorized
@@ -1261,7 +1625,7 @@ def _raise_error(status: int, body: bytes, *, method: str = "", path: str = "") 
         cls = ServerError
     else:
         cls = ElastikError
-    raise cls(status, body, method=method, path=path)
+    raise cls(status, body, method=method, path=path, headers=headers)
 
 
 def _warn_near_representation_kwargs(meta: dict[str, Any]) -> None:

--- a/sdk/src/elastik/testing.py
+++ b/sdk/src/elastik/testing.py
@@ -26,9 +26,7 @@ class FakeElastik(Elastik):
     """In-memory SDK-compatible fake for handler/unit tests."""
 
     def __init__(self):
-        self.url = "fake://elastik"
-        self.bearer_token = "fake"
-        self._etag_cache: dict[str, tuple[str, bytes]] = {}
+        super().__init__("fake://elastik", bearer_token="fake")
         self._store: dict[str, tuple[bytes, WorldMeta]] = {}
 
     def __repr__(self) -> str:

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -419,6 +419,19 @@ def main() -> int:
                 len(writer.debug_history) == threaded_history_before + 1,
                 "debug recursion guard is thread-local",
             )
+            sinkless = Elastik(base, bearer_token=write_token)
+            sinkless.enable_debug(level="all", sink=None, record=True, slow_ms=0, panel=False)
+            sinkless_writes: list[str | None] = []
+            sinkless._debug_append = lambda path, line: sinkless_writes.append(path)  # type: ignore[method-assign]
+            sinkless._debug_after_response(
+                "GET",
+                "/home/sdk/sinkless-debug",
+                {},
+                elastik.Response(500, {"x-request-id": "sinkless", "x-elapsed-us": "1"}, b"boom"),
+                101.0,
+            )
+            check(sinkless.debug_history[-1]["status"] == 500, "debug sink=None still records in memory")
+            check(sinkless_writes == [], "debug sink=None disables request/error/slow sink writes")
             writer.disable_debug()
             writer.put(
                 "/home/sdk/logo.png",

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -23,6 +23,7 @@ import compileall
 import contextlib
 import csv
 import io
+import json
 import os
 import shutil
 import socket
@@ -353,6 +354,72 @@ def main() -> int:
             check(head["cache-control"] == "max-age=60", "head cache-control")
             check(head["x-meta-author"] == "ranger", "head x-meta")
             check(head["accept-ranges"] == "bytes", "head accept-ranges")
+            debug_hooks: list[tuple[str, str, int, str]] = []
+            writer.enable_debug(
+                level="all",
+                record=True,
+                verbose=3,
+                slow_ms=0,
+                hook=lambda method, path, status, _ms, rid: debug_hooks.append(
+                    (method, path, status, rid)
+                ),
+            )
+            panel_html = reader.get_text("/tmp/debug-panel.html")
+            check("EventSource(\"/listen/tmp/debug/requests\")" in panel_html, "debug panel listens for sink wakeups")
+            check("fetch(SINK" in panel_html, "debug panel reads log body via GET")
+            writer.put("/home/sdk/debug", "trace")
+            check(writer.debug_history[-1]["path"] == "/home/sdk/debug", "debug_history records request path")
+            check(writer.debug_history[-1]["rid"] != "?", "debug_history captures X-Request-Id")
+            check(
+                writer.debug_history[-1]["request_headers"]["authorization"] == "<redacted>",
+                "debug verbose redacts Authorization",
+            )
+            check(debug_hooks[-1][:3] == ("PUT", "/home/sdk/debug", 201), "debug hook receives request summary")
+            secret_resp = writer.request("OPTIONS", "/home/sdk/debug", headers={"X-Api-Key": "secret"})
+            check(secret_resp.status == 204, "debug redaction probe request succeeds")
+            check(
+                writer.debug_history[-1]["request_headers"]["x-api-key"] == "<redacted>",
+                "debug verbose redacts *-key headers",
+            )
+            debug_log = reader.get_text("/tmp/debug/requests")
+            check("/home/sdk/debug" in debug_log, "debug sink records request JSONL in /tmp")
+            check("/tmp/debug/requests" not in debug_log, "debug sink does not recursively log itself")
+            slow_log = reader.get_text("/tmp/debug/slow")
+            check("/home/sdk/debug" in slow_log, "debug slow sink records slow-threshold matches")
+            try:
+                writer.get("/home/sdk/debug-missing")
+            except elastik.NotFound:
+                pass
+            else:
+                raise AssertionError("FAIL: debug missing read did not raise NotFound")
+            error_log = reader.get_text("/tmp/debug/errors")
+            check('"status": 404' in error_log, "debug error sink records 4xx responses")
+            stats = writer.debug_stats()
+            check(stats["total_requests"] >= 2, "debug_stats summarizes recorded requests")
+            check(stats["by_method"].get("PUT", 0) >= 1, "debug_stats groups by method")
+            check(stats["by_status"].get(404, 0) >= 1, "debug_stats groups by status")
+            first_debug_event = json.loads(debug_log.splitlines()[0])
+            check("core_us" in first_debug_event, "debug JSONL includes core elapsed us")
+            writer._debug_set_in_progress(True)
+            threaded_history_before = len(writer.debug_history)
+            debug_thread = threading.Thread(
+                target=lambda: writer._debug_after_response(
+                    "GET",
+                    "/home/sdk/thread-local-debug",
+                    {},
+                    elastik.Response(200, {"x-request-id": "thread", "x-elapsed-us": "1"}, b"ok"),
+                    1.0,
+                ),
+                daemon=True,
+            )
+            debug_thread.start()
+            debug_thread.join(5)
+            writer._debug_set_in_progress(False)
+            check(
+                len(writer.debug_history) == threaded_history_before + 1,
+                "debug recursion guard is thread-local",
+            )
+            writer.disable_debug()
             writer.put(
                 "/home/sdk/logo.png",
                 b"\x89PNG\r\n",


### PR DESCRIPTION
## Summary
- add opt-in SDK request tracing via `enable_debug(...)`, `disable_debug()`, `debug_history`, and `debug_stats()`
- support `elastik.start(..., debug=True)` / `Elastik(..., debug=...)` using the core-owned `X-Request-Id` and `X-Elapsed-Us` response headers
- write best-effort JSONL debug records into memory-backed `/tmp/debug/requests`, with `/tmp/debug/errors` and `/tmp/debug/slow` mirrors, recursion guard, hook support, redacted verbose headers, and optional `break_on` breakpoint
- install a tiny default `/tmp/debug-panel.html` when debug is enabled; it uses SSE only as a wakeup and reads `/tmp/debug/requests` over normal GET
- enrich `ElastikError` with response headers, request id, and core elapsed time for incident debugging
- document the SDK debug sink and cover it in the black-box SDK test

## Verification
- `python -m compileall sdk\src\elastik`
- `python sdk\tests\test_tools.py`
- `python sdk\tests\e2e_blackbox.py`
- `python sdk\tests\e2e_blackbox.py --no-build`
- `cargo test --manifest-path core\Cargo.toml`