### PR TITLE
refactor(core): extract execute_post into handler/post.rs; handler.rs ≤500

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,28 +126,27 @@ auto-redirect cleanly.
 
 ### Grandfather clause
 
-**Retires when both `core/src/main.rs` and `core/src/handler.rs`
-reach ≤ 500 production lines.** PR 4c brought main.rs from 1297
-to 847 and grew handler.rs from 306 to 803 production lines as the
-verb implementations moved out of main.rs into their proper home;
-neither qualifies yet. The clause stays in force until both meet
-the bar.
+**Retires when `core/src/main.rs` reaches ≤ 500 production lines.**
+PR 4c brought main.rs from 1297 to 847 production lines as the
+verb implementations moved out into `handler.rs`; the post-4c
+extraction PRs (delete + post) brought handler.rs from 803 down to
+~395 production lines, so handler.rs already qualifies. main.rs is
+the sole remaining holdout.
 
-Until then, both files retain the existing exemption: only safety
-fixes (P0/P1 concurrency, correctness, security) and extraction
-PRs that move code OUT into new sub-500-line modules may touch
-them. Net-new feature code MUST land in a new sub-500-line module.
+Until main.rs hits the bar, it retains the existing exemption:
+only safety fixes (P0/P1 concurrency, correctness, security) and
+extraction PRs that move code OUT into new sub-500-line modules
+may touch it. Net-new feature code MUST land in a new sub-500-line
+module.
 
-Active reduction targets (in priority order):
+Active reduction target:
 
-- `core/src/handler.rs` (803 production) — split `execute_delete`
-  and the DELETE-only blocking helpers
-  (`AuditAppendJob`, `world_exists_blocking`, `audit_append_blocking`,
-  `BlockingSqliteError`, `blocking_storage_error`) into
-  `core/src/handler/delete.rs`. PR followup to 4c.
-- `core/src/main.rs` (847 production) — provisional "PR 4d" splits
-  route table + middleware + env parsing + `Core::new`/`main()`
-  startup into `route.rs` / `middleware.rs` / `config.rs`.
+- `core/src/main.rs` (~847 production) — provisional "PR 4d"
+  splits the route table + axum middleware (`add_core_response_headers`)
+  + env parsing helpers + `Core::new`/`main()` startup into
+  `route.rs` / `middleware.rs` / `config.rs`. Once that lands and
+  main.rs is ≤ 500 production lines, the grandfather clause
+  retires entirely and this section can be deleted from AGENTS.md.
 
 ### Pure-mv PRs
 

--- a/core/src/handler.rs
+++ b/core/src/handler.rs
@@ -35,7 +35,9 @@
 //! can be removed at that point.
 
 mod delete;
+mod post;
 pub(crate) use delete::execute_delete;
+pub(crate) use post::execute_post;
 
 use std::sync::atomic::Ordering;
 
@@ -380,144 +382,15 @@ pub(crate) async fn execute_put(
     Phase::CommittedWrite((status, to_header_map(resp_headers), "").into_response())
 }
 
