### PR TITLE
fix(release): resolve npm publish tgz path so npm 10 doesn't treat it as a github shorthand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,12 @@ jobs:
           node sdk-js/scripts/pack-platform.mjs "${{ matrix.npm-platform }}" "${{ matrix.npm-arch }}" "$binary" --version "$version"
           mkdir -p npm-packages
           npm pack "./sdk-js/core-${{ matrix.npm-platform }}-${{ matrix.npm-arch }}" --pack-destination npm-packages
-          tgz_path=$(ls npm-packages/*.tgz | head -n 1)
+          # Resolve to an absolute path so `npm publish` cannot interpret the
+          # tgz argument as a GitHub `user/repo` shorthand. npm 10 prefers
+          # the shorthand interpretation when the path starts with a
+          # directory name (no `./` or `/`), and tries to git-clone
+          # ssh://git@github.com/<dir>/<rest>.git, failing with exit 128.
+          tgz_path=$(realpath "$(ls npm-packages/*.tgz | head -n 1)")
           if npm view "${pkg_name}@${version}" version >/dev/null 2>&1; then
             echo "${pkg_name}@${version} already published; skipping npm publish"
           else
@@ -357,7 +362,8 @@ jobs:
           pkg_name=$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync('package.json','utf8')).name)")
           mkdir -p ../npm-packages
           npm pack --pack-destination ../npm-packages
-          tgz_path=$(ls ../npm-packages/*.tgz | head -n 1)
+          # Absolute path; see the matching comment in build-core-assets above.
+          tgz_path=$(realpath "$(ls ../npm-packages/*.tgz | head -n 1)")
           if npm view "${pkg_name}@${version}" version >/dev/null 2>&1; then
             echo "${pkg_name}@${version} already published; skipping npm publish"
           else


### PR DESCRIPTION
## What broke

The v7.0.0 tag triggered the release workflow ([run 25429949025](https://github.com/rangersui/Elastik/actions/runs/25429949025)). All four `build-core-assets` matrix jobs failed at the "publish npm platform package" step. PyPI publish, npm client publish, and the cross-channel checksum step were all skipped because they depend on this step.

```
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote
  ssh://git@github.com/npm-packages/elastikjs-core-linux-arm64-7.0.0.tgz.git
npm error git@github.com: Permission denied (publickey).
```

## Root cause

`tgz_path` resolved to `npm-packages/elastikjs-core-linux-arm64-7.0.0.tgz` — relative, starting with a directory name. **npm 10 prefers the GitHub `user/repo` shorthand interpretation** for any argument that doesn't start with `./` or `/`, so it appended `.git` and tried to clone `ssh://git@github.com/npm-packages/<rest>.git`. There IS a GitHub user called `npm-packages`, so the resolution actually reached SSH auth instead of failing earlier with "unknown package".

## Fix

`realpath` the tgz path to an absolute path before passing to `npm publish`. Same fix in both publish sites:

- `build-core-assets` matrix (4 jobs publishing platform packages: `@elastikjs/core-{linux-x64,linux-arm64,darwin-arm64,win32-x64}`)
- `publish-npm-client` (`@elastikjs/client` itself)

Both `npm view` lookups in the file already use `@scope/name@version` which is correctly interpreted as a registry spec, not a path; only `npm publish <tarball>` needed the fix.

Comment added at both sites explaining the npm 10 behavior so the next reader doesn't think the `realpath` is decoration.

## After merge

Re-trigger the release on the v7.0.0 tag:

```bash
gh workflow run release.yml --ref v7.0.0
```

Then PyPI's `elastik` package, npm's five `@elastikjs/*` packages, and the cross-channel binary checksum manifest all land. The GitHub Release v7.0.0 already has the four `elastik-core-*.zip` core assets attached (those uploaded successfully before the failed npm step in the same job).

## Stats

1 file: .github/workflows/release.yml (+8 / -2). No code change; workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)