### PR TITLE
fix(sdk-tests): bump TrustedShellPool e2e timeout to absorb cold PowerShell start

### DIFF
--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -198,7 +198,13 @@ def main() -> int:
             os.environ.pop("ELASTIK_URL", None)
         else:
             os.environ["ELASTIK_URL"] = prior_url
-    with elastik.TrustedShellPool(size=1, timeout=2) as pool:
+    # Cold PowerShell on GHA Windows runners can take 1-2s just to spawn
+    # and start reading stdin; the previous timeout=2 left zero headroom and
+    # tripped a flaky -1 returncode (see PR #100 master CI run 25417478484).
+    # The check is "does the API export and run", not "does it finish in
+    # under 2s", so timeout=15 is generous on cold runners while still
+    # bounding genuinely stuck cases.
+    with elastik.TrustedShellPool(size=1, timeout=15) as pool:
         shell = pool.run("echo sdk-shell", check=True)
         check("sdk-shell" in shell.stdout, "TrustedShellPool is exported and runs")
 


### PR DESCRIPTION
## What broke

Master CI run [25417478484](https://github.com/rangersui/Elastik/actions/runs/25417478484)
(post-merge for PR #100, sha `0989500`) failed `sdk blackbox (windows-latest)`:

```
File "D:\a\Elastik\Elastik\sdk\tests\e2e_blackbox.py", line 202, in main
    shell = pool.run("echo sdk-shell", check=True)
elastik.tools.ShellPoolError: shell command failed with -1: 'echo sdk-shell'
```

`returncode = -1` matches the explicit timeout fallthrough in
`tools.py:217-221` — `pool.run()` hit its 2-second deadline before
the warm shell printed its sentinel.

## Why it's not a PR #100 regression

- PR #100 only changed Rust visibility keywords (`pub(crate)` → `fn`)
  in `core/src/path.rs`. It cannot affect Python shell pool behavior.
- PR #100 itself passed all 13 CI checks (including
  `sdk blackbox (windows-latest)`) before merge.
- Subsequent master CI runs (after #101 and #102 merges) all passed
  the same Windows blackbox check.

The failure is **timing variance on a slow GHA Windows runner**, not
a code regression. Master is currently green.

## Why it will hit again if we don't fix it

GHA Windows runners can take 1-2 seconds just to spawn `powershell.exe`
and start reading stdin (cold process startup is the worst case).
With `timeout=2` there is effectively **zero headroom** for variance.
This is a flaky-test-by-design.

The smoke test's intent is "does TrustedShellPool export and run a
command at all", not "does it complete within 2 seconds". A more
generous timeout makes the test robust without changing its meaning.

## The fix

Bump from `timeout=2` to `timeout=15`. Generous enough to absorb
cold-runner variance; still small enough to bound a genuinely hung
shell.

## Stats

- 1 file changed: `sdk/tests/e2e_blackbox.py`
- 1 numeric change + 6-line explanatory comment
- No code under `sdk/src/` changes; pool internals untouched

## Test plan

- [x] Local `python sdk/tests/e2e_blackbox.py` (Windows): passes with new timeout
- [x] No SDK behavior change — only test config
- [x] No header policy involved

## What this is not

A retry of the macOS failure on the same run. That was a separate
flake (`Couldn't resolve host: static.crates.io` — DNS resolution).
That's GHA infra, retry-only, no code change available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)