-pub(crate) async fn execute_post(
-    headers: HeaderMap,
-    body: Bytes,
-    tier: auth::Tier,
-    world: String,
-    core: &Core,
-    trace: &TraceCtx,
-) -> Phase {
-    // POST appends to an existing world. PUT is the create/replace
-    // path — POST returns 404 if the world is absent and never
-    // updates X-Meta-* headers (which are PUT-only).
-    if !can_write(&world, tier) {
-        let gate = if needs_write_approve(&world) {
-            AuthGate::WriteApprove
-        } else {
-            AuthGate::Write
-        };
-        return Phase::Error {
-            resp: unauthorized("write requires token; system worlds need approve token"),
-            reason: ErrorReason::Auth(gate),
-        };
-    }
-    let _write_guard = core.acquire_world_lock(&world).await;
-    trace.emit_aux("lock_acquired");
-    if let Err(resp) = hs::check_write_preconditions(core, &world, &headers) {
-        let reason = if resp.status() == StatusCode::PRECONDITION_FAILED {
-            ErrorReason::PreconditionFailed
-        } else {
-            ErrorReason::StorageRead
-        };
-        return Phase::Error { resp, reason };
-    }
-    let Some((body_len, content_type, stored_headers)) = (match core.world_metadata(&world) {
-        Ok(meta) => meta,
-        Err(e) => {
-            return Phase::Error {
-                resp: storage_error("storage metadata", e),
-                reason: ErrorReason::StorageRead,
-            };
-        }
-    }) else {
-        return Phase::Error {
-            resp: not_found(),
-            reason: ErrorReason::NotFound,
-        };
-    };
-    let Some(projected_len) = body_len.checked_add(body.len()) else {
-        return Phase::Error {
-            resp: payload_too_large(core.max_world_bytes),
-            reason: ErrorReason::PayloadTooLarge,
-        };
-    };
-    if projected_len > core.max_world_bytes {
-        return Phase::Error {
-            resp: payload_too_large(core.max_world_bytes),
-            reason: ErrorReason::PayloadTooLarge,
-        };
-    }
-    let new_etag = if store::is_persistent(&world) {
-        // POST adds bytes on top; existing bytes already counted.
-        // prev_len = 0 so the reservation only sizes the delta.
-        if let Some(quota) = core.max_storage_bytes {
-            let used = core.storage_body_bytes.load(Ordering::Relaxed);
-            trace.emit_aux_kv("quota_check", &format!("used={used} quota={quota}"));
-        }
-        if let Err(boxed) = core.reserve_storage(0, body.len()) {
-            return Phase::Error {
-                resp: *boxed,
-                reason: ErrorReason::QuotaExceeded,
-            };
-        }
-        match world::append_with_audit(
-            &core.data,
-            &world,
-            &body,
-            &content_type,
-            &stored_headers,
-            &core.hmac_key,
-        ) {
-            Ok(Some((_result, h))) => {
-                let etag = hs::hmac_etag(&h);
-                trace.emit_aux_kv("sqlite_committed", &format!("etag={}", etag_preview(&etag)));
-                etag
-            }
-            Ok(None) => {
-                // World disappeared between metadata read and append.
-                core.rollback_storage_reservation(0, body.len());
-                return Phase::Error {
-                    resp: not_found(),
-                    reason: ErrorReason::NotFound,
-                };
-            }
-            Err(e) => {
-                core.rollback_storage_reservation(0, body.len());
-                let reason = if is_insufficient_storage_error(&e) {
-                    ErrorReason::InsufficientStorage
-                } else {
-                    ErrorReason::StorageWriteAudit
-                };
-                return Phase::Error {
-                    resp: storage_error("storage/audit", e),
-                    reason,
-                };
-            }
-        }
-    } else {
-        match core
-            .mem
-            .append_with_quota(&world, &body, core.max_memory_bytes)
-        {
-            Ok(Some(result)) => {
-                let etag = format!("sha256-{}", result.body_sha256_after);
-                trace.emit_aux_kv("sqlite_committed", &format!("etag={}", etag_preview(&etag)));
-                etag
-            }
-            Ok(None) => {
-                return Phase::Error {
-                    resp: not_found(),
-                    reason: ErrorReason::NotFound,
-                };
-            }
-            Err(store::MemoryQuotaError { quota, .. }) => {
-                return Phase::Error {
-                    resp: payload_too_large(quota),
-                    reason: ErrorReason::PayloadTooLarge,
-                };
-            }
-        }
-    };
-    core.notify("POST", &world, &new_etag);
-    trace.emit_aux("notify_sent");
-    let resp_headers = [(header::ETAG, hs::etag_header(&new_etag))];
-    Phase::CommittedWrite((StatusCode::OK, resp_headers, "").into_response())
-}
-
 /// First 16 chars of an etag string for compact aux trace lines.
 /// Etags are HMAC-SHA256 hex (64 chars) or `sha256-<64 chars>`; a
 /// 16-char prefix is enough to disambiguate while staying readable.
