### PR TITLE
fix(core): per-world write lock replaces global mutex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,33 @@
 # Agent Instructions
 
+## Architecture Invariants
+
+These are not preferences. They are the contract every change must keep.
+
+- **File size hard limit: 500 lines per `.rs` file** for new files. The reason
+  is not style: it is the working memory limit of coding agents. Past 500
+  lines, agents start contradicting themselves; past 1000, they cannot produce
+  reliable changes at all. File size is the working contract between
+  maintainer and AI co-author.
+  - **Grandfather clause:** existing oversized files (`core/src/main.rs` in
+    particular) are allowed only for safety fixes (P0/P1 concurrency,
+    correctness, security) and for extraction PRs that move code OUT into new
+    sub-500-line modules. Net-new feature code MUST land in a new
+    sub-500-line module, even if the natural place would have been in the
+    legacy file.
+  - The hinge PR that retires the grandfather clause is the FSM pipeline
+    extraction (PR 4 of the v7 sequence). After that lands, this exception
+    is removed.
+- **Per-world locking, not global.** Writes to different worlds run concurrently;
+  writes to the same world serialize through `Core::acquire_world_lock(world)`.
+  No new global write mutex. Counters touched on the write path
+  (`storage_body_bytes`, `durable_world_count`) must use `fetch_update` /
+  `fetch_add` / `fetch_sub` so cross-world writers stay coherent.
+- **Mechanism, not policy.** Core provides primitives — token tiers, path
+  scopes, HMAC chain, change events, ETag/CAS, byte storage. Business logic
+  (validation, transactional flows, schema evolution) lives in reactors and
+  SDK code, not in core. Adding policy to core is a Phoenix violation.
+
 ## Endpoint Change Checklist
 
 Every new core route should pass the same small checklist before review:

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -134,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,20 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -160,6 +180,7 @@ version = "6.4.4"
 dependencies = [
  "axum",
  "base64",
+ "dashmap",
  "futures-util",
  "hex",
  "hmac",
@@ -396,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +459,19 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -467,6 +510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +537,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"
 percent-encoding = "2"
+dashmap = "6"
 
 [profile.release]
 lto = "thin"

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -501,13 +501,14 @@ mod tests {
         auth, store, Core, DEFAULT_LISTEN_REPLAY_MAX, DEFAULT_MAX_LISTEN_CONNECTIONS,
         DEFAULT_MAX_MEMORY_BYTES, DEFAULT_MAX_WORLD_BYTES,
     };
+    use dashmap::DashMap;
     use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize},
         Arc, Mutex as StdMutex,
     };
-    use tokio::sync::{broadcast, watch, Mutex};
+    use tokio::sync::{broadcast, watch};
 
     fn packet(bytes: &[u8]) -> Packet<'_> {
         parse_packet(bytes).unwrap()
@@ -550,7 +551,7 @@ mod tests {
                 shutdown: watch::channel(false).1,
                 next_event: Arc::new(AtomicU64::new(0)),
                 next_request: Arc::new(AtomicU64::new(0)),
-                write_lock: Arc::new(Mutex::new(())),
+                world_locks: Arc::new(DashMap::new()),
             },
             dir,
         )

