### PR TITLE
chore(core): pipeline.rs polish — placeholder note + import dedup

### DIFF
--- a/core/src/pipeline.rs
+++ b/core/src/pipeline.rs
@@ -53,7 +53,10 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::{auth, canonicalize_path, method_not_allowed, validate_world_name, Core, WORLD_ALLOW};
+use crate::{
+    auth, bad_request, canonicalize_path, method_not_allowed, validate_world_name, Core,
+    WORLD_ALLOW,
+};
 
 // ─── Phase enum ──────────────────────────────────────────────────
 
@@ -343,7 +346,7 @@ fn validate_path(
     let world = canonicalize_path(&path);
     if let Err(reason) = validate_world_name(&world) {
         return Phase::Error {
-            resp: crate::bad_request(reason),
+            resp: bad_request(reason),
             reason: ErrorReason::PathInvalid(reason),
         };
     }
@@ -456,6 +459,13 @@ pub(crate) async fn run(
                 // Until then this synthetic 501 keeps the loop
                 // closed so end-to-end tests for the FSM up to
                 // Dispatched can run.
+                //
+                // The reason field below is a placeholder (no caller
+                // actually reaches this in production because no
+                // route invokes `run()` in 4a). 4b replaces the entire
+                // arm with `handler::execute(verb, ...).await`, so the
+                // mis-categorized `MethodNotAllowed` here disappears
+                // before any 4b code path observes it.
                 Phase::Error {
                     resp: not_yet_wired_response(verb),
                     reason: ErrorReason::MethodNotAllowed,


### PR DESCRIPTION
## Two small cleanups carried over from #105 review

Neither blocked the merge of PR #105 (refactor/pipeline-skeleton)
or its companion PR #106 (AGENTS.md test-budget exemption). Both
fixes land here so PR 4b starts from a tidy base.

### Fix 1: placeholder reason annotated

`pipeline.rs::run` has a Phase::Dispatched arm that returns
`ErrorReason::MethodNotAllowed` as a synthetic reason because verb
dispatch is not wired in 4a. The reason is a placeholder, not a
semantic claim. Added an inline comment that says so explicitly
— 4b replaces the entire arm with `handler::execute(verb, ...)`,
so the mis-categorized `MethodNotAllowed` here disappears before
any 4b code path observes it.

### Fix 2: bad_request import lifted to the top of the use block

Other crate-root response constructors (`method_not_allowed`,
`canonicalize_path`, `validate_world_name`, ...) are imported at
the top of `pipeline.rs`; only `crate::bad_request(...)` was
qualified inline at the call site. Moved it into the use list
so all response helpers are imported uniformly.

No behavior change.

## Three more notes tracked (NOT in this PR)

These are tracked in `docs/architecture/v7-pr4-draft.md` 4b checklist:

- **ExecutedRead body size**: `phase_summary(ExecutedRead)` cannot
  read body length (Response body is streaming). 4b's `execute_get`
  will call `trace.emit_aux_kv("body_size", &len.to_string())`
  after computing the response.
- **Env-touching test concurrency**: new tests that mutate
  `ELASTIK_TRACE_PIPELINE` need `serial_test` or a shared `Mutex`.
  4a's single env test is safe alone.
- **Trace spacing in plan samples**: code uses `{:>7.3}` right-aligned
  for the elapsed-ms column; plan samples use simpler spacing for
  readability. Documented in the v7-pr4-draft trace samples section
  as a known cosmetic delta.

## Stats

- 1 file: `core/src/pipeline.rs`
- 12 insertions / 2 deletions = 14 churn (all in production code,
  but trivial: a comment block + an import move)
- Per the new test-budget exemption rule (PR #106), test code
  isn't counted; this PR doesn't touch tests anyway.

## Test plan

- [x] `cargo fmt --manifest-path core/Cargo.toml -- --check` — clean
- [x] `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo test --manifest-path core/Cargo.toml` — 114 passed
- [x] `git diff --check` — clean

## Cascade context

Base = master (which includes PR #105 + PR #106 already merged).
Depth 1. PR 4b (`refactor/handler-read-path`) starts after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)