### PR TITLE
feat(sdk): add reactor lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,24 @@ PUT /home/task/a  -> SSE event -> SDK handler -> PUT /home/result/a
 
 No Kafka. No Redis. No WebSocket server. Just HTTP plus an SDK callback.
 
+Lifecycle hooks wrap the SDK event loop. They are useful for worker health
+worlds and cleanup:
+
+```python
+@elastik.on_startup
+def ready(e):
+    e.put("/sys/health/worker-1", "alive")
+
+@elastik.on_shutdown
+def gone(e):
+    e.delete("/sys/health/worker-1")
+
+elastik.run(e)
+```
+
+Hooks may accept no arguments or ask for `e`. Shutdown hooks run even when
+`run()` exits through `max_events`, Ctrl+C, or an exception.
+
 ## Trusted Shell Pool
 
 For local agent pipelines, the SDK includes a warmed shell pool:

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -46,6 +46,14 @@ Reactor (declarative event handlers):
     elastik.run()                         # blocks forever; only call after
                                           # registering at least one handler
 
+    @elastik.on_startup
+    def ready(e):
+        e.put("/sys/health/worker-1", "alive")
+
+    @elastik.on_shutdown
+    def gone(e):
+        e.delete("/sys/health/worker-1")
+
 Handlers may either do side effects directly (normal Python) or return
 Action objects like Reply/Archive/MoveTo/Drop for declarative routing.
 `world` is accepted as an older name for the same value as `path`.