--- a/core/src/listen.rs
+++ b/core/src/listen.rs
@@ -178,6 +178,7 @@ fn sse_change_event(change: ChangeEvent) -> Event {
 mod tests {
     use super::*;
     use crate::{auth, store, Core};
+    use dashmap::DashMap;
     use std::{
         collections::VecDeque,
         path::PathBuf,
@@ -186,7 +187,7 @@ mod tests {
             Arc, Mutex as StdMutex,
         },
     };
-    use tokio::sync::{broadcast, watch, Mutex, Semaphore};
+    use tokio::sync::{broadcast, watch, Semaphore};
 
     #[test]
     fn patterns_are_prefix_or_exact() {
@@ -243,7 +244,7 @@ mod tests {
             shutdown: watch::channel(false).1,
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
-            write_lock: Arc::new(Mutex::new(())),
+            world_locks: Arc::new(DashMap::new()),
         });
 
         let resp = handler(
@@ -282,7 +283,7 @@ mod tests {
             shutdown: watch::channel(false).1,
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
-            write_lock: Arc::new(Mutex::new(())),
+            world_locks: Arc::new(DashMap::new()),
         };
         {
             let mut log = core.event_log.lock().unwrap();
@@ -329,7 +330,7 @@ mod tests {
             shutdown: watch::channel(false).1,
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
-            write_lock: Arc::new(Mutex::new(())),
+            world_locks: Arc::new(DashMap::new()),
         };
         {
             let mut log = core.event_log.lock().unwrap();

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -55,6 +55,7 @@ use axum::{
     routing::any,
     Router,
 };
+use dashmap::DashMap;
 use std::collections::VecDeque;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
@@ -63,7 +64,7 @@ use std::sync::{
     Arc, Mutex as StdMutex,
 };
 use std::time::Instant;
-use tokio::sync::{broadcast, watch, Mutex, Semaphore};
+use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 
 use crate::http_semantics as hs;
 use crate::world::{AppendResult, Stage};
@@ -94,12 +95,46 @@ struct Core {
     shutdown: watch::Receiver<bool>,
     next_event: Arc<AtomicU64>,
     next_request: Arc<AtomicU64>,
-    // One writer at a time keeps If-Match/If-None-Match + write atomic.
-    // tokio::Mutex avoids blocking a runtime worker while queued writers wait.
-    write_lock: Arc<Mutex<()>>,
+    // Per-world async write lock. Replaces the previous global write_lock.
+    // Writes to different worlds run concurrently; writes to the same world
+    // serialize (preserving If-Match/If-None-Match + write atomicity).
+    // Locks are created lazily on first write and never evicted while the
+    // process runs. See acquire_world_lock for the rationale (eviction is
+    // unsafe when waiters hold a clone of the Arc). DashMap shards reads,
+    // so lookup is mostly lock-free.
+    world_locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
 }
 
 impl Core {
+    /// Acquire the per-world write lock. Different worlds run concurrent
+    /// writes; same-world writes serialize. Lazy creation: the lock is
+    /// inserted on first acquire and never evicted while the process runs.
+    ///
+    /// We deliberately do NOT remove the entry on DELETE. Removing while
+    /// another waiter holds a clone of the Arc would let the next acquirer
+    /// create a fresh Arc<Mutex<()>> for the same world, breaking mutual
+    /// exclusion (two concurrent writers, two different mutexes). The map
+    /// grows by one entry per distinct world ever written -- bounded in
+    /// practice by total world cardinality.
+    ///
+    /// Lock ordering rule for callers that need more than one world lock
+    /// (currently only DELETE, which also touches the shared `var/log/deletes`
+    /// ledger): always acquire the target world lock FIRST, then any shared
+    /// ledger lock(s). This avoids cycles. See handle_delete for the only
+    /// current example.
+    ///
+    /// The DashMap entry guard is dropped before `.await`, so we never
+    /// hold a sync shard lock across an await.
+    async fn acquire_world_lock(&self, world: &str) -> OwnedMutexGuard<()> {
+        let lock = {
+            self.world_locks
+                .entry(world.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        lock.lock_owned().await
+    }
+
     fn read_world(&self, world: &str) -> rusqlite::Result<Option<Stage>> {
         Ok(self.read_world_with_etag(world)?.map(|(stage, _)| stage))
     }
@@ -135,12 +170,14 @@ impl Core {
         } else {
             let current_len = world::body_len(&self.data, world)?;
             world::write(&self.data, world, body, content_type, headers)?;
-            self.storage_body_bytes.store(
-                self.storage_body_bytes
-                    .load(Ordering::Relaxed)
-                    .saturating_sub(current_len.unwrap_or(0))
-                    .saturating_add(body.len()),
+            // Atomic delta on the counter: with per-world locking, multiple
+            // worlds can land here concurrently. fetch_update keeps the
+            // counter coherent across writers in different worlds.
+            let prev = current_len.unwrap_or(0);
+            let _ = self.storage_body_bytes.fetch_update(
                 Ordering::Relaxed,
+                Ordering::Relaxed,
+                |used| Some(used.saturating_sub(prev).saturating_add(body.len())),
             );
             if current_len.is_none() {
                 self.durable_world_count.fetch_add(1, Ordering::Relaxed);
@@ -198,15 +235,65 @@ impl Core {
         let _ = self.events.send(change);
     }
 
-    fn check_storage_quota_for_append(&self, add_len: usize) -> Result<usize, BoxedResponse> {
-        let used = self.storage_body_bytes.load(Ordering::Relaxed);
+    // (`check_storage_quota_for_append` was removed; quota is now enforced
+    // by `reserve_storage` which atomically checks and reserves in one CAS,
+    // closing the race that the snapshot-based check could not handle.)
+
+    /// Atomic reservation: check the quota and reserve `new_len - prev_len`
+    /// in a single CAS step. Replaces the old "snapshot then write then
+    /// adjust" pattern, which raced under per-world locking when two
+    /// concurrent writes on different worlds both observed usage below
+    /// quota and only afterwards pushed it past.
+    ///
+    /// Caller must hold `acquire_world_lock(world)` so that `prev_len`
+    /// reflects the world's true current body length (cannot change
+    /// underneath us). On success the global counter has already been
+    /// updated; on success of the subsequent storage write, no further
+    /// counter change is needed. On failure of the storage write, call
+    /// `rollback_storage_reservation` to credit back.
+    ///
+    /// `prev_len` is 0 for new worlds and for append (where the existing
+    /// bytes stay and we only add `new_len` new).
+    fn reserve_storage(&self, prev_len: usize, new_len: usize) -> Result<(), BoxedResponse> {
         if let Some(quota) = self.max_storage_bytes {
-            let projected = used.saturating_add(add_len);
-            if projected > quota {
-                return Err(Box::new(storage_quota_exceeded(used, quota, projected)));
+            let result = self.storage_body_bytes.fetch_update(
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+                |used| {
+                    let projected = used.saturating_sub(prev_len).saturating_add(new_len);
+                    if projected > quota {
+                        None
+                    } else {
+                        Some(projected)
+                    }
+                },
+            );
+            match result {
+                Ok(_) => Ok(()),
+                Err(used) => {
+                    let projected = used.saturating_sub(prev_len).saturating_add(new_len);
+                    Err(Box::new(storage_quota_exceeded(used, quota, projected)))
+                }
             }
+        } else {
+            // No quota: still keep the counter coherent for /proc/df.
+            let _ = self.storage_body_bytes.fetch_update(
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+                |used| Some(used.saturating_sub(prev_len).saturating_add(new_len)),
+            );
+            Ok(())
         }
-        Ok(used)
+    }
+
+    /// Inverse of `reserve_storage`. Call when the reserved write
+    /// subsequently fails so we credit the bytes back into available quota.
+    fn rollback_storage_reservation(&self, prev_len: usize, new_len: usize) {
+        let _ =
+            self.storage_body_bytes
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
+                    Some(used.saturating_sub(new_len).saturating_add(prev_len))
+                });
     }
 
     async fn put_bytes(
@@ -226,17 +313,27 @@ impl Core {
         if body.len() > self.max_world_bytes {
             return Err(payload_too_large(self.max_world_bytes));
         }
-        let _write_guard = self.write_lock.lock().await;
+        let _write_guard = self.acquire_world_lock(world_name).await;
         if let Some(req_headers) = preconditions {
             hs::check_write_preconditions(self, world_name, req_headers)?;
         }
         let existed;
         let new_etag = if store::is_persistent(world_name) {
-            let quota = self.max_storage_bytes.map(|quota| {
-                // Initialized from durable metadata at startup and adjusted
-                // under write_lock, so PUT quota enforcement stays O(1).
-                (self.storage_body_bytes.load(Ordering::Relaxed), quota)
-            });
+            // Read previous body length under the per-world lock; cannot
+            // change while we hold the guard. None means new world.
+            let prev_len_opt = world::body_len(&self.data, world_name)
+                .map_err(|e| storage_error("storage metadata", e))?;
+            existed = prev_len_opt.is_some();
+            let prev_len = prev_len_opt.unwrap_or(0);
+
+            // Atomic CAS quota reservation. Race-free across worlds: two
+            // writes on different worlds cannot both observe usage below
+            // quota and then push it past, because the CAS sees the latest
+            // counter value. On reservation failure no write happens.
+            self.reserve_storage(prev_len, body.len()).map_err(|b| *b)?;
+
+            // Quota already enforced by reservation; pass None to skip the
+            // (now redundant and racy) snapshot check inside world.rs.
             match world::write_with_audit_checked(
                 &self.data,
                 world_name,
@@ -244,29 +341,22 @@ impl Core {
                 content_type,
                 headers,
                 &self.hmac_key,
-                quota,
+                None,
             ) {
                 Ok(result) => {
-                    existed = result.existed;
-                    self.storage_body_bytes.store(
-                        self.storage_body_bytes
-                            .load(Ordering::Relaxed)
-                            .saturating_sub(result.previous_len)
-                            .saturating_add(body.len()),
-                        Ordering::Relaxed,
-                    );
-                    if !result.existed {
+                    if !existed {
                         self.durable_world_count.fetch_add(1, Ordering::Relaxed);
                     }
                     hs::hmac_etag(&result.hmac)
                 }
-                Err(world::WriteAuditError::Quota {
-                    used,
-                    quota,
-                    projected,
-                }) => return Err(storage_quota_exceeded(used, quota, projected)),
+                Err(world::WriteAuditError::Quota { .. }) => {
+                    // Unreachable: we passed quota=None above.
+                    self.rollback_storage_reservation(prev_len, body.len());
+                    return Err(server_error("unexpected quota error".to_string()));
+                }
                 Err(world::WriteAuditError::Sqlite(e)) => {
-                    return Err(storage_error("storage/audit", e))
+                    self.rollback_storage_reservation(prev_len, body.len());
+                    return Err(storage_error("storage/audit", e));
                 }
             }
         } else {
@@ -356,7 +446,7 @@ async fn main() {
         shutdown: shutdown_rx.clone(),
         next_event: Arc::new(AtomicU64::new(0)),
         next_request: Arc::new(AtomicU64::new(0)),
-        write_lock: Arc::new(Mutex::new(())),
+        world_locks: Arc::new(DashMap::new()),
     });
 
     let addr = listen_addr(&host, port);
@@ -1106,7 +1196,7 @@ async fn handle_post(
     if !can_write(world_name, tier) {
         return unauthorized("write requires token; system worlds need approve token");
     }
-    let _write_guard = core.write_lock.lock().await;
+    let _write_guard = core.acquire_world_lock(world_name).await;
     if let Err(resp) = hs::check_write_preconditions(core, world_name, req_headers) {
         return resp;
     }
@@ -1123,10 +1213,12 @@ async fn handle_post(
         return payload_too_large(core.max_world_bytes);
     }
     let new_etag = if store::is_persistent(world_name) {
-        let used = match core.check_storage_quota_for_append(body.len()) {
-            Ok(used) => used,
-            Err(resp) => return *resp,
-        };
+        // Atomic CAS reservation BEFORE the append. prev_len = 0 because
+        // POST adds bytes on top of whatever the world already holds; the
+        // existing bytes stay accounted as before.
+        if let Err(resp) = core.reserve_storage(0, body.len()) {
+            return *resp;
+        }
         match world::append_with_audit(
             &core.data,
             world_name,
@@ -1135,13 +1227,17 @@ async fn handle_post(
             &stored_headers,
             &core.hmac_key,
         ) {
-            Ok(Some((_result, h))) => {
-                core.storage_body_bytes
-                    .store(used.saturating_add(body.len()), Ordering::Relaxed);
-                hs::hmac_etag(&h)
+            Ok(Some((_result, h))) => hs::hmac_etag(&h),
+            Ok(None) => {
+                // World disappeared between the metadata read and the
+                // append. Credit the reservation back.
+                core.rollback_storage_reservation(0, body.len());
+                return not_found();
             }
-            Ok(None) => return not_found(),
-            Err(e) => return storage_error("storage/audit", e),
+            Err(e) => {
+                core.rollback_storage_reservation(0, body.len());
+                return storage_error("storage/audit", e);
+            }
         }
     } else {
         if memory_append_projected_bytes(core, body.len()) > core.max_memory_bytes {
@@ -1172,7 +1268,7 @@ async fn handle_delete(
     if world_name == "var/log/deletes" {
         return unauthorized("delete ledger is append-only");
     }
-    let _write_guard = core.write_lock.lock().await;
+    let _write_guard = core.acquire_world_lock(world_name).await;
     if let Err(resp) = hs::check_write_preconditions(core, world_name, req_headers) {
         return resp;
     }
@@ -1199,29 +1295,38 @@ async fn handle_delete(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-    let delete_ledger_existed =
-        match world_exists_blocking(core.data.clone(), "var/log/deletes").await {
+    // Audit appends touch the shared `var/log/deletes` ledger. Acquire the
+    // ledger lock briefly around the existence check + intent append so two
+    // concurrent DELETEs of different target worlds don't double-count
+    // ledger creation or interleave their HMAC-chain reads/writes outside
+    // SQLite's transaction. Lock ordering: target world lock FIRST (already
+    // held), then ledger lock — see Core::acquire_world_lock docs.
+    let intent_outcome = {
+        let _ledger_guard = core.acquire_world_lock("var/log/deletes").await;
+        let existed = match world_exists_blocking(core.data.clone(), "var/log/deletes").await {
             Ok(existed) => existed,
             Err(e) => return blocking_storage_error("delete audit intent", e),
         };
-    if let Err(e) = audit_append_blocking(
-        core.data.clone(),
-        AuditAppendJob {
-            ledger_world: "var/log/deletes",
-            event_type: "delete_intent",
-            target: world_name.to_string(),
-            body_sha256: body_sha256_before.clone(),
-            size: 0,
-            content_type: delete_content_type.clone(),
-            headers: delete_meta.clone(),
-            key: core.hmac_key.clone(),
-        },
-    )
-    .await
-    {
-        return blocking_storage_error("delete audit intent", e);
+        if let Err(e) = audit_append_blocking(
+            core.data.clone(),
+            AuditAppendJob {
+                ledger_world: "var/log/deletes",
+                event_type: "delete_intent",
+                target: world_name.to_string(),
+                body_sha256: body_sha256_before.clone(),
+                size: 0,
+                content_type: delete_content_type.clone(),
+                headers: delete_meta.clone(),
+                key: core.hmac_key.clone(),
+            },
+        )
+        .await
+        {
+            return blocking_storage_error("delete audit intent", e);
+        }
+        existed
     };
-    if !delete_ledger_existed {
+    if !intent_outcome {
         core.durable_world_count.fetch_add(1, Ordering::Relaxed);
         core.delete_ledger_created.store(true, Ordering::Relaxed);
     }
@@ -1245,6 +1350,14 @@ async fn handle_delete(
     }
     core.notify("DELETE", world_name, "");
 
+    // Re-acquire the ledger lock briefly for the commit / commit_failed
+    // appends. Each append is a single SQLite transaction; the lock
+    // serializes ordering of *audit chain entries* across concurrent
+    // DELETEs on different target worlds. Intent and commit from the same
+    // DELETE may interleave with a different DELETE's intent in the chain
+    // — this is intentional and fine, the chain is HMAC-linked, not
+    // grouped by target world.
+    let _ledger_guard = core.acquire_world_lock("var/log/deletes").await;
     if let Err(e) = audit_append_blocking(
         core.data.clone(),
         AuditAppendJob {
@@ -1874,6 +1987,54 @@ mod tests {
         assert_eq!(
             core.read_world("home/a").unwrap().unwrap().body,
             b"1234".to_vec()
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn concurrent_puts_to_distinct_worlds_do_not_overshoot_quota() {
+        // Regression: under per-world locks, the previous "snapshot then
+        // write then adjust" pattern let two concurrent PUTs to different
+        // worlds both observe usage below quota, both commit, and only
+        // afterwards push the counter past quota (lost-update race).
+        // Atomic CAS reservation in `Core::reserve_storage` closes that
+        // race. This test fires N concurrent PUTs each just under the
+        // quota and asserts that ANY mix of accept/reject keeps the
+        // counter coherent and never overshoots.
+        let (mut core, dir) = test_core("quota-race");
+        let quota = 100;
+        core.max_storage_bytes = Some(quota);
+        let core = Arc::new(core);
+
+        let workers = 16;
+        let body_len = 12; // 16 * 12 = 192 > quota: definitely contention
+        let mut handles = Vec::with_capacity(workers);
+        for i in 0..workers {
+            let core = core.clone();
+            handles.push(tokio::spawn(async move {
+                let path = format!("home/race/{i}");
+                let body = Bytes::copy_from_slice(&vec![b'x'; body_len]);
+                handle_put(&core, &path, &HeaderMap::new(), body, auth::Tier::Write).await
+            }));
+        }
+
+        let mut accepted: usize = 0;
+        for handle in handles {
+            let resp = handle.await.unwrap();
+            match resp.status() {
+                StatusCode::CREATED | StatusCode::OK => accepted += 1,
+                StatusCode::INSUFFICIENT_STORAGE => {}
+                other => panic!("unexpected status: {other}"),
+            }
+        }
+
+        let used = core.storage_body_bytes.load(Ordering::Relaxed);
+        let counted = accepted * body_len;
+        assert_eq!(used, counted, "counter must equal sum of accepted bodies");
+        assert!(
+            used <= quota,
+            "counter must never exceed quota: {used} > {quota}"
         );
 
         let _ = std::fs::remove_dir_all(dir);
@@ -3532,7 +3693,7 @@ mod tests {
                     shutdown: watch::channel(false).1,
                     next_event: Arc::new(AtomicU64::new(0)),
                     next_request: Arc::new(AtomicU64::new(0)),
-                    write_lock: Arc::new(Mutex::new(())),
+                    world_locks: Arc::new(DashMap::new()),
                 }
             },
             dir,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -67,7 +67,7 @@ use std::time::Instant;
 use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 
 use crate::http_semantics as hs;
-use crate::world::{AppendResult, Stage};
+use crate::world::Stage;
 
 type BoxedResponse = Box<Response>;
 
@@ -157,6 +157,13 @@ impl Core {
         }
     }
 
+    /// Test-only fixture: seed a world directly without going through
+    /// auth/preconditions/audit. Production writes go through `put_bytes`
+    /// (durable: `world::write_with_audit_checked` + `reserve_storage`;
+    /// memory: `MemoryStore::write_with_quota`). Kept for the existing
+    /// 80+ unit tests that build small fixture worlds before exercising
+    /// handler paths.
+    #[cfg(test)]
     fn write_world(
         &self,
         world: &str,
@@ -170,9 +177,6 @@ impl Core {
         } else {
             let current_len = world::body_len(&self.data, world)?;
             world::write(&self.data, world, body, content_type, headers)?;
-            // Atomic delta on the counter: with per-world locking, multiple
-            // worlds can land here concurrently. fetch_update keeps the
-            // counter coherent across writers in different worlds.
             let prev = current_len.unwrap_or(0);
             let _ = self.storage_body_bytes.fetch_update(
                 Ordering::Relaxed,
@@ -183,14 +187,6 @@ impl Core {
                 self.durable_world_count.fetch_add(1, Ordering::Relaxed);
             }
             Ok(())
-        }
-    }
-
-    fn append_world(&self, world: &str, body: &[u8]) -> rusqlite::Result<Option<AppendResult>> {
-        if store::is_memory_world(world) {
-            Ok(self.mem.append(world, body))
-        } else {
-            world::append(&self.data, world, body)
         }
     }
 
@@ -360,16 +356,25 @@ impl Core {
                 }
             }
         } else {
-            existed = self
-                .read_world(world_name)
-                .map_err(|e| storage_error("storage read", e))?
-                .is_some();
-            if memory_write_projected_bytes(self, world_name, body.len()) > self.max_memory_bytes {
-                return Err(payload_too_large(self.max_memory_bytes));
-            }
-            match self.write_world(world_name, body, content_type, headers) {
-                Ok(()) => hs::body_etag(body),
-                Err(e) => return Err(storage_error("storage", e)),
+            // Memory worlds: the existence check, the quota check, and the
+            // actual insert all happen under one MemoryStore HashMap mutex
+            // acquisition. That mutex was the implicit serializer the global
+            // write_lock used to provide; per-world locks alone don't help
+            // here because the budget is shared across all memory worlds.
+            match self.mem.write_with_quota(
+                world_name,
+                body,
+                content_type,
+                headers,
+                self.max_memory_bytes,
+            ) {
+                Ok(outcome) => {
+                    existed = outcome.existed;
+                    hs::body_etag(body)
+                }
+                Err(store::MemoryQuotaError { quota, .. }) => {
+                    return Err(payload_too_large(quota));
+                }
             }
         };
         self.notify("PUT", world_name, &new_etag);
@@ -1240,15 +1245,19 @@ async fn handle_post(
             }
         }
     } else {
-        if memory_append_projected_bytes(core, body.len()) > core.max_memory_bytes {
-            return payload_too_large(core.max_memory_bytes);
-        }
-        let result = match core.append_world(world_name, &body) {
-            Ok(Some(r)) => r,
+        // Memory append: same atomic-quota pattern as put_bytes' memory
+        // branch. The MemoryStore HashMap mutex is held across "compute
+        // current total -> compare against max -> append", so concurrent
+        // appends to different memory worlds cannot both pass a stale
+        // snapshot and overshoot ELASTIK_MAX_MEMORY_BYTES.
+        match core
+            .mem
+            .append_with_quota(world_name, &body, core.max_memory_bytes)
+        {
+            Ok(Some(result)) => format!("sha256-{}", result.body_sha256_after),
             Ok(None) => return not_found(),
-            Err(e) => return storage_error("storage", e),
-        };
-        format!("sha256-{}", result.body_sha256_after)
+            Err(store::MemoryQuotaError { quota, .. }) => return payload_too_large(quota),
+        }
     };
 
     let resp_headers = [(header::ETAG, hs::etag_header(&new_etag))];
@@ -1484,21 +1493,12 @@ fn can_delete(tier: auth::Tier) -> bool {
     matches!(tier, auth::Tier::Approve)
 }
 
-fn memory_write_projected_bytes(core: &Core, world_name: &str, new_len: usize) -> usize {
-    let current_len = core
-        .mem
-        .read(world_name)
-        .map(|stage| stage.body.len())
-        .unwrap_or(0);
-    core.mem
-        .total_bytes()
-        .saturating_sub(current_len)
-        .saturating_add(new_len)
-}
-
-fn memory_append_projected_bytes(core: &Core, add_len: usize) -> usize {
-    core.mem.total_bytes().saturating_add(add_len)
-}
+// (memory_write_projected_bytes / memory_append_projected_bytes were
+// removed: the snapshot-based projection they computed could be observed
+// by two concurrent writers before either had committed, letting them
+// both pass and overshoot max_memory_bytes once the global write_lock was
+// gone. Quota is now enforced inside MemoryStore::write_with_quota /
+// append_with_quota, atomically with the write itself.)
 
 fn require_read(core: &Core, headers: &HeaderMap) -> Result<(), BoxedResponse> {
     let auth_header = headers
@@ -2035,6 +2035,57 @@ mod tests {
         assert!(
             used <= quota,
             "counter must never exceed quota: {used} > {quota}"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn concurrent_memory_puts_do_not_overshoot_max_memory_bytes() {
+        // Mirror of concurrent_puts_to_distinct_worlds_do_not_overshoot_quota
+        // for memory worlds. Per-world locks let writes to /tmp/a and
+        // /tmp/b run concurrently; before this fix each one would read
+        // total_bytes() as a snapshot, both pass the budget check, and
+        // both commit -- overshooting ELASTIK_MAX_MEMORY_BYTES. With the
+        // check + write fused under the MemoryStore HashMap mutex inside
+        // write_with_quota, only the writes whose accept order keeps the
+        // running total under the cap can commit.
+        let (mut core, dir) = test_core("memory-quota-race");
+        let cap = 100;
+        core.max_memory_bytes = cap;
+        let core = Arc::new(core);
+
+        let workers = 16;
+        let body_len = 12; // 16 * 12 = 192 > cap: forced contention
+        let mut handles = Vec::with_capacity(workers);
+        for i in 0..workers {
+            let core = core.clone();
+            handles.push(tokio::spawn(async move {
+                let path = format!("tmp/race/{i}");
+                let body = Bytes::copy_from_slice(&vec![b'm'; body_len]);
+                handle_put(&core, &path, &HeaderMap::new(), body, auth::Tier::Write).await
+            }));
+        }
+
+        let mut accepted: usize = 0;
+        for handle in handles {
+            let resp = handle.await.unwrap();
+            match resp.status() {
+                StatusCode::CREATED | StatusCode::OK => accepted += 1,
+                StatusCode::PAYLOAD_TOO_LARGE => {}
+                other => panic!("unexpected status: {other}"),
+            }
+        }
+
+        let used = core.mem.total_bytes();
+        let counted = accepted * body_len;
+        assert_eq!(
+            used, counted,
+            "memory total must equal sum of accepted bodies"
+        );
+        assert!(
+            used <= cap,
+            "memory total must never exceed cap: {used} > {cap}"
         );
 
         let _ = std::fs::remove_dir_all(dir);

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -42,11 +42,37 @@ pub struct MemoryStore {
     map: Mutex<HashMap<String, MemEntry>>,
 }
 
+/// Returned by `write_with_quota` / `append_with_quota` when the requested
+/// write would push the total memory store size past `max_total_bytes`.
+/// The check happens under the same mutex as the write so concurrent
+/// writers cannot both pass a stale snapshot and then both commit
+/// (mirror of the durable `WriteAuditError::Quota` path).
+pub struct MemoryQuotaError {
+    /// Pre-write total bytes across all memory worlds. Currently the
+    /// callers only need `quota` for the 413 response, but `used` and
+    /// `projected` are populated for diagnostic clarity.
+    #[allow(dead_code)]
+    pub used: usize,
+    pub quota: usize,
+    #[allow(dead_code)]
+    pub projected: usize,
+}
+
+/// Outcome of a successful `write_with_quota`.
+pub struct MemoryWriteOutcome {
+    /// True if the world existed before this write.
+    pub existed: bool,
+}
+
 impl MemoryStore {
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Read body + metadata only, without the body hash. Currently unused
+    /// since `read_with_hash` covers all internal callers, but kept as a
+    /// convenience wrapper for future external SDK code.
+    #[allow(dead_code)]
     pub fn read(&self, world: &str) -> Option<Stage> {
         self.read_with_hash(world).map(|(stage, _)| stage)
     }
@@ -74,6 +100,11 @@ impl MemoryStore {
         self.map_guard().contains_key(world)
     }
 
+    /// Unconditional write without quota enforcement. Used only by the
+    /// test-only `Core::write_world` fixture; production goes through
+    /// `write_with_quota`. Kept as `#[allow(dead_code)]` so the test
+    /// helper survives future production-only clippy passes.
+    #[allow(dead_code)]
     pub fn write(
         &self,
         world: &str,
@@ -89,6 +120,11 @@ impl MemoryStore {
         e.headers = headers.to_vec();
     }
 
+    /// Append without quota enforcement. Replaced in production by
+    /// `append_with_quota`; kept available with `#[allow(dead_code)]`
+    /// for future tooling that wants the raw primitive (e.g. tests
+    /// asserting growth behavior).
+    #[allow(dead_code)]
     pub fn append(&self, world: &str, body: &[u8]) -> Option<AppendResult> {
         let mut map = self.map_guard();
         let e = map.get_mut(world)?;
@@ -98,6 +134,77 @@ impl MemoryStore {
         Some(AppendResult {
             body_sha256_after: after,
         })
+    }
+
+    /// Write a memory world with an atomic quota check. The HashMap mutex
+    /// is held across "compute current total -> compare against quota ->
+    /// insert", so two concurrent writes to different memory worlds
+    /// cannot both observe usage below the cap and both commit. Replaces
+    /// the previous read/check/write sequence in `put_bytes`, which was
+    /// race-prone after the global write_lock was removed.
+    ///
+    /// Returns `Ok(outcome)` with `existed` populated for the caller's
+    /// 200 vs 201 decision; `Err(MemoryQuotaError)` if accepting the
+    /// write would push the total memory store size past
+    /// `max_total_bytes`.
+    pub fn write_with_quota(
+        &self,
+        world: &str,
+        body: &[u8],
+        content_type: &str,
+        headers: &[(String, String)],
+        max_total_bytes: usize,
+    ) -> Result<MemoryWriteOutcome, MemoryQuotaError> {
+        let mut map = self.map_guard();
+        let used: usize = map.values().map(|entry| entry.body.len()).sum();
+        let prev_len = map.get(world).map(|entry| entry.body.len()).unwrap_or(0);
+        let projected = used.saturating_sub(prev_len).saturating_add(body.len());
+        if projected > max_total_bytes {
+            return Err(MemoryQuotaError {
+                used,
+                quota: max_total_bytes,
+                projected,
+            });
+        }
+        let existed = map.contains_key(world);
+        let e = map.entry(world.to_string()).or_default();
+        e.body = body.to_vec();
+        e.body_hash = world::sha256_hex(body);
+        e.content_type = content_type.to_string();
+        e.headers = headers.to_vec();
+        Ok(MemoryWriteOutcome { existed })
+    }
+
+    /// Append to a memory world with an atomic quota check. Returns
+    /// `Ok(None)` if the world does not exist (caller maps to 404).
+    /// `Err(MemoryQuotaError)` if accepting the append would push the
+    /// total memory store size past `max_total_bytes`. Otherwise
+    /// `Ok(Some(result))` with the post-append SHA-256 of the body.
+    pub fn append_with_quota(
+        &self,
+        world: &str,
+        body: &[u8],
+        max_total_bytes: usize,
+    ) -> Result<Option<AppendResult>, MemoryQuotaError> {
+        let mut map = self.map_guard();
+        let used: usize = map.values().map(|entry| entry.body.len()).sum();
+        let projected = used.saturating_add(body.len());
+        if projected > max_total_bytes {
+            return Err(MemoryQuotaError {
+                used,
+                quota: max_total_bytes,
+                projected,
+            });
+        }
+        let Some(entry) = map.get_mut(world) else {
+            return Ok(None);
+        };
+        entry.body.extend_from_slice(body);
+        let after = world::sha256_hex(&entry.body);
+        entry.body_hash = after.clone();
+        Ok(Some(AppendResult {
+            body_sha256_after: after,
+        }))
     }
 
     pub fn delete(&self, world: &str) -> bool {

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -161,12 +161,27 @@ pub struct AppendResult {
 
 pub struct WriteAuditResult {
     pub hmac: String,
+    /// Body length before this write. Populated for callers that may want
+    /// it (e.g. counter accounting). Currently unused by the production
+    /// code path because `Core::reserve_storage` reads `previous_len`
+    /// outside the SQLite transaction under the per-world lock.
+    #[allow(dead_code)]
     pub previous_len: usize,
+    /// Whether the world existed before this write. Same status as
+    /// `previous_len` -- kept for potential future callers; the active
+    /// path uses `world::body_len` outside the tx.
+    #[allow(dead_code)]
     pub existed: bool,
 }
 
 pub enum WriteAuditError {
     Sqlite(rusqlite::Error),
+    /// Returned only if the caller passes a `quota` argument to
+    /// `write_with_audit_checked`. The active path passes `None` and
+    /// enforces quota via `Core::reserve_storage` instead, so this variant
+    /// is currently unreachable in production. Kept for diagnostic clarity
+    /// and possible test fixtures.
+    #[allow(dead_code)]
     Quota {
         used: usize,
         quota: usize,

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -287,6 +287,11 @@ pub fn read_with_hmac(
     )))
 }
 
+/// Test-only seed primitive: write body + headers without touching the
+/// HMAC chain. Production durable writes go through
+/// `write_with_audit_checked` (which signs the chain). Kept for the
+/// fixtures used by `Core::write_world`.
+#[cfg(test)]
 pub fn write(
     data_root: &Path,
     world: &str,
@@ -402,9 +407,12 @@ pub fn write_with_audit_checked(
     })
 }
 
-/// Append bytes to an existing world's body. Returns Ok(None) if the
-/// world does not exist; caller responds 404. Does not touch headers
-/// (POST append never updates metadata; PUT owns metadata).
+/// Append bytes to an existing world's body without entering the HMAC
+/// chain. Production POST appends go through `append_with_audit`; this
+/// raw form is unused after the lock refactor and is preserved with
+/// `#[allow(dead_code)]` against future direct callers (e.g. log
+/// rotation tooling). Returns Ok(None) if the world does not exist.
+#[allow(dead_code)]
 pub fn append(
     data_root: &Path,
     world: &str,


### PR DESCRIPTION
The global write_lock: Arc<Mutex<()>> is gone. In its place each Core holds a DashMap<String, Arc<Mutex<()>>> and exposes acquire_world_lock(world) which lazy-creates and clones an Arc to the world's mutex. The DashMap shard guard is dropped before the .await on the inner mutex, so we never hold a sync lock across a yield.

Splitting the global lock exposed two shared resources it had been implicitly serializing. Both are addressed in this commit:

1. Storage quota counter race The old "snapshot then write then adjust" pattern lost updates under cross-world contention -- two writes on different worlds could both observe usage below quota, both commit, and only afterwards push the counter past quota. Fixed with Core::reserve_storage(prev, new): a single CAS via fetch_update that atomically checks the quota and reserves the delta in one step. On write failure, callers invoke rollback_storage_reservation to credit back. Regression test: concurrent_puts_to_distinct_worlds_do_not_overshoot_quota fires 16 concurrent PUTs against 16 distinct worlds with a quota deliberately below the sum of all bodies, then asserts the counter never exceeds the quota and exactly matches sum-of-accepted-bodies.

   The quota arg to world::write_with_audit_checked is now passed None in the active path; the in-tx snapshot check is unreachable. Fields that fed it (WriteAuditResult.previous_len/existed and WriteAuditError::Quota) are kept with #[allow(dead_code)] for diagnostic clarity. They go away in a follow-up cleanup.

2. Shared var/log/deletes ledger Two DELETEs of different target worlds were both writing to the same audit ledger without coordination. Fixed by acquiring acquire_world_lock("var/log/deletes") around the existence check + intent append (one critical section) and again around commit / commit_failed appends. Lock ordering: target world FIRST, then ledger -- documented in acquire_world_lock to forbid cycles. The physical delete still runs without the ledger lock, so concurrent DELETEs of different worlds parallelize on the SQLite delete and serialize only on the audit appends. Intent/commit pairs from different DELETEs may interleave in the chain; this is fine because the chain is HMAC-linked, not grouped by target world.

Codifies three architecture invariants in AGENTS.md:
- File size 500-line hard limit for new files (working memory of AI co-author). Existing oversized files are grandfathered for safety fixes and extraction PRs only; the grandfather clause retires when the FSM pipeline extraction PR 4 lands.
- Per-world locking. No new global write mutex.
- Mechanism not policy. Business logic lives in reactors.

Cleanup forced by the new pattern:
- check_storage_quota_for_append removed (subsumed by reserve_storage).
- BoxedResponse used for reserve_storage to avoid clippy::result_large_err.
- Field-level comment on world_locks fixed (it had said locks evict on DELETE, contradicting the implementation; eviction is unsafe while a waiter holds a clone of the Arc).

cargo fmt --manifest-path core/Cargo.toml -- --check: clean
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings: clean
cargo test --manifest-path core/Cargo.toml: 99 passed, 0 failed