### PR TITLE
chore: bump version 6.4.4 -> 7.0.0 across core + Python + JS SDKs

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "6.4.4"
+version = "7.0.0"
 dependencies = [
  "axum",
  "base64",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "elastik-core"
 version = "7.0.0"
 edition = "2021"
-description = "Elastik V7 Engine: FSM pipeline, six verbs, one HTTP disk."
+description = "Elastik V6 Engine: six verbs, one HTTP disk."
 
 [dependencies]
 axum = { version = "0.7", default-features = false, features = ["http1", "tokio"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "elastik-core"
-version = "6.4.4"
+version = "7.0.0"
 edition = "2021"
-description = "Elastik V6 Engine: six verbs, one HTTP disk."
+description = "Elastik V7 Engine: FSM pipeline, six verbs, one HTTP disk."
 
 [dependencies]
 axum = { version = "0.7", default-features = false, features = ["http1", "tokio"] }

--- a/sdk-js/core-darwin-arm64/package.json
+++ b/sdk-js/core-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-darwin-arm64",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "description": "Elastik V6 Engine — bundled Rust core binary for macOS Apple Silicon. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-linux-arm64/package.json
+++ b/sdk-js/core-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-linux-arm64",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "description": "Elastik V6 Engine — bundled Rust core binary for Linux ARM64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-linux-x64/package.json
+++ b/sdk-js/core-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-linux-x64",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "description": "Elastik V6 Engine — bundled Rust core binary for Linux x64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-win32-x64/package.json
+++ b/sdk-js/core-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-win32-x64",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "description": "Elastik V6 Engine — bundled Rust core binary for Windows x64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core.exe"

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/client",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "description": "JavaScript SDK for Elastik V6 Engine. Six verbs, one import, zero dependencies. Works in browser AND Node 18+. fetch is all you need.",
   "type": "module",
   "main": "./index.mjs",
@@ -53,10 +53,10 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "@elastikjs/core-linux-x64": "6.4.4",
-    "@elastikjs/core-linux-arm64": "6.4.4",
-    "@elastikjs/core-darwin-arm64": "6.4.4",
-    "@elastikjs/core-win32-x64": "6.4.4"
+    "@elastikjs/core-linux-x64": "7.0.0",
+    "@elastikjs/core-linux-arm64": "7.0.0",
+    "@elastikjs/core-darwin-arm64": "7.0.0",
+    "@elastikjs/core-win32-x64": "7.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elastik"
-version = "6.4.4"
+version = "7.0.0"
 description = "Elastik V6 Engine: six verbs, one HTTP disk."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
PR 4d (#113) closed the v7 FSM pipeline cascade. Bump every package manifest the release workflow consumes so a `v7.0.0` tag can publish without colliding on prior 6.4.4 artifacts.

**Three package channels, one release:**

| File | Field | 6.4.4 → 7.0.0 |
|---|---|---|
| `core/Cargo.toml` | `version` | ✓ |
| `sdk/pyproject.toml` | `version` (PyPI: `elastik`) | ✓ |
| `sdk-js/package.json` | `version` (npm: `@elastikjs/client`) | ✓ |
| `sdk-js/package.json` | `optionalDependencies."@elastikjs/core-{linux-x64,linux-arm64,darwin-arm64,win32-x64}"` ×4 | ✓ |
| `sdk-js/core-{darwin-arm64,linux-arm64,linux-x64,win32-x64}/package.json` | `version` ×4 | ✓ |

11 version strings total (1 Cargo.toml + 1 pyproject + 5 in main npm + 4 in platform npm). The four platform npm packages MUST move together with the main `@elastikjs/client` because its `optionalDependencies` pin them by exact version — a mismatched set falls back to a previous release or fails to install.

**V6 Engine ≠ version number** (carry-over correction):

- **V6 Engine** = product/engine code name. Six verbs (GET HEAD PUT POST DELETE OPTIONS) — like a V6 car engine, an engine designation. Doesn't change unless we add a seventh verb.
- **v7.0.0** = version number. Internal FSM pipeline refactor; user-visible API unchanged.

So `description = "Elastik V6 Engine: ..."` (in `core/Cargo.toml` and `sdk/pyproject.toml`) and `"description": "JavaScript SDK for Elastik V6 Engine..."` (in `sdk-js/package.json`) all stay put. Only the version strings move.

`Cargo.lock` regenerated (already in this PR's first commit).

After merge: `git tag -a v7.0.0 -m "FSM pipeline complete"` on the resulting master commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)