### PR TITLE
refactor(core): extract path.rs from main.rs

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -42,13 +42,16 @@ mod auth;
 mod coap;
 mod http_semantics;
 mod listen;
+mod path;
 mod response;
 mod store;
 mod world;
 
-// Re-export response constructors at the crate root so existing
-// `use crate::not_found;` etc. in sibling modules keep working
-// without import churn after the response.rs extraction.
+// Re-export the small pure-function modules at the crate root so
+// sibling modules keep referring to `crate::not_found` /
+// `crate::canonicalize_path` etc. without per-extraction import
+// churn. Each cascading PR adds one line here.
+pub(crate) use crate::path::*;
 pub(crate) use crate::response::*;
 
 use axum::{
@@ -959,88 +962,10 @@ async fn handle_world_method(
     }
 }
 
-/// Path prefix is policy: `/home/tmp/foo` must stay a durable home
-/// world, not silently become transient `/tmp/foo`. Bare `/foo` is the
-/// convenience spelling for `/home/foo`; explicit namespaces are kept.
-fn canonicalize_path(p: &str) -> String {
-    let stripped = p.trim_start_matches('/');
-    let first = stripped.split('/').next().unwrap_or("");
-    match first {
-        "home" | "tmp" | "dev" | "sys" | "proc" | "etc" | "lib" | "boot" | "usr" | "var" => {
-            stripped.to_owned()
-        }
-        _ => format!("home/{stripped}"),
-    }
-}
-
-fn valid_world_name(world_name: &str) -> bool {
-    validate_world_name(world_name).is_ok()
-}
-
-fn validate_world_name(world_name: &str) -> Result<(), &'static str> {
-    if world_name.is_empty() {
-        return Err("world path is empty");
-    }
-    if is_reserved_world_name(world_name) {
-        return Err("world path is a reserved namespace root");
-    }
-    if world_name.contains('\\') {
-        return Err("world path contains backslash");
-    }
-    if world_name.chars().any(char::is_control) {
-        return Err("world path contains control bytes");
-    }
-    for segment in world_name.split('/') {
-        if segment.is_empty() {
-            return Err("world path has empty segment");
-        }
-        if is_dot_segment(segment) {
-            return Err("world path contains dot or encoded-dot segment");
-        }
-    }
-    Ok(())
-}
-
-fn is_dot_segment(segment: &str) -> bool {
-    let Some(rest) = strip_dot_token(segment) else {
-        return false;
-    };
-    rest.is_empty()
-        || strip_dot_token(rest)
-            .map(|tail| tail.is_empty())
-            .unwrap_or(false)
-}
-
-fn strip_dot_token(segment: &str) -> Option<&str> {
-    if let Some(rest) = segment.strip_prefix('.') {
-        return Some(rest);
-    }
-    if segment
-        .as_bytes()
-        .get(..3)
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"%2e"))
-    {
-        return Some(&segment[3..]);
-    }
-    None
-}
-
-fn is_reserved_world_name(world_name: &str) -> bool {
-    matches!(
-        world_name,
-        "home"
-            | "tmp"
-            | "dev"
-            | "sys"
-            | "proc"
-            | "etc"
-            | "lib"
-            | "boot"
-            | "usr"
-            | "var"
-            | "var/log"
-    ) || world_name.starts_with("proc/")
-}
+// Path validation and canonicalization (canonicalize_path,
+// valid_world_name, validate_world_name, is_dot_segment,
+// strip_dot_token, is_reserved_world_name) live in `path.rs` and
+// are re-exported at the crate root.
 
 // ─── handlers ───────────────────────────────────────────────────────
 

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -1,0 +1,110 @@
+//! Request path validation and canonicalization.
+//!
+//! Pure string functions: take an incoming HTTP path, decide whether
+//! it is a valid world name, and (where appropriate) attach a
+//! human-readable rejection reason. No `Core`, no I/O.
+//!
+//! Re-exported into the crate root by `main.rs`; existing callers
+//! (`coap.rs`, the request handlers, the tests) reach these as
+//! `crate::canonicalize_path` etc. without import churn.
+
+/// Path prefix is policy: `/home/tmp/foo` must stay a durable home
+/// world, not silently become transient `/tmp/foo`. Bare `/foo` is the
+/// convenience spelling for `/home/foo`; explicit namespaces are kept.
+pub(crate) fn canonicalize_path(p: &str) -> String {
+    let stripped = p.trim_start_matches('/');
+    let first = stripped.split('/').next().unwrap_or("");
+    match first {
+        "home" | "tmp" | "dev" | "sys" | "proc" | "etc" | "lib" | "boot" | "usr" | "var" => {
+            stripped.to_owned()
+        }
+        _ => format!("home/{stripped}"),
+    }
+}
+
+/// Boolean wrapper for callers that only need the yes/no answer (CoAP
+/// surface, top-level reject path). Prefer `validate_world_name` when
+/// the rejection reason matters — the bool form is documented to elide
+/// the reason and a 400 with a generic message.
+pub(crate) fn valid_world_name(world_name: &str) -> bool {
+    validate_world_name(world_name).is_ok()
+}
+
+/// Returns the specific rejection reason so HTTP callers can surface
+/// it in `400 bad_request: world path contains backslash` rather than
+/// the historic blanket `400 bad_request: control bytes`. This makes
+/// SDK-side error messages diagnostically useful.
+pub(crate) fn validate_world_name(world_name: &str) -> Result<(), &'static str> {
+    if world_name.is_empty() {
+        return Err("world path is empty");
+    }
+    if is_reserved_world_name(world_name) {
+        return Err("world path is a reserved namespace root");
+    }
+    if world_name.contains('\\') {
+        return Err("world path contains backslash");
+    }
+    if world_name.chars().any(char::is_control) {
+        return Err("world path contains control bytes");
+    }
+    for segment in world_name.split('/') {
+        if segment.is_empty() {
+            return Err("world path has empty segment");
+        }
+        if is_dot_segment(segment) {
+            return Err("world path contains dot or encoded-dot segment");
+        }
+    }
+    Ok(())
+}
+
+/// True if the segment is one of `.`, `..`, `%2e`, `%2e.`, `%2e%2e`,
+/// `.%2e`, `%2E%2E`, etc. — anything an attacker might use to walk out
+/// of a namespace through URL encoding tricks. Decoded paths AND raw
+/// percent-encoded paths are both rejected.
+pub(crate) fn is_dot_segment(segment: &str) -> bool {
+    let Some(rest) = strip_dot_token(segment) else {
+        return false;
+    };
+    rest.is_empty()
+        || strip_dot_token(rest)
+            .map(|tail| tail.is_empty())
+            .unwrap_or(false)
+}
+
+/// Strip a leading `.` or case-insensitive `%2e` from a segment.
+/// Helper for `is_dot_segment`; returns the remaining slice or None
+/// if the segment doesn't begin with a dot token.
+pub(crate) fn strip_dot_token(segment: &str) -> Option<&str> {
+    if let Some(rest) = segment.strip_prefix('.') {
+        return Some(rest);
+    }
+    if segment
+        .as_bytes()
+        .get(..3)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"%2e"))
+    {
+        return Some(&segment[3..]);
+    }
+    None
+}
+
+/// Reserved namespace roots (no world named exactly `home`, `tmp`,
+/// etc.) and the entire `/proc/*` subtree (which is read-only
+/// introspection, not a world).
+pub(crate) fn is_reserved_world_name(world_name: &str) -> bool {
+    matches!(
+        world_name,
+        "home"
+            | "tmp"
+            | "dev"
+            | "sys"
+            | "proc"
+            | "etc"
+            | "lib"
+            | "boot"
+            | "usr"
+            | "var"
+            | "var/log"
+    ) || world_name.starts_with("proc/")
+}