@@ -84,8 +92,11 @@ from elastik.reactor import (
     listen,
     run,
     clear_routes,
+    clear_lifecycle_hooks,
     unlisten,
     has_routes,
+    on_startup,
+    on_shutdown,
     MoveTo,
     Reply,
     Archive,
@@ -128,7 +139,8 @@ __all__ = [
     "Response",
     "WorldMeta", "WorldRef", "WorldReader", "FakeElastik",
     # Reactor sugar
-    "listen", "run", "clear_routes", "unlisten", "has_routes",
+    "listen", "run", "clear_routes", "clear_lifecycle_hooks",
+    "unlisten", "has_routes", "on_startup", "on_shutdown",
     "MoveTo", "Reply", "Archive", "Drop", "Action", "Ctx",
     # Lifecycle
     "start", "stop", "is_running", "default_url", "binary_info", "live_info",

--- a/sdk/src/elastik/reactor.py
+++ b/sdk/src/elastik/reactor.py
@@ -19,6 +19,8 @@ from elastik.sdk import Elastik
 F = TypeVar("F", bound=Callable[..., Any])
 
 _routes: dict[str, Callable[..., Any]] = {}
+_startup_hooks: list[Callable[..., Any]] = []
+_shutdown_hooks: list[Callable[..., Any]] = []
 
 
 def listen(pattern: str, *, replace: bool = False) -> Callable[[F], F]:
@@ -57,9 +59,57 @@ def clear_routes() -> None:
     _routes.clear()
 
 
+def on_startup(func: F) -> F:
+    """Register a function called once before run() starts consuming events.
+
+    Hooks may accept no arguments or ask for `e`; both forms are supported:
+
+        @elastik.on_startup
+        def ready(e):
+            e.put("/sys/health/worker-1", "alive")
+    """
+    _startup_hooks.append(func)
+    return func
+
+
+def on_shutdown(func: F) -> F:
+    """Register a function called when run() exits.
+
+    Shutdown hooks run in reverse registration order. They may accept no
+    arguments or ask for `e`.
+    """
+    _shutdown_hooks.append(func)
+    return func
+
+
+def clear_lifecycle_hooks() -> None:
+    """Remove startup/shutdown hooks. Useful for tests and notebooks."""
+    _startup_hooks.clear()
+    _shutdown_hooks.clear()
+
+
 def has_routes() -> bool:
     """Return True when at least one @listen handler is registered."""
     return bool(_routes)
+
+
+def _call_lifecycle_hook(hook: Callable[..., Any], e: Elastik) -> Any:
+    sig = inspect.signature(hook)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return hook(e=e)
+    if "e" in sig.parameters:
+        return hook(e=e)
+    return hook()
+
+
+def _run_startup_hooks(e: Elastik) -> None:
+    for hook in list(_startup_hooks):
+        _call_lifecycle_hook(hook, e)
+
+
+def _run_shutdown_hooks(e: Elastik) -> None:
+    for hook in reversed(list(_shutdown_hooks)):
+        _call_lifecycle_hook(hook, e)
 
 
 def _matches(pattern: str, path: str) -> bool:
@@ -254,30 +304,62 @@ def run(
         e = Elastik()
     last_event_id = ""
     dispatched = 0
-    while True:
-        try:
-            for event in e.listen("*", last_event_id=last_event_id or None):
-                if event.get("id"):
-                    last_event_id = event["id"]
-                if event.get("event") == "lag":
-                    print(
-                        f"elastik reactor: missed SSE events: {event.get('data', '')}",
-                        file=sys.stderr,
-                    )
-                    continue
-                world = event.get("path", "")
-                method = event.get("method", event.get("event", "")).upper()
-                if not world:
-                    continue
-                routes = _matching_routes(world)
-                if not routes:
-                    continue
-                if method == "DELETE":
+    failure: BaseException | None = None
+    try:
+        _run_startup_hooks(e)
+        while True:
+            try:
+                for event in e.listen("*", last_event_id=last_event_id or None):
+                    if event.get("id"):
+                        last_event_id = event["id"]
+                    if event.get("event") == "lag":
+                        print(
+                            f"elastik reactor: missed SSE events: {event.get('data', '')}",
+                            file=sys.stderr,
+                        )
+                        continue
+                    world = event.get("path", "")
+                    method = event.get("method", event.get("event", "")).upper()
+                    if not world:
+                        continue
+                    routes = _matching_routes(world)
+                    if not routes:
+                        continue
+                    if method == "DELETE":
+                        _dispatch(
+                            world,
+                            b"",
+                            event.get("etag", ""),
+                            {},
+                            e,
+                            method,
+                            event,
+                            routes=routes,
+                        )
+                        dispatched += 1
+                        if max_events is not None and dispatched >= max_events:
+                            return
+                        continue
+                    try:
+                        body = e.get(world)
+                        head = e.head(world)
+                    except Exception as exc:
+                        print(
+                            f"elastik reactor: failed to fetch {world}: "
+                            f"{type(exc).__name__}: {exc}",
+                            file=sys.stderr,
+                        )
+                        continue
+                    meta = {
+                        k: v
+                        for k, v in head.items()
+                        if k.lower().startswith("x-meta-")
+                    }
                     _dispatch(
                         world,
-                        b"",
-                        event.get("etag", ""),
-                        {},
+                        body,
+                        head.get("etag", event.get("etag", "")),
+                        meta,
                         e,
                         method,
                         event,
@@ -286,43 +368,29 @@ def run(
                     dispatched += 1
                     if max_events is not None and dispatched >= max_events:
                         return
-                    continue
-                try:
-                    body = e.get(world)
-                    head = e.head(world)
-                except Exception as exc:
-                    print(
-                        f"elastik reactor: failed to fetch {world}: "
-                        f"{type(exc).__name__}: {exc}",
-                        file=sys.stderr,
-                    )
-                    continue
-                meta = {
-                    k: v
-                    for k, v in head.items()
-                    if k.lower().startswith("x-meta-")
-                }
-                _dispatch(
-                    world,
-                    body,
-                    head.get("etag", event.get("etag", "")),
-                    meta,
-                    e,
-                    method,
-                    event,
-                    routes=routes,
-                )
-                dispatched += 1
-                if max_events is not None and dispatched >= max_events:
-                    return
-        except KeyboardInterrupt:
-            raise
-        except Exception as exc:
-            if not reconnect:
+            except KeyboardInterrupt:
                 raise
-            print(
-                f"elastik reactor: {type(exc).__name__}: {exc}; "
-                f"retrying in {retry_s}s",
-                file=sys.stderr,
-            )
-            time.sleep(retry_s)
+            except Exception as exc:
+                if not reconnect:
+                    raise
+                print(
+                    f"elastik reactor: {type(exc).__name__}: {exc}; "
+                    f"retrying in {retry_s}s",
+                    file=sys.stderr,
+                )
+                time.sleep(retry_s)
+    except BaseException as exc:
+        failure = exc
+        raise
+    finally:
+        if failure is None:
+            _run_shutdown_hooks(e)
+        else:
+            try:
+                _run_shutdown_hooks(e)
+            except BaseException as cleanup_exc:
+                print(
+                    "elastik reactor: shutdown hook failed during unwind: "
+                    f"{type(cleanup_exc).__name__}: {cleanup_exc}",
+                    file=sys.stderr,
+                )

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -197,6 +197,7 @@ def main() -> int:
         check("sdk-shell" in shell.stdout, "TrustedShellPool is exported and runs")
 
     elastik.clear_routes()
+    elastik.clear_lifecycle_hooks()
     try:
         elastik.run(reconnect=False)
     except RuntimeError as e:
@@ -223,6 +224,111 @@ def main() -> int:
         raise AssertionError("FAIL: duplicate reactor handler was accepted")
     elastik.unlisten("/home/sdk/unit/*")
     check(not elastik.has_routes(), "reactor unlisten removes handler")
+    lifecycle_calls: list[str] = []
+
+    @elastik.on_startup
+    def _startup_no_args():
+        lifecycle_calls.append("startup-no-args")
+
+    @elastik.on_shutdown
+    def _shutdown_no_args():
+        lifecycle_calls.append("shutdown-no-args")
+
+    elastik.clear_lifecycle_hooks()
+    check(lifecycle_calls == [], "clear_lifecycle_hooks removes registered hooks")
+    startup_failure_calls: list[str] = []
+
+    @elastik.listen("/home/sdk/unit/*")
+    def _startup_failure_handler(body):
+        return None
+
+    @elastik.on_startup
+    def _startup_fails():
+        startup_failure_calls.append("startup")
+        raise RuntimeError("boom")
+
+    @elastik.on_shutdown
+    def _shutdown_after_startup_failure():
+        startup_failure_calls.append("shutdown")
+
+    try:
+        elastik.run(elastik.FakeElastik(), reconnect=False, max_events=1)
+    except RuntimeError as e:
+        check("boom" in str(e), "reactor surfaces startup hook failures")
+    else:
+        raise AssertionError("FAIL: startup hook failure did not propagate")
+    check(
+        startup_failure_calls == ["startup", "shutdown"],
+        "shutdown hooks run after startup failure",
+    )
+    elastik.clear_routes()
+    elastik.clear_lifecycle_hooks()
+
+    preserve_calls: list[str] = []
+
+    @elastik.listen("/home/sdk/unit/*")
+    def _preserve_handler(body):
+        return None
+
+    @elastik.on_startup
+    def _startup_root_cause():
+        preserve_calls.append("startup")
+        raise RuntimeError("root-cause")
+
+    @elastik.on_shutdown
+    def _shutdown_breaks_too():
+        preserve_calls.append("shutdown")
+        raise RuntimeError("cleanup-broke")
+
+    try:
+        elastik.run(elastik.FakeElastik(), reconnect=False, max_events=1)
+    except RuntimeError as e:
+        check(
+            "root-cause" in str(e),
+            "shutdown hook failure preserves original run exception",
+            str(e),
+        )
+    else:
+        raise AssertionError("FAIL: shutdown failure replaced original exception")
+    check(
+        preserve_calls == ["startup", "shutdown"],
+        "failing shutdown hook still runs during unwind",
+    )
+    elastik.clear_routes()
+    elastik.clear_lifecycle_hooks()
+
+    snapshot_calls: list[str] = []
+
+    @elastik.listen("/home/sdk/unit/*")
+    def _snapshot_handler(body):
+        return None
+
+    @elastik.on_startup
+    def _snapshot_exit():
+        raise RuntimeError("snapshot-exit")
+
+    @elastik.on_shutdown
+    def _shutdown_last_from_snapshot():
+        snapshot_calls.append("last")
+
+    @elastik.on_shutdown
+    def _shutdown_mutates_registry():
+        snapshot_calls.append("mutates")
+        elastik.clear_lifecycle_hooks()
+
+    try:
+        elastik.run(elastik.FakeElastik(), reconnect=False, max_events=1)
+    except RuntimeError as e:
+        check("snapshot-exit" in str(e), "snapshot test exits through startup hook")
+    else:
+        raise AssertionError("FAIL: snapshot startup failure did not propagate")
+    check(
+        snapshot_calls == ["mutates", "last"],
+        "shutdown hooks run from an immutable reverse-order snapshot",
+        str(snapshot_calls),
+    )
+    elastik.clear_routes()
+    elastik.clear_lifecycle_hooks()
 
     client_env = (
         "ELASTIK_URL",
@@ -919,23 +1025,38 @@ def main() -> int:
             check(int(replay.get("id", "0")) > int(ev.get("id", "0")), "replayed SSE id advances")
 
             elastik.clear_routes()
+            elastik.clear_lifecycle_hooks()
             handled: list[tuple[str, bytes]] = []
+            lifecycle: list[str] = []
 
             @elastik.listen("/home/sdk/reactor-run/*")
             def _on_reactor_event(body, path):
                 handled.append((path, body))
 
+            @elastik.on_startup
+            def _on_startup(e):
+                lifecycle.append("startup")
+                e.put("/tmp/sdk/lifecycle/ready", "alive")
+
+            @elastik.on_shutdown
+            def _on_shutdown(e):
+                lifecycle.append("shutdown")
+                e.delete("/tmp/sdk/lifecycle/ready")
+
             threading.Timer(
                 0.2,
                 lambda: writer.put("/home/sdk/reactor-run/a", b"reactor"),
             ).start()
-            elastik.run(reader, reconnect=False, max_events=1)
+            elastik.run(approver, reconnect=False, max_events=1)
             check(
                 handled == [("/home/sdk/reactor-run/a", b"reactor")],
                 "reactor run dispatches path kwarg and exits with max_events",
                 repr(handled),
             )
+            check(lifecycle == ["startup", "shutdown"], "reactor lifecycle hooks wrap run()")
+            expect_error(lambda: reader.get("/tmp/sdk/lifecycle/ready"), 404, check, "shutdown hook cleaned health world")
             elastik.clear_routes()
+            elastik.clear_lifecycle_hooks()
 
             print(f"\nPASS sdk e2e blackbox: {check.n} checks")
             return 0


### PR DESCRIPTION
## Summary
- add `@elastik.on_startup` and `@elastik.on_shutdown` decorators for SDK reactor lifecycle hooks
- add `clear_lifecycle_hooks()` for tests/notebooks
- run startup hooks before the SSE loop and shutdown hooks in `finally`, including max-events return and startup failure cleanup
- export the new APIs and document worker health-world usage in the README

## Verification
- `python -m compileall sdk\src\elastik`
- `python sdk\tests\test_tools.py`
- `python sdk\tests\e2e_blackbox.py --no-build`
- `cargo test --manifest-path core\Cargo.toml`