-fn etag_preview(etag: &str) -> String {
+///
+/// Visibility is `pub(in crate::handler)` so the sibling `post.rs`
+/// module can reuse it (PUT and POST both emit the same
+/// `sqlite_committed etag=...` aux line). Not visible outside
+/// `crate::handler` — etag presentation is a verb-handler concern,
+/// not a crate-wide utility.
+pub(in crate::handler) fn etag_preview(etag: &str) -> String {
     etag.chars().take(16).collect()
 }

--- a/core/src/handler/delete.rs
+++ b/core/src/handler/delete.rs
@@ -1,10 +1,12 @@
 //! DELETE verb implementation + its blocking-SQLite helpers.
 //!
-//! Extracted from `handler.rs` (PR followup to 4c) to keep
-//! `handler.rs` under the 500-line ceiling. DELETE is the most
-//! involved verb — intent / commit / commit_failed two-step audit
-//! dance plus the blocking-spawn helpers — so it carries enough
-//! weight to deserve its own file.
+//! Extracted from `handler.rs` so DELETE's intent / commit /
+//! commit_failed two-step audit dance — and the blocking-spawn
+//! helpers it needs (`AuditAppendJob`, `world_exists_blocking`,
+//! `audit_append_blocking`) — live in their own file. This is the
+//! first of two post-PR-4c extractions that bring `handler.rs`
+//! back under the 500-line ceiling; the second
+//! (`crate::handler::post`) lands the same shape.
 //!
 //! `pub(crate) use` re-exports `execute_delete` from `handler.rs`
 //! so callers (`handler::execute(verb=Delete, ...)` and the

--- a/core/src/handler/post.rs
+++ b/core/src/handler/post.rs
@@ -1,0 +1,165 @@
+//! POST verb implementation — append to an existing world.
+//!
+//! Extracted from `handler.rs` so the four verb implementations
+//! (GET / HEAD / PUT / POST) plus the dispatcher fit comfortably
+//! inside the 500-line ceiling. POST is structurally similar to
+//! PUT (both write under per-world lock, both reserve quota, both
+//! notify) but semantically distinct: POST appends rather than
+//! replaces, never updates `X-Meta-*` (PUT-only), and 404s when
+//! the world is absent. Keeping POST in its own file makes that
+//! distinction visible at the module level rather than buried in
+//! a long shared file.
+//!
+//! `pub(crate) use` re-exports `execute_post` from `handler.rs`
+//! so callers (`handler::execute(verb=Post, ...)` and the
+//! white-box tests in `main.rs`) keep their import path stable.
+
+use std::sync::atomic::Ordering;
+
+use axum::{
+    body::Bytes,
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+
+use super::etag_preview;
+use crate::{
+    auth, can_write, http_semantics as hs, is_insufficient_storage_error, needs_write_approve,
+    not_found, payload_too_large, storage_error, store, unauthorized, world, AuthGate, Core,
+    ErrorReason, Phase, TraceCtx,
+};
+
+pub(crate) async fn execute_post(
+    headers: HeaderMap,
+    body: Bytes,
+    tier: auth::Tier,
+    world: String,
+    core: &Core,
+    trace: &TraceCtx,
+) -> Phase {
+    // POST appends to an existing world. PUT is the create/replace
+    // path — POST returns 404 if the world is absent and never
+    // updates X-Meta-* headers (which are PUT-only).
+    if !can_write(&world, tier) {
+        let gate = if needs_write_approve(&world) {
+            AuthGate::WriteApprove
+        } else {
+            AuthGate::Write
+        };
+        return Phase::Error {
+            resp: unauthorized("write requires token; system worlds need approve token"),
+            reason: ErrorReason::Auth(gate),
+        };
+    }
+    let _write_guard = core.acquire_world_lock(&world).await;
+    trace.emit_aux("lock_acquired");
+    if let Err(resp) = hs::check_write_preconditions(core, &world, &headers) {
+        let reason = if resp.status() == StatusCode::PRECONDITION_FAILED {
+            ErrorReason::PreconditionFailed
+        } else {
+            ErrorReason::StorageRead
+        };
+        return Phase::Error { resp, reason };
+    }
+    let Some((body_len, content_type, stored_headers)) = (match core.world_metadata(&world) {
+        Ok(meta) => meta,
+        Err(e) => {
+            return Phase::Error {
+                resp: storage_error("storage metadata", e),
+                reason: ErrorReason::StorageRead,
+            };
+        }
+    }) else {
+        return Phase::Error {
+            resp: not_found(),
+            reason: ErrorReason::NotFound,
+        };
+    };
+    let Some(projected_len) = body_len.checked_add(body.len()) else {
+        return Phase::Error {
+            resp: payload_too_large(core.max_world_bytes),
+            reason: ErrorReason::PayloadTooLarge,
+        };
+    };
+    if projected_len > core.max_world_bytes {
+        return Phase::Error {
+            resp: payload_too_large(core.max_world_bytes),
+            reason: ErrorReason::PayloadTooLarge,
+        };
+    }
+    let new_etag = if store::is_persistent(&world) {
+        // POST adds bytes on top; existing bytes already counted.
+        // prev_len = 0 so the reservation only sizes the delta.
+        if let Some(quota) = core.max_storage_bytes {
+            let used = core.storage_body_bytes.load(Ordering::Relaxed);
+            trace.emit_aux_kv("quota_check", &format!("used={used} quota={quota}"));
+        }
+        if let Err(boxed) = core.reserve_storage(0, body.len()) {
+            return Phase::Error {
+                resp: *boxed,
+                reason: ErrorReason::QuotaExceeded,
+            };
+        }
+        match world::append_with_audit(
+            &core.data,
+            &world,
+            &body,
+            &content_type,
+            &stored_headers,
+            &core.hmac_key,
+        ) {
+            Ok(Some((_result, h))) => {
+                let etag = hs::hmac_etag(&h);
+                trace.emit_aux_kv("sqlite_committed", &format!("etag={}", etag_preview(&etag)));
+                etag
+            }
+            Ok(None) => {
+                // World disappeared between metadata read and append.
+                core.rollback_storage_reservation(0, body.len());
+                return Phase::Error {
+                    resp: not_found(),
+                    reason: ErrorReason::NotFound,
+                };
+            }
+            Err(e) => {
+                core.rollback_storage_reservation(0, body.len());
+                let reason = if is_insufficient_storage_error(&e) {
+                    ErrorReason::InsufficientStorage
+                } else {
+                    ErrorReason::StorageWriteAudit
+                };
+                return Phase::Error {
+                    resp: storage_error("storage/audit", e),
+                    reason,
+                };
+            }
+        }
+    } else {
+        match core
+            .mem
+            .append_with_quota(&world, &body, core.max_memory_bytes)
+        {
+            Ok(Some(result)) => {
+                let etag = format!("sha256-{}", result.body_sha256_after);
+                trace.emit_aux_kv("sqlite_committed", &format!("etag={}", etag_preview(&etag)));
+                etag
+            }
+            Ok(None) => {
+                return Phase::Error {
+                    resp: not_found(),
+                    reason: ErrorReason::NotFound,
+                };
+            }
+            Err(store::MemoryQuotaError { quota, .. }) => {
+                return Phase::Error {
+                    resp: payload_too_large(quota),
+                    reason: ErrorReason::PayloadTooLarge,
+                };
+            }
+        }
+    };
+    core.notify("POST", &world, &new_etag);
+    trace.emit_aux("notify_sent");
+    let resp_headers = [(header::ETAG, hs::etag_header(&new_etag))];
+    Phase::CommittedWrite((StatusCode::OK, resp_headers, "").into_response())
+}


### PR DESCRIPTION
## Why

Second of two post-PR-4c extractions. PR #111 split out `execute_delete` + blocking helpers into `handler/delete.rs`; this PR splits out `execute_post` into `handler/post.rs` and brings `handler.rs` from 523 down to 396 production lines — finally below the 500-line ceiling.

After this PR, only `core/src/main.rs` (~847 production) remains in violation. The grandfather clause's exit criterion drops to a single condition.

## What moves

**`core/src/handler/post.rs` (new, 165 lines):**

- `pub(crate) async fn execute_post` — verbatim from handler.rs.
- Imports `super::etag_preview` since both PUT (still in handler.rs) and POST emit the same `sqlite_committed etag=...` aux trace line.

**`core/src/handler.rs` (523 → 396 lines):**

- `mod post;` + `pub(crate) use post::execute_post;` next to the delete re-export. **No call-site changes** in main.rs / pipeline.rs; the dispatcher and white-box tests keep their import path stable.
- Deleted execute_post body (134 lines).
- `etag_preview` lifted from `fn` to `pub(in crate::handler) fn` so post.rs can `use super::etag_preview;`. Visibility scoped to the handler module tree only — etag presentation is verb-handler-internal, not a crate-wide utility.

## Doc nits fixed (carry-over from PR #111 review)

- **AGENTS.md**: was `handler.rs (803 production)` — stale since PR #111 brought it to 523. Section rewritten to reflect post-this-PR state (handler.rs ~395, qualifies; main.rs is the sole remaining target).
- **`handler/delete.rs` module doc**: was "to keep handler.rs under the 500-line ceiling" — strictly false at the moment PR #111 landed (handler.rs was 523, still 23 over). Reworded to "first of two post-PR-4c extractions that bring handler.rs back under the 500-line ceiling; the second (`crate::handler::post`) lands the same shape" — now accurate.

## Stats

- 4 files touched.
- Net production: +43 lines (per-file doc + import set duplicated across the new module boundary; same shape as PR #111).
- `core/src/handler.rs` production: 523 → **396** (✓ ≤ 500).
- `core/src/handler/delete.rs`: 308 (✓).
- `core/src/handler/post.rs`: 165 (✓).
- `core/src/main.rs` production: unchanged at ~847 (PR 4d's job).

## Test plan

- [x] `cargo test` — 124 unit tests pass.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `python sdk/tests/e2e_blackbox.py` — 233/233 checks pass.
- [ ] CI sdk-blackbox on Windows — same flake class as before; PR #109's CoAP timeout fix is in master.

## What's next

**PR 4d**: split main.rs's route table + axum middleware (`add_core_response_headers`) + env parsing helpers + `Core::new`/`main()` startup into `route.rs` / `middleware.rs` / `config.rs`. Once main.rs ≤ 500 production lines, the grandfather clause retires entirely and the AGENTS.md section can be deleted.

## Cascade depth

Depth 1 — branched off `origin/master` directly (PR #111 is merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)