### PR TITLE
chore(core): tighten path.rs helper visibility to module-private

### DIFF
--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -62,7 +62,11 @@ pub(crate) fn validate_world_name(world_name: &str) -> Result<(), &'static str> 
 /// `.%2e`, `%2E%2E`, etc. — anything an attacker might use to walk out
 /// of a namespace through URL encoding tricks. Decoded paths AND raw
 /// percent-encoded paths are both rejected.
-pub(crate) fn is_dot_segment(segment: &str) -> bool {
+///
+/// Module-private: only `validate_world_name` calls it. Keeping it
+/// out of `pub(crate) use crate::path::*;` prevents sibling modules
+/// from acquiring an accidental dependency on this internal helper.
+fn is_dot_segment(segment: &str) -> bool {
     let Some(rest) = strip_dot_token(segment) else {
         return false;
     };
@@ -74,8 +78,8 @@ pub(crate) fn is_dot_segment(segment: &str) -> bool {
 
 /// Strip a leading `.` or case-insensitive `%2e` from a segment.
 /// Helper for `is_dot_segment`; returns the remaining slice or None
-/// if the segment doesn't begin with a dot token.
-pub(crate) fn strip_dot_token(segment: &str) -> Option<&str> {
+/// if the segment doesn't begin with a dot token. Module-private.
+fn strip_dot_token(segment: &str) -> Option<&str> {
     if let Some(rest) = segment.strip_prefix('.') {
         return Some(rest);
     }
@@ -91,8 +95,9 @@ pub(crate) fn strip_dot_token(segment: &str) -> Option<&str> {
 
 /// Reserved namespace roots (no world named exactly `home`, `tmp`,
 /// etc.) and the entire `/proc/*` subtree (which is read-only
-/// introspection, not a world).
-pub(crate) fn is_reserved_world_name(world_name: &str) -> bool {
+/// introspection, not a world). Module-private: only
+/// `validate_world_name` calls it.
+fn is_reserved_world_name(world_name: &str) -> bool {
     matches!(
         world_name,
         "home"


### PR DESCRIPTION
## Visibility tightening: 3 helpers → module-private

Codex's PR #99 review caught visibility creep introduced by the
mechanical extraction in #99: three helpers in `path.rs`
(`is_dot_segment`, `strip_dot_token`, `is_reserved_world_name`) were
lifted to `pub(crate)` as part of the move, but they are only called
from within `path.rs` itself (transitively from `validate_world_name`).
No sibling module needs them.

Lower them back to default `fn` (module-private) so they stop being
re-exported by the crate-root `pub(crate) use crate::path::*;` glob.

### Why a separate PR

PR #99 declared "pure mv" so it stayed byte-identical to the
deletions. This visibility tightening is a deliberate **change**
(reducing visibility), not a move, so it gets its own commit and PR.
Mixing it into #99 would have invalidated the pure-mv label.

### Stats

- 1 file changed
- 10 insertions / 5 deletions
- 3 keyword removals + comments updated to call out module-private
  status

### Why this matters

`pub(crate) use crate::path::*;` re-exports every `pub(crate)` item
at the crate root. A re-export of internals creates a quiet
attractor for "I'll just call `crate::is_dot_segment`" from some
future handler — exactly the kind of accidental cross-module
dependency the 500-line module boundaries are meant to forbid.
Keeping internals internal makes the module boundary actually
mean something.

### Test plan

- [x] `cargo fmt --manifest-path core/Cargo.toml -- --check` — clean
- [x] `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo test --manifest-path core/Cargo.toml` — 100 passed
- [x] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)