### PR TITLE
feat(core,sdk): verify audit chains via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,28 @@ Memory worlds use a body hash:
 ETag: "sha256-..."
 ```
 
+Audit verification is HTTP too. The core owns the HMAC key, so it replays the
+chain itself and answers in status plus headers:
+
+```http
+HEAD /proc/audit/home/note/verify
+```
+
+An intact durable chain returns:
+
+```http
+HTTP/1.1 200 OK
+X-Audit-Valid: true
+X-Audit-Events: 42
+X-Audit-Genesis: hmac-...
+X-Audit-Latest: hmac-...
+```
+
+A broken chain returns `409 Conflict` with `X-Audit-Valid: false`,
+`X-Audit-Break-At`, `X-Audit-Expected`, and `X-Audit-Actual`. Missing worlds
+return `404 Not Found`. Memory worlds return `204 No Content` with
+`X-Audit-Valid: n/a`.
+
 Create only if missing:
 
 ```powershell

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -60,13 +60,15 @@ pub fn append_tx(
         .unwrap_or_default();
     let h = event_hmac(
         key,
-        &prev,
-        event_type,
-        target,
-        body_sha256,
-        size,
-        content_type,
-        &meta_sha256,
+        EventHmacInput {
+            prev: &prev,
+            event_type,
+            target,
+            body_sha256,
+            size,
+            content_type,
+            meta_sha256: &meta_sha256,
+        },
     );
     tx.execute(
         r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
@@ -124,6 +126,16 @@ struct EventRow {
     prev_hmac: String,
 }
 
+struct EventHmacInput<'a> {
+    prev: &'a str,
+    event_type: &'a str,
+    target: &'a str,
+    body_sha256: &'a str,
+    size: i64,
+    content_type: &'a str,
+    meta_sha256: &'a str,
+}
+
 pub fn verify_chain(
     data_root: &Path,
     world_name: &str,
@@ -133,7 +145,7 @@ pub fn verify_chain(
     if !path.exists() {
         return Ok(None);
     }
-    let c = Connection::open(path)?;
+    let c = world::open(data_root, world_name)?;
     verify_connection(&c, key).map(Some)
 }
 
@@ -144,33 +156,26 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
            FROM events
            ORDER BY id ASC"#,
     )?;
-    let rows = stmt
-        .query_map([], |r| {
-            Ok(EventRow {
-                id: r.get(0)?,
-                event_type: r.get(1)?,
-                target: r.get(2)?,
-                body_sha256: r.get(3)?,
-                size: r.get(4)?,
-                content_type: r.get(5)?,
-                meta_sha256: r.get(6)?,
-                hmac: r.get(7)?,
-                prev_hmac: r.get(8)?,
-            })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-
-    if rows.is_empty() {
-        return Ok(VerifyReport::Broken(VerifyBreak {
-            break_at: 0,
-            expected: "at-least-one-event".to_owned(),
-            actual: "no-events".to_owned(),
-        }));
-    }
-
     let mut prev = String::new();
     let mut genesis = String::new();
-    for (idx, row) in rows.iter().enumerate() {
+    let mut events = 0usize;
+    let rows = stmt.query_map([], |r| {
+        Ok(EventRow {
+            id: r.get(0)?,
+            event_type: r.get(1)?,
+            target: r.get(2)?,
+            body_sha256: r.get(3)?,
+            size: r.get(4)?,
+            content_type: r.get(5)?,
+            meta_sha256: r.get(6)?,
+            hmac: r.get(7)?,
+            prev_hmac: r.get(8)?,
+        })
+    })?;
+
+    for row in rows {
+        let row = row?;
+        let idx = events;
         if row.prev_hmac != prev {
             return Ok(VerifyReport::Broken(VerifyBreak {
                 break_at: idx,
@@ -189,13 +194,15 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
         }
         let expected_hmac = event_hmac(
             key,
-            &prev,
-            &row.event_type,
-            &row.target,
-            &row.body_sha256,
-            row.size,
-            &row.content_type,
-            &row.meta_sha256,
+            EventHmacInput {
+                prev: &prev,
+                event_type: &row.event_type,
+                target: &row.target,
+                body_sha256: &row.body_sha256,
+                size: row.size,
+                content_type: &row.content_type,
+                meta_sha256: &row.meta_sha256,
+            },
         );
         if expected_hmac != row.hmac {
             return Ok(VerifyReport::Broken(VerifyBreak {
@@ -208,10 +215,19 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
             genesis = row.hmac.clone();
         }
         prev = row.hmac.clone();
+        events += 1;
+    }
+
+    if events == 0 {
+        return Ok(VerifyReport::Broken(VerifyBreak {
+            break_at: 0,
+            expected: "at-least-one-event".to_owned(),
+            actual: "no-events".to_owned(),
+        }));
     }
 
     Ok(VerifyReport::Valid(VerifyOk {
-        events: rows.len(),
+        events,
         genesis: hmac_label(&genesis),
         latest: hmac_label(&prev),
     }))
@@ -254,24 +270,15 @@ fn hmac_field(mac: &mut Hmac<Sha256>, label: &[u8], value: &str) {
     mac.update(b"\0");
 }
 
-fn event_hmac(
-    key: &[u8],
-    prev: &str,
-    event_type: &str,
-    target: &str,
-    body_sha256: &str,
-    size: i64,
-    content_type: &str,
-    meta_sha256: &str,
-) -> String {
+fn event_hmac(key: &[u8], input: EventHmacInput<'_>) -> String {
     let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("hmac key");
-    hmac_field(&mut mac, b"prev", prev);
-    hmac_field(&mut mac, b"type", event_type);
-    hmac_field(&mut mac, b"target", target);
-    hmac_field(&mut mac, b"body-sha256", body_sha256);
-    hmac_field(&mut mac, b"size", &size.to_string());
-    hmac_field(&mut mac, b"content-type", content_type);
-    hmac_field(&mut mac, b"meta-sha256", meta_sha256);
+    hmac_field(&mut mac, b"prev", input.prev);
+    hmac_field(&mut mac, b"type", input.event_type);
+    hmac_field(&mut mac, b"target", input.target);
+    hmac_field(&mut mac, b"body-sha256", input.body_sha256);
+    hmac_field(&mut mac, b"size", &input.size.to_string());
+    hmac_field(&mut mac, b"content-type", input.content_type);
+    hmac_field(&mut mac, b"meta-sha256", input.meta_sha256);
     hex::encode(mac.finalize().into_bytes())
 }
 

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -141,11 +141,9 @@ pub fn verify_chain(
     world_name: &str,
     key: &[u8],
 ) -> rusqlite::Result<Option<VerifyReport>> {
-    let path = world::world_db(data_root, world_name);
-    if !path.exists() {
+    let Some(c) = world::open_existing(data_root, world_name)? else {
         return Ok(None);
-    }
-    let c = world::open(data_root, world_name)?;
+    };
     verify_connection(&c, key).map(Some)
 }
 

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,7 +4,7 @@
 //! the HTTP write.
 
 use hmac::{Hmac, Mac};
-use rusqlite::Transaction;
+use rusqlite::{Connection, Transaction};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
@@ -58,15 +58,16 @@ pub fn append_tx(
             |r| r.get::<_, String>(0),
         )
         .unwrap_or_default();
-    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("hmac key");
-    hmac_field(&mut mac, b"prev", &prev);
-    hmac_field(&mut mac, b"type", event_type);
-    hmac_field(&mut mac, b"target", target);
-    hmac_field(&mut mac, b"body-sha256", body_sha256);
-    hmac_field(&mut mac, b"size", &size.to_string());
-    hmac_field(&mut mac, b"content-type", content_type);
-    hmac_field(&mut mac, b"meta-sha256", &meta_sha256);
-    let h = hex::encode(mac.finalize().into_bytes());
+    let h = event_hmac(
+        key,
+        &prev,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        &meta_sha256,
+    );
     tx.execute(
         r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
                               content_type, meta_sha256, hmac, prev_hmac)
@@ -89,6 +90,140 @@ pub fn append_tx(
         stmt.execute(rusqlite::params![event_id, name, value])?;
     }
     Ok(h)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyOk {
+    pub events: usize,
+    pub genesis: String,
+    pub latest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyBreak {
+    pub break_at: usize,
+    pub expected: String,
+    pub actual: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyReport {
+    Valid(VerifyOk),
+    Broken(VerifyBreak),
+}
+
+struct EventRow {
+    id: i64,
+    event_type: String,
+    target: String,
+    body_sha256: String,
+    size: i64,
+    content_type: String,
+    meta_sha256: String,
+    hmac: String,
+    prev_hmac: String,
+}
+
+pub fn verify_chain(
+    data_root: &Path,
+    world_name: &str,
+    key: &[u8],
+) -> rusqlite::Result<Option<VerifyReport>> {
+    let path = world::world_db(data_root, world_name);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let c = Connection::open(path)?;
+    verify_connection(&c, key).map(Some)
+}
+
+fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyReport> {
+    let mut stmt = c.prepare(
+        r#"SELECT id, event_type, target, body_sha256, size,
+                  content_type, meta_sha256, hmac, prev_hmac
+           FROM events
+           ORDER BY id ASC"#,
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(EventRow {
+                id: r.get(0)?,
+                event_type: r.get(1)?,
+                target: r.get(2)?,
+                body_sha256: r.get(3)?,
+                size: r.get(4)?,
+                content_type: r.get(5)?,
+                meta_sha256: r.get(6)?,
+                hmac: r.get(7)?,
+                prev_hmac: r.get(8)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if rows.is_empty() {
+        return Ok(VerifyReport::Broken(VerifyBreak {
+            break_at: 0,
+            expected: "at-least-one-event".to_owned(),
+            actual: "no-events".to_owned(),
+        }));
+    }
+
+    let mut prev = String::new();
+    let mut genesis = String::new();
+    for (idx, row) in rows.iter().enumerate() {
+        if row.prev_hmac != prev {
+            return Ok(VerifyReport::Broken(VerifyBreak {
+                break_at: idx,
+                expected: hmac_label(&prev),
+                actual: hmac_label(&row.prev_hmac),
+            }));
+        }
+        let headers = event_headers(c, row.id)?;
+        let expected_meta = meta_sha256_canonical(&row.content_type, &headers);
+        if expected_meta != row.meta_sha256 {
+            return Ok(VerifyReport::Broken(VerifyBreak {
+                break_at: idx,
+                expected: format!("meta-sha256-{expected_meta}"),
+                actual: format!("meta-sha256-{}", row.meta_sha256),
+            }));
+        }
+        let expected_hmac = event_hmac(
+            key,
+            &prev,
+            &row.event_type,
+            &row.target,
+            &row.body_sha256,
+            row.size,
+            &row.content_type,
+            &row.meta_sha256,
+        );
+        if expected_hmac != row.hmac {
+            return Ok(VerifyReport::Broken(VerifyBreak {
+                break_at: idx,
+                expected: hmac_label(&expected_hmac),
+                actual: hmac_label(&row.hmac),
+            }));
+        }
+        if idx == 0 {
+            genesis = row.hmac.clone();
+        }
+        prev = row.hmac.clone();
+    }
+
+    Ok(VerifyReport::Valid(VerifyOk {
+        events: rows.len(),
+        genesis: hmac_label(&genesis),
+        latest: hmac_label(&prev),
+    }))
+}
+
+fn event_headers(c: &Connection, event_id: i64) -> rusqlite::Result<Vec<(String, String)>> {
+    let mut stmt =
+        c.prepare("SELECT name, value FROM event_headers WHERE event_id=? ORDER BY name, value")?;
+    let rows = stmt
+        .query_map([event_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+        .collect();
+    rows
 }
 
 #[cfg(test)]
@@ -119,6 +254,37 @@ fn hmac_field(mac: &mut Hmac<Sha256>, label: &[u8], value: &str) {
     mac.update(b"\0");
 }
 
+fn event_hmac(
+    key: &[u8],
+    prev: &str,
+    event_type: &str,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    meta_sha256: &str,
+) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("hmac key");
+    hmac_field(&mut mac, b"prev", prev);
+    hmac_field(&mut mac, b"type", event_type);
+    hmac_field(&mut mac, b"target", target);
+    hmac_field(&mut mac, b"body-sha256", body_sha256);
+    hmac_field(&mut mac, b"size", &size.to_string());
+    hmac_field(&mut mac, b"content-type", content_type);
+    hmac_field(&mut mac, b"meta-sha256", meta_sha256);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn hmac_label(raw: &str) -> String {
+    if raw.is_empty() {
+        "hmac-".to_owned()
+    } else if raw.starts_with("hmac-") {
+        raw.to_owned()
+    } else {
+        format!("hmac-{raw}")
+    }
+}
+
 fn canonical_headers(headers: &[(String, String)]) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = headers
         .iter()
@@ -147,7 +313,7 @@ mod tests {
     use super::*;
     use rusqlite::Connection;
 
-    fn hmac_for(event_type: &str, target: &str) -> String {
+    fn test_connection() -> Connection {
         let c = Connection::open_in_memory().unwrap();
         c.execute_batch(
             r#"
@@ -171,6 +337,11 @@ mod tests {
             "#,
         )
         .unwrap();
+        c
+    }
+
+    fn hmac_for(event_type: &str, target: &str) -> String {
+        let c = test_connection();
         let tx = c.unchecked_transaction().unwrap();
         append_tx(&tx, event_type, target, "abc", 3, "text/plain", &[], b"key").unwrap()
     }
@@ -178,5 +349,87 @@ mod tests {
     #[test]
     fn hmac_chain_domain_separates_adjacent_fields() {
         assert_ne!(hmac_for("PUT/home/", "x"), hmac_for("PUT", "/home/x"));
+    }
+
+    #[test]
+    fn verify_connection_accepts_intact_chain() {
+        let mut c = test_connection();
+        let tx = c.transaction().unwrap();
+        let h1 = append_tx(
+            &tx,
+            "put",
+            "home/a",
+            "abc",
+            3,
+            "text/plain",
+            &[("x-meta-author".to_owned(), "ranger".to_owned())],
+            b"key",
+        )
+        .unwrap();
+        let h2 = append_tx(&tx, "append", "home/a", "def", 6, "text/plain", &[], b"key").unwrap();
+        tx.commit().unwrap();
+
+        let report = verify_connection(&c, b"key").unwrap();
+        assert_eq!(
+            report,
+            VerifyReport::Valid(VerifyOk {
+                events: 2,
+                genesis: format!("hmac-{h1}"),
+                latest: format!("hmac-{h2}"),
+            })
+        );
+    }
+
+    #[test]
+    fn verify_connection_rejects_tampered_event_hmac() {
+        let mut c = test_connection();
+        let tx = c.transaction().unwrap();
+        append_tx(&tx, "put", "home/a", "abc", 3, "text/plain", &[], b"key").unwrap();
+        tx.commit().unwrap();
+        c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
+            .unwrap();
+
+        let report = verify_connection(&c, b"key").unwrap();
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak {
+                break_at: 0,
+                actual,
+                ..
+            }) if actual == "hmac-bad"
+        ));
+    }
+
+    #[test]
+    fn verify_connection_rejects_tampered_event_headers() {
+        let mut c = test_connection();
+        let tx = c.transaction().unwrap();
+        append_tx(
+            &tx,
+            "put",
+            "home/a",
+            "abc",
+            3,
+            "text/plain",
+            &[("x-meta-author".to_owned(), "ranger".to_owned())],
+            b"key",
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        c.execute(
+            "UPDATE event_headers SET value='intruder' WHERE name='x-meta-author'",
+            [],
+        )
+        .unwrap();
+
+        let report = verify_connection(&c, b"key").unwrap();
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak {
+                break_at: 0,
+                expected,
+                actual,
+            }) if expected.starts_with("meta-sha256-") && actual.starts_with("meta-sha256-")
+        ));
     }
 }

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,7 +4,7 @@
 //! the HTTP write.
 
 use hmac::{Hmac, Mac};
-use rusqlite::{Connection, Transaction};
+use rusqlite::{Connection, Statement, Transaction};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
@@ -159,6 +159,8 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
     let mut prev = String::new();
     let mut genesis = String::new();
     let mut events = 0usize;
+    let mut header_stmt =
+        c.prepare("SELECT name, value FROM event_headers WHERE event_id=? ORDER BY name, value")?;
     let rows = stmt.query_map([], |r| {
         Ok(EventRow {
             id: r.get(0)?,
@@ -183,7 +185,7 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
                 actual: hmac_label(&row.prev_hmac),
             }));
         }
-        let headers = event_headers(c, row.id)?;
+        let headers = event_headers(&mut header_stmt, row.id)?;
         let expected_meta = meta_sha256_canonical(&row.content_type, &headers);
         if expected_meta != row.meta_sha256 {
             return Ok(VerifyReport::Broken(VerifyBreak {
@@ -233,9 +235,10 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
     }))
 }
 
-fn event_headers(c: &Connection, event_id: i64) -> rusqlite::Result<Vec<(String, String)>> {
-    let mut stmt =
-        c.prepare("SELECT name, value FROM event_headers WHERE event_id=? ORDER BY name, value")?;
+fn event_headers(
+    stmt: &mut Statement<'_>,
+    event_id: i64,
+) -> rusqlite::Result<Vec<(String, String)>> {
     let rows = stmt
         .query_map([event_id], |r| Ok((r.get(0)?, r.get(1)?)))?
         .collect();

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,7 +4,7 @@
 //! the HTTP write.
 
 use hmac::{Hmac, Mac};
-use rusqlite::{Connection, Statement, Transaction};
+use rusqlite::{Connection, Transaction};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
@@ -149,18 +149,22 @@ pub fn verify_chain(
 
 fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyReport> {
     let mut stmt = c.prepare(
-        r#"SELECT id, event_type, target, body_sha256, size,
-                  content_type, meta_sha256, hmac, prev_hmac
-           FROM events
-           ORDER BY id ASC"#,
+        r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
+                  e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
+                  h.name, h.value
+           FROM events e
+           LEFT JOIN event_headers h ON h.event_id=e.id
+           ORDER BY e.id ASC, h.name ASC, h.value ASC"#,
     )?;
     let mut prev = String::new();
     let mut genesis = String::new();
     let mut events = 0usize;
-    let mut header_stmt =
-        c.prepare("SELECT name, value FROM event_headers WHERE event_id=? ORDER BY name, value")?;
-    let rows = stmt.query_map([], |r| {
-        Ok(EventRow {
+    let mut rows = stmt.query([])?;
+    let mut current: Option<EventRow> = None;
+    let mut headers = Vec::new();
+
+    while let Some(r) = rows.next()? {
+        let row = EventRow {
             id: r.get(0)?,
             event_type: r.get(1)?,
             target: r.get(2)?,
@@ -170,52 +174,32 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
             meta_sha256: r.get(6)?,
             hmac: r.get(7)?,
             prev_hmac: r.get(8)?,
-        })
-    })?;
+        };
+        if current.as_ref().is_some_and(|event| event.id != row.id) {
+            let event = current.take().expect("current event");
+            if let Some(break_report) =
+                verify_event(&event, &headers, key, &mut prev, &mut genesis, &mut events)
+            {
+                return Ok(VerifyReport::Broken(break_report));
+            }
+            headers.clear();
+        }
+        if current.is_none() {
+            current = Some(row);
+        }
+        let header_name: Option<String> = r.get(9)?;
+        let header_value: Option<String> = r.get(10)?;
+        if let (Some(name), Some(value)) = (header_name, header_value) {
+            headers.push((name, value));
+        }
+    }
 
-    for row in rows {
-        let row = row?;
-        let idx = events;
-        if row.prev_hmac != prev {
-            return Ok(VerifyReport::Broken(VerifyBreak {
-                break_at: idx,
-                expected: hmac_label(&prev),
-                actual: hmac_label(&row.prev_hmac),
-            }));
+    if let Some(event) = current {
+        if let Some(break_report) =
+            verify_event(&event, &headers, key, &mut prev, &mut genesis, &mut events)
+        {
+            return Ok(VerifyReport::Broken(break_report));
         }
-        let headers = event_headers(&mut header_stmt, row.id)?;
-        let expected_meta = meta_sha256_canonical(&row.content_type, &headers);
-        if expected_meta != row.meta_sha256 {
-            return Ok(VerifyReport::Broken(VerifyBreak {
-                break_at: idx,
-                expected: format!("meta-sha256-{expected_meta}"),
-                actual: format!("meta-sha256-{}", row.meta_sha256),
-            }));
-        }
-        let expected_hmac = event_hmac(
-            key,
-            EventHmacInput {
-                prev: &prev,
-                event_type: &row.event_type,
-                target: &row.target,
-                body_sha256: &row.body_sha256,
-                size: row.size,
-                content_type: &row.content_type,
-                meta_sha256: &row.meta_sha256,
-            },
-        );
-        if expected_hmac != row.hmac {
-            return Ok(VerifyReport::Broken(VerifyBreak {
-                break_at: idx,
-                expected: hmac_label(&expected_hmac),
-                actual: hmac_label(&row.hmac),
-            }));
-        }
-        if idx == 0 {
-            genesis = row.hmac.clone();
-        }
-        prev = row.hmac.clone();
-        events += 1;
     }
 
     if events == 0 {
@@ -233,14 +217,55 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
     }))
 }
 
-fn event_headers(
-    stmt: &mut Statement<'_>,
-    event_id: i64,
-) -> rusqlite::Result<Vec<(String, String)>> {
-    let rows = stmt
-        .query_map([event_id], |r| Ok((r.get(0)?, r.get(1)?)))?
-        .collect();
-    rows
+fn verify_event(
+    row: &EventRow,
+    headers: &[(String, String)],
+    key: &[u8],
+    prev: &mut String,
+    genesis: &mut String,
+    events: &mut usize,
+) -> Option<VerifyBreak> {
+    let idx = *events;
+    if row.prev_hmac != *prev {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: hmac_label(prev),
+            actual: hmac_label(&row.prev_hmac),
+        });
+    }
+    let expected_meta = meta_sha256_canonical(&row.content_type, headers);
+    if expected_meta != row.meta_sha256 {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: format!("meta-sha256-{expected_meta}"),
+            actual: format!("meta-sha256-{}", row.meta_sha256),
+        });
+    }
+    let expected_hmac = event_hmac(
+        key,
+        EventHmacInput {
+            prev,
+            event_type: &row.event_type,
+            target: &row.target,
+            body_sha256: &row.body_sha256,
+            size: row.size,
+            content_type: &row.content_type,
+            meta_sha256: &row.meta_sha256,
+        },
+    );
+    if expected_hmac != row.hmac {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: hmac_label(&expected_hmac),
+            actual: hmac_label(&row.hmac),
+        });
+    }
+    if idx == 0 {
+        *genesis = row.hmac.clone();
+    }
+    *prev = row.hmac.clone();
+    *events += 1;
+    None
 }
 
 #[cfg(test)]

--- a/core/src/http_semantics.rs
+++ b/core/src/http_semantics.rs
@@ -217,6 +217,7 @@ fn is_persisted_representation_header_lowercase(name: &str) -> bool {
 fn is_never_persisted_header(name: &str) -> bool {
     name.starts_with("sec-")
         || name.starts_with("access-control-request-")
+        || name.starts_with("want-")
         || matches!(
             name,
             // Credentials and ambient identity must never come back as stored data.
@@ -256,6 +257,34 @@ fn is_never_persisted_header(name: &str) -> bool {
                 | "if-range"
                 | "if-modified-since"
                 | "if-unmodified-since"
+                // Browser client hints are request-only hints, not response metadata.
+                | "device-memory"
+                | "downlink"
+                | "dpr"
+                | "ect"
+                | "rtt"
+                | "save-data"
+                | "width"
+                | "viewport-width"
+                // Browser/client negotiation state is consumed per request.
+                | "accept-ch"
+                | "alt-used"
+                | "attribution-reporting-eligible"
+                | "available-dictionary"
+                | "dictionary-id"
+                | "early-data"
+                | "idempotency-key"
+                | "service-worker"
+                | "service-worker-navigation-preload"
+                | "upgrade-insecure-requests"
+                // Server/transport advertisements describe this response or stream.
+                | "alt-svc"
+                | "server-timing"
+                | "retry-after"
+                | "x-powered-by"
+                | "preference-applied"
+                | "priority"
+                | "critical-ch"
                 // Core-owned response headers are derived from stored bytes/audit.
                 // Content-Type is persisted separately as Stage.content_type.
                 | "content-type"

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -537,7 +537,7 @@ async fn proc_worlds(
         .into_response()
 }
 
-// ─── /<world> all five methods ──────────────────────────────────────
+// /proc/audit/{world}/verify
 async fn proc_audit_verify(
     State(core): State<Arc<Core>>,
     method: Method,
@@ -594,6 +594,7 @@ async fn proc_reserved(method: Method) -> Response {
     }
 }
 
+// ─── /<world> all five methods ──────────────────────────────────────
 async fn world_handler(
     State(core): State<Arc<Core>>,
     method: Method,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -572,7 +572,7 @@ async fn proc_audit_verify(
     }
 
     if store::is_memory_world(&world_name) {
-        if core.read_world(&world_name).is_none() {
+        if !core.mem.contains(&world_name) {
             return not_found();
         }
         return audit_not_applicable();
@@ -1914,6 +1914,27 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
         assert_eq!(resp.headers().get("x-audit-valid").unwrap(), "n/a");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proc_audit_verify_missing_disk_world_does_not_create_db() {
+        let (core, dir) = test_core("proc-audit-missing-no-create");
+        let db = world::world_db(&core.data, "home/missing-audit");
+        assert!(!db.exists());
+
+        let state = Arc::new(core);
+        let resp = proc_audit_verify(
+            State(state),
+            Method::HEAD,
+            AxPath("home/missing-audit/verify".to_owned()),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(!db.exists());
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -221,6 +221,7 @@ impl Core {
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ROOT_ALLOW: &str = "GET, HEAD, OPTIONS";
 const PROC_ALLOW: &str = "GET, HEAD, OPTIONS";
+const AUDIT_VERIFY_ALLOW: &str = "GET, HEAD, OPTIONS";
 const WORLD_ALLOW: &str = "GET, HEAD, PUT, POST, DELETE, OPTIONS";
 const LISTEN_REPLAY_MAX: usize = 1024;
 const DEFAULT_MAX_WORLD_BYTES: usize = 64 * 1024 * 1024;
@@ -280,6 +281,7 @@ async fn main() {
         .route("/listen/*pattern", any(listen::handler))
         .route("/proc/version", any(proc_version))
         .route("/proc/worlds", any(proc_worlds))
+        .route("/proc/audit/*audit_path", any(proc_audit_verify))
         .route("/proc", any(proc_reserved))
         .route("/proc/*reserved", any(proc_reserved))
         .route("/*world", any(world_handler))
@@ -536,6 +538,54 @@ async fn proc_worlds(
 }
 
 // ─── /<world> all five methods ──────────────────────────────────────
+async fn proc_audit_verify(
+    State(core): State<Arc<Core>>,
+    method: Method,
+    AxPath(audit_path): AxPath<String>,
+    headers: HeaderMap,
+) -> Response {
+    if method == Method::OPTIONS {
+        return options_response(AUDIT_VERIFY_ALLOW);
+    }
+    if method != Method::GET && method != Method::HEAD {
+        return method_not_allowed(AUDIT_VERIFY_ALLOW);
+    }
+
+    let Some(raw_world) = audit_path.strip_suffix("/verify") else {
+        return not_found();
+    };
+    let raw_world = raw_world.trim_end_matches('/');
+    if raw_world.is_empty() {
+        return bad_request("audit verify requires a world path");
+    }
+    let world_name = canonicalize_path(raw_world);
+    if !valid_world_name(&world_name) {
+        return bad_request("world path contains control bytes");
+    }
+
+    let auth_header = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+    let tier = core.tokens.check(auth_header);
+    if !can_read(&core, tier) {
+        return unauthorized("read requires read token");
+    }
+
+    if store::is_memory_world(&world_name) {
+        if core.read_world(&world_name).is_none() {
+            return not_found();
+        }
+        return audit_not_applicable();
+    }
+
+    match audit::verify_chain(&core.data, &world_name, &core.hmac_key) {
+        Ok(Some(audit::VerifyReport::Valid(report))) => audit_valid(report),
+        Ok(Some(audit::VerifyReport::Broken(report))) => audit_broken(report),
+        Ok(None) => not_found(),
+        Err(e) => server_error(format!("audit verify: {e}")),
+    }
+}
+
 async fn proc_reserved(method: Method) -> Response {
     match method {
         Method::OPTIONS => options_response(PROC_ALLOW),
@@ -958,6 +1008,75 @@ fn apply_meta_headers(headers: &[(String, String)], out: &mut Vec<(HeaderName, H
         };
         out.push((name, val));
     }
+}
+
+fn audit_valid(report: audit::VerifyOk) -> Response {
+    (
+        StatusCode::OK,
+        to_header_map(vec![
+            (
+                HeaderName::from_static("x-audit-valid"),
+                HeaderValue::from_static("true"),
+            ),
+            (
+                HeaderName::from_static("x-audit-events"),
+                HeaderValue::from_str(&report.events.to_string()).unwrap(),
+            ),
+            (
+                HeaderName::from_static("x-audit-genesis"),
+                HeaderValue::from_str(&report.genesis).unwrap(),
+            ),
+            (
+                HeaderName::from_static("x-audit-latest"),
+                HeaderValue::from_str(&report.latest).unwrap(),
+            ),
+            (header::CONTENT_LENGTH, HeaderValue::from_static("0")),
+        ]),
+        "",
+    )
+        .into_response()
+}
+
+fn audit_broken(report: audit::VerifyBreak) -> Response {
+    (
+        StatusCode::CONFLICT,
+        to_header_map(vec![
+            (
+                HeaderName::from_static("x-audit-valid"),
+                HeaderValue::from_static("false"),
+            ),
+            (
+                HeaderName::from_static("x-audit-break-at"),
+                HeaderValue::from_str(&report.break_at.to_string()).unwrap(),
+            ),
+            (
+                HeaderName::from_static("x-audit-expected"),
+                HeaderValue::from_str(&report.expected).unwrap(),
+            ),
+            (
+                HeaderName::from_static("x-audit-actual"),
+                HeaderValue::from_str(&report.actual).unwrap(),
+            ),
+            (header::CONTENT_LENGTH, HeaderValue::from_static("0")),
+        ]),
+        "",
+    )
+        .into_response()
+}
+
+fn audit_not_applicable() -> Response {
+    (
+        StatusCode::NO_CONTENT,
+        to_header_map(vec![
+            (
+                HeaderName::from_static("x-audit-valid"),
+                HeaderValue::from_static("n/a"),
+            ),
+            (header::CONTENT_LENGTH, HeaderValue::from_static("0")),
+        ]),
+        "",
+    )
+        .into_response()
 }
 
 fn not_found() -> Response {
@@ -1659,6 +1778,93 @@ mod tests {
         let put = proc_reserved(Method::PUT).await;
         assert_eq!(put.status(), StatusCode::METHOD_NOT_ALLOWED);
         assert_eq!(put.headers().get(header::ALLOW).unwrap(), PROC_ALLOW);
+    }
+
+    #[tokio::test]
+    async fn proc_audit_verify_reports_valid_chain_in_headers() {
+        let (core, dir) = test_core("proc-audit-valid");
+        let h = world::write_with_audit(
+            &core.data,
+            "home/audit-ok",
+            b"hello",
+            "text/plain",
+            &[("x-meta-author".to_owned(), "ranger".to_owned())],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let state = Arc::new(core);
+        let resp = proc_audit_verify(
+            State(state),
+            Method::HEAD,
+            AxPath("home/audit-ok/verify".to_owned()),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("x-audit-valid").unwrap(), "true");
+        assert_eq!(resp.headers().get("x-audit-events").unwrap(), "1");
+        assert_eq!(
+            resp.headers().get("x-audit-latest").unwrap(),
+            &format!("hmac-{h}")
+        );
+        assert_eq!(resp.headers().get(header::CONTENT_LENGTH).unwrap(), "0");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proc_audit_verify_reports_broken_chain_in_headers() {
+        let (core, dir) = test_core("proc-audit-broken");
+        world::write_with_audit(
+            &core.data,
+            "home/audit-broken",
+            b"hello",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let db = world::world_db(&core.data, "home/audit-broken");
+        let c = rusqlite::Connection::open(db).unwrap();
+        c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
+            .unwrap();
+
+        let state = Arc::new(core);
+        let resp = proc_audit_verify(
+            State(state),
+            Method::HEAD,
+            AxPath("home/audit-broken/verify".to_owned()),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        assert_eq!(resp.headers().get("x-audit-valid").unwrap(), "false");
+        assert_eq!(resp.headers().get("x-audit-break-at").unwrap(), "0");
+        assert_eq!(resp.headers().get("x-audit-actual").unwrap(), "hmac-bad");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proc_audit_verify_reports_memory_world_not_applicable() {
+        let (core, dir) = test_core("proc-audit-memory");
+        core.write_world("tmp/scratch", b"draft", "text/plain", &[])
+            .unwrap();
+        let state = Arc::new(core);
+        let resp = proc_audit_verify(
+            State(state),
+            Method::HEAD,
+            AxPath("tmp/scratch/verify".to_owned()),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(resp.headers().get("x-audit-valid").unwrap(), "n/a");
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[tokio::test]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -560,7 +560,7 @@ async fn proc_audit_verify(
     }
     let world_name = canonicalize_path(raw_world);
     if !valid_world_name(&world_name) {
-        return bad_request("world path contains control bytes");
+        return bad_request("invalid world path");
     }
 
     let auth_header = headers
@@ -1025,11 +1025,11 @@ fn audit_valid(report: audit::VerifyOk) -> Response {
             ),
             (
                 HeaderName::from_static("x-audit-genesis"),
-                HeaderValue::from_str(&report.genesis).unwrap(),
+                audit_header_value(&report.genesis),
             ),
             (
                 HeaderName::from_static("x-audit-latest"),
-                HeaderValue::from_str(&report.latest).unwrap(),
+                audit_header_value(&report.latest),
             ),
             (header::CONTENT_LENGTH, HeaderValue::from_static("0")),
         ]),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1052,17 +1052,29 @@ fn audit_broken(report: audit::VerifyBreak) -> Response {
             ),
             (
                 HeaderName::from_static("x-audit-expected"),
-                HeaderValue::from_str(&report.expected).unwrap(),
+                audit_header_value(&report.expected),
             ),
             (
                 HeaderName::from_static("x-audit-actual"),
-                HeaderValue::from_str(&report.actual).unwrap(),
+                audit_header_value(&report.actual),
             ),
             (header::CONTENT_LENGTH, HeaderValue::from_static("0")),
         ]),
         "",
     )
         .into_response()
+}
+
+fn audit_header_value(value: &str) -> HeaderValue {
+    let mut out = String::with_capacity(value.len());
+    for b in value.bytes() {
+        if (0x20..=0x7e).contains(&b) {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("\\x{b:02x}"));
+        }
+    }
+    HeaderValue::from_str(&out).expect("escaped audit header is visible ASCII")
 }
 
 fn audit_not_applicable() -> Response {
@@ -1844,6 +1856,44 @@ mod tests {
         assert_eq!(resp.headers().get("x-audit-valid").unwrap(), "false");
         assert_eq!(resp.headers().get("x-audit-break-at").unwrap(), "0");
         assert_eq!(resp.headers().get("x-audit-actual").unwrap(), "hmac-bad");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proc_audit_verify_escapes_tampered_header_values() {
+        let (core, dir) = test_core("proc-audit-header-escape");
+        world::write_with_audit(
+            &core.data,
+            "home/audit-escaped",
+            b"hello",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let db = world::world_db(&core.data, "home/audit-escaped");
+        let c = rusqlite::Connection::open(db).unwrap();
+        c.execute(
+            "UPDATE events SET hmac=? WHERE id=1",
+            ["bad\nInjected: yes"],
+        )
+        .unwrap();
+
+        let state = Arc::new(core);
+        let resp = proc_audit_verify(
+            State(state),
+            Method::HEAD,
+            AxPath("home/audit-escaped/verify".to_owned()),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            resp.headers().get("x-audit-actual").unwrap(),
+            "hmac-bad\\x0aInjected: yes"
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -55,6 +55,10 @@ impl MemoryStore {
         })
     }
 
+    pub fn contains(&self, world: &str) -> bool {
+        self.map_guard().contains_key(world)
+    }
+
     pub fn write(
         &self,
         world: &str,

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -25,7 +25,7 @@
 
 use crate::audit;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OpenFlags};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -110,6 +110,27 @@ pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
         "#,
     )?;
     Ok(c)
+}
+
+/// Open an existing world's universe.db without creating directories,
+/// files, or schema. Audit verification uses this path because probing
+/// a missing world must not resurrect it.
+pub fn open_existing(data_root: &Path, world: &str) -> rusqlite::Result<Option<Connection>> {
+    let path = world_db(data_root, world);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let c = match Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(c) => c,
+        Err(e) => {
+            if !path.exists() {
+                return Ok(None);
+            }
+            return Err(e);
+        }
+    };
+    c.busy_timeout(Duration::from_millis(5000))?;
+    Ok(Some(c))
 }
 
 pub struct Stage {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -392,6 +392,7 @@ More stdlib-shaped helpers are thin wrappers over HTTP:
 ```python
 e.get_cached("note")                  # GET + If-None-Match cache
 e.checksum("note")                    # HEAD -> ETag
+e.is_audited("note")                  # True if ETag is hmac-backed
 e.diff("note", "new text")            # local unified diff
 e.preview("note", max_bytes=512)      # Range GET + text preview
 e.put_gzip("log.gz", "hello")         # Content-Encoding: gzip
@@ -399,6 +400,11 @@ e.put_csv("table.csv", [["t", "v"]])  # text/csv
 e.put_struct("dev/s0", ">ff", 1.0, 2.0)
 e.get_many(["a", "b"])                # concurrent GETs, no batch endpoint
 ```
+
+`is_audited()` is only a storage-mode check. It tells you whether the current
+ETag is HMAC-backed, not whether the full audit chain has been replayed.
+`verify()` is reserved for that future full-chain check and currently raises
+`NotImplementedError`.
 
 `open(path, "rb")` returns a read-only file-like object backed by Range GETs:
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -393,6 +393,7 @@ More stdlib-shaped helpers are thin wrappers over HTTP:
 e.get_cached("note")                  # GET + If-None-Match cache
 e.checksum("note")                    # HEAD -> ETag
 e.is_audited("note")                  # True if ETag is hmac-backed
+e.verify("note")                      # HEAD /proc/audit/home/note/verify
 e.diff("note", "new text")            # local unified diff
 e.preview("note", max_bytes=512)      # Range GET + text preview
 e.put_gzip("log.gz", "hello")         # Content-Encoding: gzip
@@ -403,8 +404,10 @@ e.get_many(["a", "b"])                # concurrent GETs, no batch endpoint
 
 `is_audited()` is only a storage-mode check. It tells you whether the current
 ETag is HMAC-backed, not whether the full audit chain has been replayed.
-`verify()` is reserved for that future full-chain check and currently raises
-`NotImplementedError`.
+`verify()` asks the core to replay the durable audit chain via
+`HEAD /proc/audit/{path}/verify`. It returns `True` only for `200 OK` with
+`X-Audit-Valid: true`; memory worlds (`204 No Content`) and broken chains
+(`409 Conflict`) return `False`.
 
 `open(path, "rb")` returns a read-only file-like object backed by Range GETs:
 

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -32,9 +32,10 @@ Path rule: "foo" and "/foo" both mean "/home/foo". "tmp/foo" means
 /proc internals are reserved by the core.
 
 put(..., project="demo") stores `X-Meta-Project: demo`. These kwargs
-are plain metadata, not auth or audit fields. Standard HTTP
-representation headers use named kwargs: content_type, cache_control,
-content_encoding, content_language, and content_disposition.
+do not drive auth or routing, but durable worlds include them in audited
+representation metadata. Standard HTTP representation headers use named
+kwargs: content_type, cache_control, content_encoding, content_language,
+and content_disposition.
 
 Reactor (declarative event handlers):
 
@@ -472,7 +473,7 @@ def is_audited(path: str) -> bool:
 
 
 def verify(path: str) -> bool:
-    """Alias for is_audited(); does not replay the full audit chain."""
+    """Reserve the name for future full audit-chain replay verification."""
     return _client().verify(path)
 
 

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -473,7 +473,7 @@ def is_audited(path: str) -> bool:
 
 
 def verify(path: str) -> bool:
-    """Reserve the name for future full audit-chain replay verification."""
+    """Ask core to replay and verify the durable audit chain."""
     return _client().verify(path)
 
 

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -835,11 +835,23 @@ class Elastik(MutableMapping[str, bytes]):
         return self.checksum(path).strip('"').startswith("hmac-")
 
     def verify(self, path: str) -> bool:
-        """Reserve the name for future full audit-chain replay verification."""
-        raise NotImplementedError(
-            "Full audit-chain verification requires a /proc/audit endpoint. "
-            "Use is_audited() to check whether this world is HMAC-backed."
-        )
+        """Ask core to replay and verify the durable audit chain.
+
+        Returns True only when core returns 200 with X-Audit-Valid: true.
+        Memory worlds return False because they are not audit-backed. Broken
+        chains return False. Missing worlds and auth failures still raise the
+        normal ElastikError subclasses.
+        """
+        world = _canonical_world_name(path)
+        audit_path = f"/proc/audit/{world}/verify"
+        resp = self.request("HEAD", audit_path)
+        if resp.status == 200:
+            return resp.headers.get("x-audit-valid") == "true"
+        if resp.status in (204, 409):
+            return False
+        if resp.status >= 400:
+            _raise_for_response(resp, "HEAD", audit_path)
+        return False
 
     def diff(self, path: str, new_data: str) -> str:
         """Return a unified text diff between current body and new_data."""
@@ -1480,13 +1492,32 @@ def _best_env_token() -> str:
 
 
 def _quote_path(path: str) -> str:
+    proc_path = _canonical_proc_path(path)
+    if proc_path is not None:
+        return "/" + urllib.parse.quote(proc_path, safe="/")
     world = _canonical_world_name(path)
-    if world in _PROC_ENDPOINTS:
-        return "/" + urllib.parse.quote(world, safe="/")
     if world == "proc" or world.startswith("proc/"):
         raise ValueError("/proc is reserved; only /proc/version and /proc/worlds exist")
     _validate_world_name(world)
     return "/" + urllib.parse.quote(world, safe="/")
+
+
+def _canonical_proc_path(path: str) -> str | None:
+    stripped = path.lstrip("/")
+    if stripped in _PROC_ENDPOINTS:
+        return stripped
+    prefix = "proc/audit/"
+    suffix = "/verify"
+    if not stripped.startswith(prefix):
+        return None
+    if not stripped.endswith(suffix):
+        raise ValueError("/proc/audit only exposes /proc/audit/{path}/verify")
+    raw_world = stripped[len(prefix) : -len(suffix)].strip("/")
+    if not raw_world:
+        raise ValueError("/proc/audit verify requires a world path")
+    world = _canonical_world_name(raw_world)
+    _validate_world_name(world)
+    return f"proc/audit/{world}/verify"
 
 
 def _canonical_world_name(path: str) -> str:

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -828,12 +828,18 @@ class Elastik(MutableMapping[str, bytes]):
         return self.head(path).get("etag", "")
 
     def is_audited(self, path: str) -> bool:
-        """Return True when the current ETag is audit-chain backed."""
+        """Return True when the current ETag is audit-chain backed.
+
+        This is a storage-mode check, not a full audit-chain replay.
+        """
         return self.checksum(path).strip('"').startswith("hmac-")
 
     def verify(self, path: str) -> bool:
-        """Alias for is_audited(); does not replay the full audit chain."""
-        return self.is_audited(path)
+        """Reserve the name for future full audit-chain replay verification."""
+        raise NotImplementedError(
+            "Full audit-chain verification requires a /proc/audit endpoint. "
+            "Use is_audited() to check whether this world is HMAC-backed."
+        )
 
     def diff(self, path: str, new_data: str) -> str:
         """Return a unified text diff between current body and new_data."""

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -1497,7 +1497,10 @@ def _quote_path(path: str) -> str:
         return "/" + urllib.parse.quote(proc_path, safe="/")
     world = _canonical_world_name(path)
     if world == "proc" or world.startswith("proc/"):
-        raise ValueError("/proc is reserved; only /proc/version and /proc/worlds exist")
+        raise ValueError(
+            "/proc is reserved; only /proc/version, /proc/worlds, "
+            "and /proc/audit/{path}/verify exist"
+        )
     _validate_world_name(world)
     return "/" + urllib.parse.quote(world, safe="/")
 

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -864,8 +864,9 @@ class Elastik(MutableMapping[str, bytes]):
 
         Returns True only when core returns 200 with X-Audit-Valid: true.
         Memory worlds return False because they are not audit-backed. Broken
-        chains return False. Missing worlds and auth failures still raise the
-        normal ElastikError subclasses.
+        chains return False. Cores that do not expose the verify endpoint
+        return False after confirming the target path exists. Missing worlds
+        and auth failures still raise the normal ElastikError subclasses.
         """
         world = _canonical_world_name(path)
         audit_path = f"/proc/audit/{world}/verify"
@@ -873,6 +874,12 @@ class Elastik(MutableMapping[str, bytes]):
         if resp.status == 200:
             return resp.headers.get("x-audit-valid") == "true"
         if resp.status in (204, 409):
+            return False
+        if resp.status == 404:
+            try:
+                self.head(path)
+            except NotFound:
+                _raise_for_response(resp, "HEAD", audit_path)
             return False
         if resp.status >= 400:
             _raise_for_response(resp, "HEAD", audit_path)

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -99,6 +99,31 @@ _NON_PERSISTED_RESPONSE_HEADERS = {
     "if-range",
     "if-modified-since",
     "if-unmodified-since",
+    "device-memory",
+    "downlink",
+    "dpr",
+    "ect",
+    "rtt",
+    "save-data",
+    "width",
+    "viewport-width",
+    "accept-ch",
+    "alt-used",
+    "attribution-reporting-eligible",
+    "available-dictionary",
+    "dictionary-id",
+    "early-data",
+    "idempotency-key",
+    "service-worker",
+    "service-worker-navigation-preload",
+    "upgrade-insecure-requests",
+    "alt-svc",
+    "server-timing",
+    "retry-after",
+    "x-powered-by",
+    "preference-applied",
+    "priority",
+    "critical-ch",
     "content-type",
     "content-length",
     "etag",
@@ -1595,6 +1620,7 @@ def _should_persist_response_header(name: str) -> bool:
         bool(n)
         and not n.startswith("sec-")
         and not n.startswith("access-control-request-")
+        and not n.startswith("want-")
         and n not in _NON_PERSISTED_RESPONSE_HEADERS
     )
 

--- a/sdk/src/elastik/testing.py
+++ b/sdk/src/elastik/testing.py
@@ -114,6 +114,10 @@ class FakeElastik(Elastik):
         except KeyError:
             raise NotFound(404, b"not found", method="HEAD", path=path) from None
 
+    def verify(self, path: str) -> bool:
+        self.head(path)
+        return False
+
     def delete(self, path: str, **_kwargs: Any) -> bool:
         world = self._world(path)
         self._etag_cache.pop(world, None)

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -799,6 +799,7 @@ def main() -> int:
             check(isinstance(fake, MutableMapping), "FakeElastik is also MutableMapping-shaped")
             check(fake.get_text("fake/note") == "hello", "FakeElastik get_text works")
             check(fake.head("fake/note")["etag"].startswith("fake-"), "FakeElastik returns fake ETags")
+            check(not fake.verify("fake/note"), "FakeElastik verify reports audit unsupported")
             check(fake.get_cached("fake/note") == b"hello", "FakeElastik supports get_cached")
             fake_ref = fake / "home" / "fake" / "ref"
             fake_ref.write("fake-ref")

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -636,7 +636,12 @@ def main() -> int:
             check(reader.sizeof("/home/sdk/mapping") == 6, "sizeof() reads Content-Length")
             check(reader.checksum("/home/sdk/mapping").strip('"').startswith("hmac-"), "checksum() returns ETag")
             check(reader.is_audited("/home/sdk/mapping"), "is_audited() detects hmac ETag")
-            check(reader.verify("/home/sdk/mapping"), "verify() aliases is_audited")
+            try:
+                reader.verify("/home/sdk/mapping")
+            except NotImplementedError:
+                check(True, "verify() is reserved for full audit-chain replay")
+            else:
+                raise AssertionError("FAIL: verify() should not pretend to replay the audit chain")
             check(reader.get_cached("/home/sdk/mapping") == b"mapped", "get_cached first read downloads")
             check(reader.get_cached("/home/sdk/mapping") == b"mapped", "get_cached second read uses validator")
             writer.put("/home/sdk/mapping", "remapped")

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -596,7 +596,22 @@ def main() -> int:
                     "X-Future-HTTP-Thing": "ok",
                 },
             )
+            writer.put(
+                "/home/sdk/browser-put.html",
+                "<html>",
+                content_type="text/html",
+                headers={
+                    "Device-Memory": "8",
+                    "DPR": "2",
+                    "Save-Data": "on",
+                    "Idempotency-Key": "abc",
+                    "Upgrade-Insecure-Requests": "1",
+                    "Want-Content-Digest": "sha-256",
+                    "Server-Timing": "dur=1",
+                },
+            )
             policy_head = reader.head("/home/sdk/logo.png")
+            browser_put_head = reader.head("/home/sdk/browser-put.html")
             check(
                 policy_head["access-control-allow-origin"] == "*",
                 "safe response policy header is stored",
@@ -610,6 +625,19 @@ def main() -> int:
                 policy_head["x-future-http-thing"] == "ok",
                 "future safe response header is stored",
             )
+            for request_only in [
+                "device-memory",
+                "dpr",
+                "save-data",
+                "idempotency-key",
+                "upgrade-insecure-requests",
+                "want-content-digest",
+                "server-timing",
+            ]:
+                check(
+                    request_only not in browser_put_head,
+                    f"browser request header {request_only} is not persisted",
+                )
             check("home/sdk/text" in reader.list(), "sdk list sees world")
             check("home/sdk/text" in reader.list_paths(), "sdk list_paths aliases list")
             check("home/sdk/text" in reader.list_keys(), "sdk list_keys aliases list")
@@ -785,6 +813,8 @@ def main() -> int:
                     "Access-Control-Allow-Origin": "*",
                     "Content-Security-Policy": "default-src 'self'",
                     "Authorization": "Bearer should-not-persist",
+                    "Device-Memory": "8",
+                    "Want-Content-Digest": "sha-256",
                 },
             )
             check(fake.head("fake/raw")["content-type"] == "text/custom", "FakeElastik request preserves Content-Type")
@@ -796,6 +826,11 @@ def main() -> int:
             check(
                 "authorization" not in fake.head("fake/raw"),
                 "FakeElastik does not persist Authorization",
+            )
+            check(
+                "device-memory" not in fake.head("fake/raw")
+                and "want-content-digest" not in fake.head("fake/raw"),
+                "FakeElastik does not persist browser request headers",
             )
             config_buf = io.StringIO()
             with contextlib.redirect_stdout(config_buf):

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -636,12 +636,7 @@ def main() -> int:
             check(reader.sizeof("/home/sdk/mapping") == 6, "sizeof() reads Content-Length")
             check(reader.checksum("/home/sdk/mapping").strip('"').startswith("hmac-"), "checksum() returns ETag")
             check(reader.is_audited("/home/sdk/mapping"), "is_audited() detects hmac ETag")
-            try:
-                reader.verify("/home/sdk/mapping")
-            except NotImplementedError:
-                check(True, "verify() is reserved for full audit-chain replay")
-            else:
-                raise AssertionError("FAIL: verify() should not pretend to replay the audit chain")
+            check(reader.verify("/home/sdk/mapping"), "verify() replays durable audit chain")
             check(reader.get_cached("/home/sdk/mapping") == b"mapped", "get_cached first read downloads")
             check(reader.get_cached("/home/sdk/mapping") == b"mapped", "get_cached second read uses validator")
             writer.put("/home/sdk/mapping", "remapped")
@@ -1033,6 +1028,7 @@ def main() -> int:
             tmp_head = reader.head("/tmp/sdk/scratch")
             check(reader.get("/tmp/sdk/scratch") == b"temp", "tmp memory world reads")
             check(tmp_head["etag"].startswith('"sha256-'), "tmp world uses body ETag")
+            check(not reader.verify("/tmp/sdk/scratch"), "verify() reports memory worlds as not applicable")
 
             # Tier checks.
             expect_error(lambda: reader.put("/home/sdk/nope", b"x"), 401, check, "read token cannot write")


### PR DESCRIPTION
﻿## Summary

Adds HTTP-native audit-chain verification.

Core now exposes:

```http
HEAD /proc/audit/{world}/verify
```

Responses use status codes plus headers, not JSON:

- `200 OK` with `X-Audit-Valid: true` for intact durable chains.
- `409 Conflict` with `X-Audit-Valid: false`, `X-Audit-Break-At`, `X-Audit-Expected`, and `X-Audit-Actual` for broken chains.
- `404 Not Found` for missing worlds.
- `204 No Content` with `X-Audit-Valid: n/a` for memory worlds.

SDK `verify(path)` now calls that endpoint with `HEAD` and returns a bool. `is_audited(path)` remains the cheap ETag-prefix/storage-mode check. If the target exists but the connected core/FakeElastik does not support audit verification, `verify()` returns `False` rather than pretending the chain was verified.

## Review follow-ups

- Keeps verification in core so the HMAC key never leaves the process.
- Uses a side-effect-free read-only SQLite open path for verification, with `busy_timeout`; it intentionally skips schema/PRAGMA creation so probing missing or deleted worlds never resurrects them.
- Streams event/header verification through one joined query instead of materializing the full event table or issuing per-event header queries.
- Uses a cheap memory-store existence check for `/tmp`, `/dev`, and `/sys` verify requests.
- Updates the reserved `/proc` SDK error message to include `/proc/audit/{path}/verify`.
- Moves the `/world` handler comment back to the actual world handler block.

## Tests

- `cargo test`
- `cargo clippy -- -D warnings`
- `python -m compileall sdk/src/elastik`
- `python sdk/tests/test_tools.py`
- `python sdk/tests/e2e_blackbox.py`
