### PR TITLE
docs: clarify SCoAP identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,35 @@ SCoAP is intentionally small: `GET` and `PUT`, one UDP datagram, content formats
 the core can map (`text/plain`, `application/octet-stream`, `application/json`,
 `application/cbor`). Larger bodies and arbitrary media types should use HTTP.
 
+This is not a full RFC 7252 CoAP stack. It is a CoAP-shaped UDP surface:
+CoAP wire format, HTTP-shaped storage semantics, and elastik auth.
+
+It keeps the parts with semantic zero distance from HTTP:
+
+- CoAP v1 header
+- method codes for `GET` and `PUT`
+- `Uri-Path` as the path
+- `Content-Format` as `Content-Type`
+- payload marker
+- token echo
+- response codes
+
+It intentionally does not implement CoAP politics:
+
+- retransmission or dedup cache
+- Observe
+- Block-Wise transfer
+- DTLS / OSCORE
+- `.well-known/core`
+- multicast discovery
+- `Max-Age`
+- strict critical-option handling
+
+Elastik uses private option `65001` to carry the raw elastik auth token. That
+is not encryption and not CoAPS; it is the UDP equivalent of
+`Authorization: Bearer ...`. Need full CoAP behavior? Put a compliant CoAP
+gateway at the edge. Need reliability or large bodies? Use HTTP.
+
 `ELASTIK_DATA` is the universe selector. Point the same binary at another data
 directory and it serves another Elastik universe. Local SSD/tempdir is best for
 writes. Synced folders and network shares can be useful for distribution, but

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -39,6 +39,7 @@ No hidden object model: `put()` replaces bytes, `post()` appends bytes,
 | Inspect metadata | `e.head`, `e.checksum`, `e.preview`, `e.diff` |
 | Use scratch space | `with e.tmp() as path:` |
 | Drop to raw HTTP | `e.request(method, path, headers=...)` |
+| Send one UDP-curl packet | `CoapClient`, `python -m elastik coap` |
 
 Prefer `e.put(...)` instance methods in libraries, tests, and long-running
 tools where client lifecycle should be explicit. Use module-level
@@ -162,6 +163,37 @@ operations are disabled.
 Migration note: `ELASTIK_TOKEN` was the old write-token name. It still works as
 a temporary fallback when `ELASTIK_WRITE_TOKEN` is unset, but the SDK warns so
 you can rename it.
+
+## SCoAP / UDP Helper
+
+The core can expose an opt-in SCoAP/UDP surface when `ELASTIK_COAP_PORT` is
+set. The SDK gives humans a small translator so nobody has to hand-type CoAP
+bytes:
+
+```powershell
+python -m elastik coap put 127.0.0.1 5683 /home/sensor/temp "23.5" --token write-token
+python -m elastik coap get 127.0.0.1 5683 /home/sensor/temp --token read-token
+```
+
+Or keep the endpoint once:
+
+```python
+from elastik import CoapClient
+
+c = CoapClient("127.0.0.1", 5683, token="write-token")
+c.put("/home/sensor/temp", "23.5").raise_for_status()
+print(c.get("/home/sensor/temp").payload)
+```
+
+This is not a full RFC 7252 CoAP stack. It is a CoAP-shaped UDP adapter:
+one datagram in, one datagram out, `GET`/`PUT`, `Uri-Path`, `Content-Format`,
+payload bytes, and response codes. It does not implement retransmission,
+dedup, Observe, Block-Wise transfer, DTLS/OSCORE, `.well-known/core`, multicast
+discovery, `Max-Age`, or strict critical-option handling.
+
+Elastik private option `65001` carries the raw auth token, like a UDP-shaped
+`Authorization: Bearer ...`. It is not encryption. Use a CoAP gateway at the
+edge if you need full CoAP behavior; use HTTP for reliability or large bodies.
 
 ## Paths
 


### PR DESCRIPTION
## Summary

Clarifies the identity of the SCoAP/UDP surface in the root README and SDK README.

- Defines SCoAP as a CoAP-shaped UDP adapter, not a full RFC 7252 CoAP stack.
- Lists the CoAP wire-truth pieces elastik keeps: v1 header, GET/PUT method codes, Uri-Path, Content-Format, payload marker, token echo, response codes.
- Lists the CoAP runtime politics elastik intentionally does not implement: retransmission, dedup, Observe, Block-Wise, DTLS/OSCORE, .well-known/core, multicast discovery, Max-Age, strict critical-option handling.
- Documents private option 65001 as raw elastik auth token, not encryption or CoAPS.
- Adds SDK README examples for `python -m elastik coap` and `CoapClient`.

## Verification

- `git diff --check`
