### PR TITLE
docs(agents): codify the cascade stack depth limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,49 @@ Without cascading, PR 4's diff = PR 0 + 1 + 2 + 3 + 4 = 1260 lines = AI
 loses the thread. With cascading each PR is an independent 500-line
 review.
 
+### Cascade stack depth: 3-4 levels max
+
+Cascading is not free. To review PR N a reviewer (human or AI) has
+to first mentally accept PR 0 → PR 1 → ... → PR N-1, then read PR N's
+diff against that imagined state. **Each level adds one item to the
+mental stack.** Past 3-4 levels the stack overflows for the same
+reason a single 1500-line PR overflows: working memory runs out.
+
+The cascade form does not eliminate the budget; it changes what the
+budget is spent on. Per-PR diff stays at 500 lines, but cumulative
+stack-depth context is bounded too.
+
+**The rule**:
+
+- **Soft cap: 3 levels**. Comfortable.
+- **Hard cap: 4 levels**. Acceptable when the bottom levels are
+  small or trivial (e.g., one-line `chore/visibility-fix`).
+- **Above 4: stop adding new PRs. Drain the stack first.**
+
+**Draining**:
+
+1. Merge the **bottom** of the stack (the level closest to master,
+   typically the first-written PR) into master.
+2. The level above it now has its base auto-redirected to master and
+   becomes depth 1.
+3. Keep merging upward until the stack is shallow enough.
+4. Then resume opening new PRs.
+
+```
+Before drain:
+  master → PR 0 → PR 1 → PR 2 → PR 3 → PR 4 → PR 5
+                                              (depth 6, blown)
+
+After merging PR 0, 1, 2:
+  master(includes 0/1/2) → PR 3 → PR 4 → PR 5
+                                              (depth 3, fits)
+```
+
+This is why the merge order matches the cascade order: oldest /
+deepest-base first. Trying to merge a higher-up PR while a lower-down
+PR is still open creates a divergent base that GitHub will not
+auto-redirect cleanly.
+
 ### Grandfather clause
 
 Existing oversized files (`core/src/main.rs` in particular) are allowed


### PR DESCRIPTION
## What this adds

A **Cascade stack depth: 3-4 levels max** subsection to AGENTS.md,
right after the cascading-PR diagram from #101.

## The gap

PR #101 explained that cascading PRs are the natural form ("PR N's
base = PR N-1, not master") but did not state that the cascade has
a depth limit. The rule was articulated during the actual cascade
work (#97 → #98 → #99 → #100), but never made it back into the doc.

This PR closes that gap.

## The rule

Each cascade level adds one item to the reviewer's mental stack.
Past 3-4 levels the stack overflows for the same reason a single
1500-line PR overflows: working memory runs out.

- **Soft cap: 3 levels** — comfortable
- **Hard cap: 4 levels** — acceptable when bottom levels are small
- **Above 4: drain the stack first**, then resume

## What "drain" means

1. Merge the **bottom** of the stack (the level closest to master,
   typically the first-written PR) into master
2. The level above it now becomes depth 1
3. Keep merging upward until the stack is shallow
4. Then resume opening new PRs

This is why merge order matters: oldest first. We literally just did
this: #97 → #98 → #99 → #100 → #101 in that order.

## Self-demonstration

| Property | Value |
|---|---|
| Self-size | 43 insertions, 0 deletions |
| Single subject | "stack depth bound" |
| Pure docs | 1 file changed |
| Base | `master` (depth 1) |
| Independent of any other open PR | Yes |

The PR codifying the depth-limit rule is itself a depth-1 PR. That's
the rule applied to itself.

## Test plan

- [x] No code touched
- [x] `git diff --check` — clean
- [x] AGENTS.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)