### PR TITLE
fix(sdk-tests): bump CoAP CLI subprocess timeout to absorb cold Python start

### DIFF
--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -943,6 +943,15 @@ def main() -> int:
             cli_env = os.environ.copy()
             cli_env["PYTHONPATH"] = str(SDK_SRC)
             cli_env["ELASTIK_NO_DOTENV"] = "1"
+            # CoAP CLI subprocess timeout is generous (5s, not 0.5s)
+            # because GHA Windows runners can take 1-2 seconds just to
+            # cold-start `python -m elastik` (process spawn + import +
+            # asyncio loop bring-up). The CoAP exchange itself is
+            # sub-millisecond on localhost, so 5s is comfortably above
+            # any reasonable variance while still bounding a genuinely
+            # hung CLI. Same class of flake as PR #103 (TrustedShellPool
+            # cold start, fixed by bumping timeout=2 to 15).
+            coap_cli_timeout = "5"
             cli_put = subprocess.run(
                 [
                     sys.executable,
@@ -957,7 +966,7 @@ def main() -> int:
                     "--token",
                     write_token,
                     "--timeout",
-                    "0.5",
+                    coap_cli_timeout,
                 ],
                 env=cli_env,
                 capture_output=True,
@@ -981,7 +990,7 @@ def main() -> int:
                     "--token",
                     read_token,
                     "--timeout",
-                    "0.5",
+                    coap_cli_timeout,
                 ],
                 env=cli_env,
                 capture_output=True,
@@ -1008,7 +1017,7 @@ def main() -> int:
                     "--content-type",
                     "image/png",
                     "--timeout",
-                    "0.5",
+                    coap_cli_timeout,
                 ],
                 env=cli_env,
                 capture_output=True,


### PR DESCRIPTION
## What broke

PR #108 CI run [25422257469](https://github.com/rangersui/Elastik/actions/runs/25422257469)
(head sha for `refactor/handler-read-path`) failed `sdk blackbox (windows-latest)`:

```
File "D:\a\Elastik\Elastik\sdk\tests\e2e_blackbox.py", line 59, in __call__
    raise AssertionError(f"FAIL {self.n}: {name}{suffix}")
AssertionError: FAIL 167: CLI CoAP PUT succeeds without stdout noise
  coap: timeout
```

12 of 13 checks passed; only `sdk blackbox (windows-latest)` failed.

## Why it's not a PR #108 regression

- The three CoAP CLI subprocess tests (167 / 168 / bad-content-type)
  were added in commit `4d9bf05` (May 3) — they predate PR 4b.
- PR #108 only touches the Rust core (pipeline read path: `pipeline.rs`,
  `handler.rs`, `main.rs`, `Cargo.toml`). It cannot affect Python CLI
  subprocess timing.
- Same class of flake as PR #100's `TrustedShellPool` failure
  (fixed in PR #103) — both are cold-startup-sensitive operations
  hitting a too-tight timeout on a slow GHA Windows runner.

## Why it will hit again if we don't fix it

GHA Windows runners can take 1-2 seconds just to cold-start
`python -m elastik` (process spawn + import + asyncio loop bring-up).
With `--timeout 0.5` there is effectively **zero headroom** before
the CoAP timeout fires. This is a flaky-test-by-design.

The smoke test's intent is "does the CoAP CLI roundtrip at all", not
"does it complete within 0.5 seconds". A more generous timeout makes
the test robust without changing its meaning.

## The fix

Bump from `--timeout 0.5` to `--timeout 5` for all three CoAP CLI
subprocess invocations. Generous enough to absorb cold-runner
variance; still small enough to bound a genuinely hung CLI.

In-process CoAP calls in the same test (lines 891, 898, 910, 923, 936)
keep `timeout=0.5` unchanged — the test process is already warm, so
the cold-start argument doesn't apply, and those have stayed green.

## Stats

- 1 file changed: `sdk/tests/e2e_blackbox.py`
- 3 numeric callsites + 1 shared variable + 8-line explanatory comment
- No code under `sdk/src/` changes; CoAP CLI internals untouched

## Test plan

- [x] Local `python sdk/tests/e2e_blackbox.py` (Windows): 233/233 pass with new timeout
- [x] No SDK behavior change — only test config
- [x] No header policy involved

## Cascade context

Filing as an independent fix branch off master (same shape as PR #103).
Once this lands, PR #108 (`refactor/handler-read-path`) can rebase onto
a green master to clear the same flake on its own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)