### PR DESCRIPTION
## Pure code move: 6 path validation fns → `core/src/path.rs`

**No logic change.** Every inserted body is byte-identical to what it
replaces. Reviewers should verify "did everything land" rather than
"is the new logic correct".

### Moved (6 fns)

| Function | Role |
|---|---|
| `canonicalize_path` | `/foo` → `home/foo`; namespace prefix policy |
| `valid_world_name` | Bool wrapper for callers that only need yes/no |
| `validate_world_name` | `Result<(), reason>` — returns specific rejection so HTTP 400 carries an honest message |
| `is_dot_segment` | Rejects `.`, `..`, `%2e`, `%2e%2e`, mixed encoding |
| `strip_dot_token` | Helper for `is_dot_segment` |
| `is_reserved_world_name` | Namespace roots + `/proc/*` subtree |

### Module wiring

- All marked `pub(crate)`.
- main.rs adds `mod path;` and one line to the existing crate-root
  re-export block (`pub(crate) use crate::path::*;`) — the same
  pattern PR #98 set for response.rs. Each cascading PR adds one
  re-export line.
- Existing call sites in `coap.rs` (which references
  `crate::canonicalize_path` / `crate::valid_world_name`) and the
  inline tests in main.rs (via `super::*`) keep working with no
  import churn.

### Stats

- 120 insertions
- 85 deletions
- 205-line total churn — well within the 500-line PR budget either way.

### Cascade context

PR 2 of the v7 FSM-pipeline cascade. Now depth-1 against master because
PR 1 (#98 response.rs) is merged. A follow-up PR `chore/path-tighten-visibility`
is already pushed and will rebase to depth-1 once this merges.

### Test plan

- [x] `cargo fmt --manifest-path core/Cargo.toml -- --check` — clean
- [x] `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo test --manifest-path core/Cargo.toml` — 100 passed
- [x] `git diff --check` — clean

### Pure-mv verification

```bash
# Codex's verification approach in PR #98 review:
git show refactor/path:core/src/path.rs | grep -A20 "fn canonicalize_path"
# matches byte-for-byte the deletion in main.rs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)