### PR TITLE
v7.1 SQLite connection pool cascade (#118 + #119 + #120 cherry-picked to master)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ ELASTIK_MAX_MEMORY_BYTES=268435456
 ELASTIK_MAX_LISTEN_CONNECTIONS=1024
 ELASTIK_LISTEN_REPLAY_MAX=1024
 ELASTIK_COAP_MAX_IN_FLIGHT=1024
+# Per-world SQLite read connection cache cap. Each cached entry
+# bounds memory to ~250 KiB via PRAGMA cache_size=-200; default 5000
+# entries puts the worst-case at ~1.25 GiB. At-cap reads still go
+# through the SlotState protocol via a transient slot (see
+# AGENTS.md "Drain before remove") -- the cap controls
+# persistence, not safety registration. Surface the actual hit /
+# miss / capped counts via /proc/pool. Zero or non-numeric values
+# fall back to the default.
+ELASTIK_READ_CACHE_MAX_ENTRIES=5000
 
 # Audit-chain HMAC key. Required by the Rust core. The SDK no longer
 # substitutes a constant default. Generate one with:

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Resource caps:
 | `ELASTIK_MAX_LISTEN_CONNECTIONS` | `1024` | Maximum concurrent `/listen/*` SSE connections. |
 | `ELASTIK_LISTEN_REPLAY_MAX` | `1024` | Number of recent change events kept for `Last-Event-ID` replay. |
 | `ELASTIK_COAP_MAX_IN_FLIGHT` | `1024` | Maximum concurrent SCoAP/UDP request handlers when CoAP is enabled. |
+| `ELASTIK_READ_CACHE_MAX_ENTRIES` | `5000` | Per-world SQLite read connection cache cap. Each cached entry pins ~250 KiB (PRAGMA `cache_size=-200`); default 5000 entries puts worst-case resident at ~1.25 GiB. At-cap reads still go through the slot protocol via a transient slot (the cap controls persistence, not safety). Zero or non-numeric values fall back to the default. Surface live cache state via `/proc/pool`. |
 
 The HTTP request body limit is 64 MiB. `POST` append also checks the projected
 final world size before writing. If a write would cross a cap, the core returns
@@ -315,8 +316,8 @@ the Python SDK warn so you can rename it.
 Policy is small:
 
 - `GET`, `HEAD`, `OPTIONS`, `/listen/*`, `/proc/worlds`, `/proc/du`,
-  `/proc/df`, and `/proc/audit/{path}/verify` require read only when
-  `ELASTIK_READ_TOKEN` is configured.
+  `/proc/df`, `/proc/pool`, and `/proc/audit/{path}/verify` require read only
+  when `ELASTIK_READ_TOKEN` is configured.
 - `PUT` and `POST` require `ELASTIK_WRITE_TOKEN` for ordinary worlds.
 - `/etc/*`, `/lib/*`, `/boot/*`, `/usr/*`, and `/var/log/*` writes require
   `ELASTIK_APPROVE_TOKEN`.
@@ -796,6 +797,33 @@ storage	5	unlimited	unlimited
 memory	4	268435456	268435452
 worlds	2	unlimited	unlimited
 ```
+
+`/proc/pool` reports the SQLite read connection cache and audit
+ledger writer state. Eight metrics, one per line, with a
+Prometheus-style `counter` (monotonic from process start) or
+`snapshot` (instantaneous gauge) label so a polling operator knows
+which to subtract vs read directly:
+
+```text
+read_cache_entries 7 snapshot
+read_cache_tombstones 0 snapshot
+read_cache_hits 1842 counter
+read_cache_misses 11 counter
+read_cache_capped 0 counter
+read_cache_open_fails 0 counter
+read_cache_max_entries 5000 snapshot
+ledger_writer_inits 1 counter
+```
+
+`read_cache_capped > 0` means the workload's hot working set
+exceeds `ELASTIK_READ_CACHE_MAX_ENTRIES`; at-cap reads still
+complete correctly via a transient slot but skip caching. Raise
+the cap if hit-rate drops. `ledger_writer_inits` should equal `1`
+in steady state (lazy-init on first DELETE); higher values surface
+re-init events that would otherwise be invisible. The DashMap walk
+runs inside `spawn_blocking` so polling does not stall the async
+runtime. Same auth gating as `/proc/df`: read token if
+`ELASTIK_READ_TOKEN` is set, otherwise public.
 
 ## SDKs
 

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -10,10 +10,15 @@ use std::path::Path;
 
 use crate::world;
 
+/// Append a single row to the audit chain, reusing an already-open
+/// `Connection`. Cached writers (the ledger writer
+/// `Mutex<Option<Connection>>` on `Core`) call this directly so the
+/// hot DELETE path doesn't re-open `var/log/deletes` 2-3 times per
+/// request. Per-write paths that don't cache a connection compose
+/// `world::open` + `append_with_conn` directly.
 #[allow(clippy::too_many_arguments)]
-pub fn append(
-    data_root: &Path,
-    world_name: &str,
+pub fn append_with_conn(
+    conn: &mut Connection,
     event_type: &str,
     target: &str,
     body_sha256: &str,
@@ -22,8 +27,7 @@ pub fn append(
     headers: &[(String, String)],
     key: &[u8],
 ) -> rusqlite::Result<String> {
-    let mut c = world::open(data_root, world_name)?;
-    let tx = c.transaction()?;
+    let tx = conn.transaction()?;
     let h = append_tx(
         &tx,
         event_type,

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -6,9 +6,15 @@
 use hmac::{Hmac, Mac};
 use rusqlite::{Connection, Transaction};
 use sha2::{Digest, Sha256};
-use std::path::Path;
 
+// `#[cfg(test)]` items below (`latest_hmac`, the in-module tests) need
+// `Path` and `world::world_db`. Production code reaches the audit chain
+// only via `append_with_conn` and `verify_chain_via_conn`, which both
+// take a tracked Connection from the caller and never open one.
+#[cfg(test)]
 use crate::world;
+#[cfg(test)]
+use std::path::Path;
 
 /// Append a single row to the audit chain, reusing an already-open
 /// `Connection`. Cached writers (the ledger writer
@@ -140,15 +146,19 @@ struct EventHmacInput<'a> {
     meta_sha256: &'a str,
 }
 
-pub fn verify_chain(
-    data_root: &Path,
-    world_name: &str,
+/// Verify the audit chain through a `TrackedReadConnection` (the
+/// SlotState-tracked read path). Mirrors `world::read_with_hmac_via_conn`
+/// — the cache layer drives the slot-before-open dance and hands us
+/// the connection through the type gate. The bare per-request
+/// `verify_chain(data, world, key)` path is gone (Bug 58); admin
+/// `/proc/audit/{world}/verify` now goes through `Core::cached_verify_chain`,
+/// so DELETE on the same world drains in-flight verifies via the
+/// usual SlotState write guard.
+pub fn verify_chain_via_conn(
+    tracked: &mut crate::read_cache::TrackedReadConnection,
     key: &[u8],
-) -> rusqlite::Result<Option<VerifyReport>> {
-    let Some(c) = world::open_existing(data_root, world_name)? else {
-        return Ok(None);
-    };
-    verify_connection(&c, key).map(Some)
+) -> rusqlite::Result<VerifyReport> {
+    verify_connection(tracked.as_mut_conn(), key)
 }
 
 fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyReport> {

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -148,7 +148,7 @@ struct EventHmacInput<'a> {
 
 /// Verify the audit chain through a `TrackedReadConnection` (the
 /// SlotState-tracked read path). Mirrors `world::read_with_hmac_via_conn`
-/// — the cache layer drives the slot-before-open dance and hands us
+/// -- the cache layer drives the slot-before-open dance and hands us
 /// the connection through the type gate. The bare per-request
 /// `verify_chain(data, world, key)` path is gone (Bug 58); admin
 /// `/proc/audit/{world}/verify` now goes through `Core::cached_verify_chain`,

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -552,6 +552,7 @@ mod tests {
                 next_event: Arc::new(AtomicU64::new(0)),
                 next_request: Arc::new(AtomicU64::new(0)),
                 world_locks: Arc::new(DashMap::new()),
+                ledger_writer: Arc::new(StdMutex::new(None)),
             },
             dir,
         )

--- a/core/src/coap.rs
+++ b/core/src/coap.rs
@@ -552,7 +552,10 @@ mod tests {
                 next_event: Arc::new(AtomicU64::new(0)),
                 next_request: Arc::new(AtomicU64::new(0)),
                 world_locks: Arc::new(DashMap::new()),
-                ledger_writer: Arc::new(StdMutex::new(None)),
+                ledger: Arc::new(crate::ledger::LedgerWriter::new()),
+                read_cache: Arc::new(crate::read_cache::ReadCache::new(
+                    crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+                )),
             },
             dir,
         )

--- a/core/src/handler.rs
+++ b/core/src/handler.rs
@@ -8,7 +8,7 @@
 //!    `can_write` / `can_delete`). Authentication is the driver's
 //!    job; authorization lives next to the verb because the gate is
 //!    verb-and-path-specific.
-//! 2. Performs the verb's actual work — including, for write verbs,
+//! 2. Performs the verb's actual work -- including, for write verbs,
 //!    the lock acquire / preconditions / SQLite write+audit append /
 //!    counter update / notify sequence. The verb owns audit + notify
 //!    ordering; the FSM only models the request envelope.
@@ -22,7 +22,7 @@
 //! `notify_sent`. DELETE additionally emits the
 //! `audit_intent` / `audit_commit` / `audit_commit_failed[_event_failed]`
 //! sequence so an operator reading `grep req-N` can reconstruct the
-//! intent / commit dance — including the honest double-failure case
+//! intent / commit dance -- including the honest double-failure case
 //! where the commit append AND the subsequent failure-event append
 //! both fail (e.g. persistent DiskFull).
 //!
@@ -240,7 +240,7 @@ pub(crate) async fn execute_put(
     trace: &TraceCtx,
 ) -> Phase {
     // 1. Auth gate (verb-and-path-specific). Driver authenticated;
-    //    the verb authorizes — the gate kind drives the trace
+    //    the verb authorizes -- the gate kind drives the trace
     //    `Auth(Write)` vs `Auth(WriteApprove)` distinction so an
     //    operator sees which token tier was insufficient.
     if !can_write(&world, tier) {
@@ -254,7 +254,7 @@ pub(crate) async fn execute_put(
             reason: ErrorReason::Auth(gate),
         };
     }
-    // 2. Per-world body cap (413 — never confuse with quota / 507).
+    // 2. Per-world body cap (413 -- never confuse with quota / 507).
     if body.len() > core.max_world_bytes {
         return Phase::Error {
             resp: payload_too_large(core.max_world_bytes),
@@ -263,11 +263,22 @@ pub(crate) async fn execute_put(
     }
     let content_type = hs::request_content_type(&headers);
     let meta = hs::request_meta_headers(&headers);
-    // 3. Per-world write lock — serializes same-world writers so
+    // 3. Per-world write lock -- serializes same-world writers so
     //    preconditions and write are atomic w.r.t. concurrent PUTs
     //    on this world. Different worlds run concurrently.
     let _write_guard = core.acquire_world_lock(&world).await;
     trace.emit_aux("lock_acquired");
+    // 3b. Defence-in-depth tombstone clear (Bug 19). PUT/POST and
+    //     DELETE both serialize on the same per-world lock, so a
+    //     prior DELETE on this world has either succeeded (tombstone
+    //     already cleared by `clear_tombstone` after
+    //     `delete_world_blocking`) or panicked mid-flight. Calling
+    //     `clear_tombstone` here covers the panic case so a phantom
+    //     tombstone doesn't outlive the lock release. Position is
+    //     critical: clearing BEFORE `acquire_world_lock` would let
+    //     a concurrent in-flight DELETE re-open the v1 fd race via
+    //     a different trigger.
+    core.clear_tombstone(&world);
     // 4. If-Match / If-None-Match preconditions (412 on mismatch).
     //    Storage-error during precondition read maps to StorageRead
     //    (500); the 412 path is the optimistic-concurrency signal.
@@ -388,7 +399,7 @@ pub(crate) async fn execute_put(
 /// Visibility is `pub(in crate::handler)` so the sibling `post.rs`
 /// module can reuse it (PUT and POST both emit the same
 /// `sqlite_committed etag=...` aux line). Not visible outside
-/// `crate::handler` — etag presentation is a verb-handler concern,
+/// `crate::handler` -- etag presentation is a verb-handler concern,
 /// not a crate-wide utility.
 pub(in crate::handler) fn etag_preview(etag: &str) -> String {
     etag.chars().take(16).collect()

--- a/core/src/handler/delete.rs
+++ b/core/src/handler/delete.rs
@@ -20,8 +20,9 @@ use axum::{
 };
 
 use crate::{
-    audit, auth, can_delete, http_semantics as hs, not_found, server_error, storage_error, store,
-    unauthorized, world, AuthGate, Core, ErrorReason, Phase, TraceCtx,
+    auth, can_delete, http_semantics as hs, not_found, server_error, storage_error, store,
+    unauthorized, world, AuditAppendJob, AuthGate, BlockingSqliteError, Core, ErrorReason, Phase,
+    TraceCtx,
 };
 
 pub(crate) async fn execute_delete(
@@ -85,51 +86,46 @@ pub(crate) async fn execute_delete(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-    // Acquire the ledger lock briefly around the existence check +
-    // intent append so two concurrent DELETEs don't double-count
-    // ledger creation. Lock ordering: target world FIRST (already
-    // held), then ledger lock. See Core::acquire_world_lock docs.
-    let intent_outcome = {
-        let _ledger_guard = core.acquire_world_lock("var/log/deletes").await;
-        trace.emit_aux("ledger_lock_acquired");
-        let existed = match world_exists_blocking(core.data.clone(), "var/log/deletes").await {
-            Ok(existed) => existed,
-            Err(e) => {
-                trace.emit_aux("ledger_lock_released");
-                return Phase::Error {
-                    resp: blocking_storage_error("delete audit intent", e),
-                    reason: ErrorReason::StorageWriteAudit,
-                };
-            }
-        };
-        if let Err(e) = audit_append_blocking(
-            core.data.clone(),
-            AuditAppendJob {
-                ledger_world: "var/log/deletes",
-                event_type: "delete_intent",
-                target: world.clone(),
-                body_sha256: body_sha256_before.clone(),
-                size: 0,
-                content_type: delete_content_type.clone(),
-                headers: delete_meta.clone(),
-                key: core.hmac_key.clone(),
-            },
-        )
+    // The cached `ledger_writer` Mutex serializes ledger appends, so
+    // the prior `acquire_world_lock("var/log/deletes")` calls are
+    // gone — this Mutex provides the same ordering guarantee with no
+    // extra async hop. Ledger existence is tracked by
+    // `delete_ledger_created` AtomicBool: initialized at startup from
+    // `world::sizes`, and atomically swapped to true on the first
+    // successful append in this process run. The previous
+    // `world_exists_blocking` RO open per DELETE is gone.
+    if let Err(e) = core
+        .append_to_ledger(AuditAppendJob {
+            ledger_world: "var/log/deletes",
+            event_type: "delete_intent",
+            target: world.clone(),
+            body_sha256: body_sha256_before.clone(),
+            size: 0,
+            content_type: delete_content_type.clone(),
+            headers: delete_meta.clone(),
+            key: core.hmac_key.clone(),
+        })
         .await
-        {
-            trace.emit_aux("ledger_lock_released");
-            return Phase::Error {
-                resp: blocking_storage_error("delete audit intent", e),
-                reason: ErrorReason::StorageWriteAudit,
-            };
-        }
-        trace.emit_aux("audit_intent");
-        trace.emit_aux("ledger_lock_released");
-        existed
-    };
-    if !intent_outcome {
+    {
+        return Phase::Error {
+            resp: blocking_storage_error("delete audit intent", e),
+            reason: ErrorReason::StorageWriteAudit,
+        };
+    }
+    trace.emit_aux("audit_intent");
+    // Bump the durable_world_count exactly once — the first append in
+    // this process run that observes the flag still false is the one
+    // that "created" the ledger world (or first observed it after
+    // startup). `swap` returns the *prior* value, so `was_first` is
+    // true only for that one caller; concurrent DELETEs racing on the
+    // same false→true edge are serialized by the ledger_writer Mutex
+    // inside `append_to_ledger`, so the swap here always runs after
+    // a successful append. AcqRel matches the load-on-startup pattern
+    // in main.rs (Acquire) and keeps the durable_world_count bump
+    // visible to subsequent observers.
+    let was_first = !core.delete_ledger_created.swap(true, Ordering::AcqRel);
+    if was_first {
         core.durable_world_count.fetch_add(1, Ordering::Relaxed);
-        core.delete_ledger_created.store(true, Ordering::Relaxed);
     }
 
     let ok = core.delete_world_blocking(&world).await;
@@ -157,17 +153,14 @@ pub(crate) async fn execute_delete(
     core.notify("DELETE", &world, "");
     trace.emit_aux("notify_sent");
 
-    // Re-acquire the ledger lock for the commit / commit_failed
-    // appends. Each append is one SQLite tx; the lock serializes
-    // ordering of *audit chain entries* across concurrent DELETEs on
-    // different target worlds. Intent and commit from the same DELETE
-    // may interleave with a different DELETE's intent — intentional;
-    // the chain is HMAC-linked, not grouped by target world.
-    let _ledger_guard = core.acquire_world_lock("var/log/deletes").await;
-    trace.emit_aux("ledger_lock_acquired");
-    if let Err(commit_err) = audit_append_blocking(
-        core.data.clone(),
-        AuditAppendJob {
+    // commit / commit_failed appends — same `ledger_writer` Mutex
+    // serializes ordering of audit chain entries across concurrent
+    // DELETEs on different target worlds. Intent and commit from the
+    // same DELETE may interleave with a different DELETE's intent —
+    // intentional; the chain is HMAC-linked, not grouped by target
+    // world.
+    if let Err(commit_err) = core
+        .append_to_ledger(AuditAppendJob {
             ledger_world: "var/log/deletes",
             event_type: "delete_commit",
             target: world.clone(),
@@ -176,9 +169,8 @@ pub(crate) async fn execute_delete(
             content_type: delete_content_type.clone(),
             headers: delete_meta.clone(),
             key: core.hmac_key.clone(),
-        },
-    )
-    .await
+        })
+        .await
     {
         // Honest cascade-failure trace. The world is already gone, so
         // we still return 204 — the write side of the DELETE
@@ -188,9 +180,8 @@ pub(crate) async fn execute_delete(
         // the failure.
         eprintln!("  WARNING: delete_commit audit append failed for {world}: {commit_err:?}");
         trace.emit_aux_kv("audit_commit_failed", &format!("err={commit_err:?}"));
-        match audit_append_blocking(
-            core.data.clone(),
-            AuditAppendJob {
+        match core
+            .append_to_ledger(AuditAppendJob {
                 ledger_world: "var/log/deletes",
                 event_type: "delete_commit_failed",
                 target: world.clone(),
@@ -199,9 +190,8 @@ pub(crate) async fn execute_delete(
                 content_type: delete_content_type,
                 headers: delete_meta,
                 key: core.hmac_key.clone(),
-            },
-        )
-        .await
+            })
+            .await
         {
             Ok(_) => {
                 // Sub-case A: commit failed but the failure event
@@ -230,79 +220,23 @@ pub(crate) async fn execute_delete(
     } else {
         trace.emit_aux("audit_commit");
     }
-    trace.emit_aux("ledger_lock_released");
 
     Phase::CommittedWrite((StatusCode::NO_CONTENT, "").into_response())
 }
 
 // ─── DELETE blocking helpers ──────────────────────────────────────
 //
-// These wrap `audit::append` and `world::open_existing` in
-// `tokio::task::spawn_blocking` so a slow SQLite call cannot stall
-// the runtime. They live next to `execute_delete` (their only
-// caller) rather than on `Core`, to keep Core's API surface
-// orthogonal to verb-internal sequencing.
-
-#[derive(Debug)]
-enum BlockingSqliteError {
-    Sqlite(rusqlite::Error),
-    Worker,
-}
-
-struct AuditAppendJob {
-    ledger_world: &'static str,
-    event_type: &'static str,
-    target: String,
-    body_sha256: String,
-    size: i64,
-    content_type: String,
-    headers: Vec<(String, String)>,
-    key: Vec<u8>,
-}
+// `AuditAppendJob` and `BlockingSqliteError` moved to `state.rs` —
+// they're used by `Core::append_to_ledger` (the cached-writer entry
+// point that replaced the pre-cache `audit_append_blocking` here)
+// and re-exported via `pub(crate) use crate::state::*;` in `main.rs`.
+// `world_exists_blocking` is gone too: ledger existence is tracked
+// by the `delete_ledger_created` AtomicBool, swapped to true on the
+// first successful append in this process.
 
 fn blocking_storage_error(scope: &str, err: BlockingSqliteError) -> Response {
     match err {
         BlockingSqliteError::Sqlite(err) => storage_error(scope, err),
         BlockingSqliteError::Worker => server_error(format!("{scope} worker failed")),
-    }
-}
-
-async fn world_exists_blocking(
-    data: std::path::PathBuf,
-    world_name: &'static str,
-) -> Result<bool, BlockingSqliteError> {
-    match tokio::task::spawn_blocking(move || {
-        world::open_existing(&data, world_name).map(|existing| existing.is_some())
-    })
-    .await
-    {
-        Ok(Ok(existed)) => Ok(existed),
-        Ok(Err(err)) => Err(BlockingSqliteError::Sqlite(err)),
-        Err(_) => Err(BlockingSqliteError::Worker),
-    }
-}
-
-async fn audit_append_blocking(
-    data: std::path::PathBuf,
-    job: AuditAppendJob,
-) -> Result<String, BlockingSqliteError> {
-    match tokio::task::spawn_blocking(move || {
-        audit::append(
-            &data,
-            job.ledger_world,
-            job.event_type,
-            &job.target,
-            &job.body_sha256,
-            job.size,
-            &job.content_type,
-            &job.headers,
-            &job.key,
-        )
-    })
-    .await
-    {
-        Ok(Ok(h)) => Ok(h),
-        Ok(Err(err)) => Err(BlockingSqliteError::Sqlite(err)),
-        Err(_) => Err(BlockingSqliteError::Worker),
     }
 }

--- a/core/src/handler/delete.rs
+++ b/core/src/handler/delete.rs
@@ -1,9 +1,9 @@
 //! DELETE verb implementation + its blocking-SQLite helpers.
 //!
 //! Extracted from `handler.rs` so DELETE's intent / commit /
-//! commit_failed two-step audit dance — and the blocking-spawn
+//! commit_failed two-step audit dance -- and the blocking-spawn
 //! helpers it needs (`AuditAppendJob`, `world_exists_blocking`,
-//! `audit_append_blocking`) — live in their own file. This is the
+//! `audit_append_blocking`) -- live in their own file. This is the
 //! first of two post-PR-4c extractions that bring `handler.rs`
 //! back under the 500-line ceiling; the second
 //! (`crate::handler::post`) lands the same shape.
@@ -32,7 +32,7 @@ pub(crate) async fn execute_delete(
     core: &Core,
     trace: &TraceCtx,
 ) -> Phase {
-    // DELETE is approve-only across all paths — no harvard split.
+    // DELETE is approve-only across all paths -- no harvard split.
     if !can_delete(tier) {
         return Phase::Error {
             resp: unauthorized("delete requires token; system worlds need approve token"),
@@ -88,7 +88,7 @@ pub(crate) async fn execute_delete(
         .to_string();
     // The cached `ledger_writer` Mutex serializes ledger appends, so
     // the prior `acquire_world_lock("var/log/deletes")` calls are
-    // gone — this Mutex provides the same ordering guarantee with no
+    // gone -- this Mutex provides the same ordering guarantee with no
     // extra async hop. Ledger existence is tracked by
     // `delete_ledger_created` AtomicBool: initialized at startup from
     // `world::sizes`, and atomically swapped to true on the first
@@ -113,12 +113,12 @@ pub(crate) async fn execute_delete(
         };
     }
     trace.emit_aux("audit_intent");
-    // Bump the durable_world_count exactly once — the first append in
+    // Bump the durable_world_count exactly once -- the first append in
     // this process run that observes the flag still false is the one
     // that "created" the ledger world (or first observed it after
     // startup). `swap` returns the *prior* value, so `was_first` is
     // true only for that one caller; concurrent DELETEs racing on the
-    // same false→true edge are serialized by the ledger_writer Mutex
+    // same false->true edge are serialized by the ledger_writer Mutex
     // inside `append_to_ledger`, so the swap here always runs after
     // a successful append. AcqRel matches the load-on-startup pattern
     // in main.rs (Acquire) and keeps the durable_world_count bump
@@ -128,7 +128,25 @@ pub(crate) async fn execute_delete(
         core.durable_world_count.fetch_add(1, Ordering::Relaxed);
     }
 
+    // Drain the read cache and install a tombstone BEFORE the
+    // physical delete. The drain waits for in-flight readers on
+    // this world to release, then `mem::replace` Tombstone closes
+    // the cached fd inside the slot's write-guard window. By the
+    // time `delete_world_blocking` runs, no fd is alive on the
+    // world's DB -- Windows file-in-use can't occur. New readers
+    // arriving in the evict->delete window see the tombstone via
+    // Phase 1 and short-circuit to 404. See
+    // `crate::read_cache::ReadCache::install_tombstone_blocking`
+    // and AGENTS.md section "No fallback to unguarded paths".
+    core.install_tombstone(&world).await;
+    trace.emit_aux("read_cache_drained");
+
     let ok = core.delete_world_blocking(&world).await;
+    // Clear the tombstone on BOTH success and failure (Bug 20). On
+    // failure, the world is still on disk; without this clear, GET
+    // would return a phantom 404 forever -- contract regression vs
+    // pre-cache behaviour where DELETE-fail kept the world readable.
+    core.clear_tombstone(&world);
     if !ok {
         return Phase::Error {
             resp: server_error("delete failed after audit intent".to_string()),
@@ -153,10 +171,10 @@ pub(crate) async fn execute_delete(
     core.notify("DELETE", &world, "");
     trace.emit_aux("notify_sent");
 
-    // commit / commit_failed appends — same `ledger_writer` Mutex
+    // commit / commit_failed appends -- same `ledger_writer` Mutex
     // serializes ordering of audit chain entries across concurrent
     // DELETEs on different target worlds. Intent and commit from the
-    // same DELETE may interleave with a different DELETE's intent —
+    // same DELETE may interleave with a different DELETE's intent --
     // intentional; the chain is HMAC-linked, not grouped by target
     // world.
     if let Err(commit_err) = core
@@ -173,8 +191,8 @@ pub(crate) async fn execute_delete(
         .await
     {
         // Honest cascade-failure trace. The world is already gone, so
-        // we still return 204 — the write side of the DELETE
-        // succeeded — but the audit chain is now in a degraded state
+        // we still return 204 -- the write side of the DELETE
+        // succeeded -- but the audit chain is now in a degraded state
         // and the operator MUST see exactly which kind. eprintln stays
         // (PR 0 contract): even with trace disabled, stderr carries
         // the failure.
@@ -205,7 +223,7 @@ pub(crate) async fn execute_delete(
                 // Sub-case B: BOTH appends failed (e.g. persistent
                 // DiskFull). Audit chain has only `delete_intent`,
                 // indistinguishable from "process crashed between
-                // intent and commit" by chain alone — but the trace
+                // intent and commit" by chain alone -- but the trace
                 // and the eprintln preserve the truth that the
                 // commit was attempted and failed twice.
                 eprintln!(
@@ -224,9 +242,9 @@ pub(crate) async fn execute_delete(
     Phase::CommittedWrite((StatusCode::NO_CONTENT, "").into_response())
 }
 
-// ─── DELETE blocking helpers ──────────────────────────────────────
+// --- DELETE blocking helpers --------------------------------------
 //
-// `AuditAppendJob` and `BlockingSqliteError` moved to `state.rs` —
+// `AuditAppendJob` and `BlockingSqliteError` moved to `state.rs` --
 // they're used by `Core::append_to_ledger` (the cached-writer entry
 // point that replaced the pre-cache `audit_append_blocking` here)
 // and re-exported via `pub(crate) use crate::state::*;` in `main.rs`.

--- a/core/src/handler/post.rs
+++ b/core/src/handler/post.rs
@@ -1,4 +1,4 @@
-//! POST verb implementation — append to an existing world.
+//! POST verb implementation -- append to an existing world.
 //!
 //! Extracted from `handler.rs` so the four verb implementations
 //! (GET / HEAD / PUT / POST) plus the dispatcher fit comfortably
@@ -38,7 +38,7 @@ pub(crate) async fn execute_post(
     trace: &TraceCtx,
 ) -> Phase {
     // POST appends to an existing world. PUT is the create/replace
-    // path — POST returns 404 if the world is absent and never
+    // path -- POST returns 404 if the world is absent and never
     // updates X-Meta-* headers (which are PUT-only).
     if !can_write(&world, tier) {
         let gate = if needs_write_approve(&world) {
@@ -53,6 +53,9 @@ pub(crate) async fn execute_post(
     }
     let _write_guard = core.acquire_world_lock(&world).await;
     trace.emit_aux("lock_acquired");
+    // Defence-in-depth tombstone clear (Bug 19). Mirrors the same
+    // call in `execute_put`. See that doc-comment for rationale.
+    core.clear_tombstone(&world);
     if let Err(resp) = hs::check_write_preconditions(core, &world, &headers) {
         let reason = if resp.status() == StatusCode::PRECONDITION_FAILED {
             ErrorReason::PreconditionFailed

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -56,7 +56,7 @@ pub(crate) enum BlockingSqliteError {
 pub(crate) struct LedgerWriter {
     /// `None` until the first successful `world::open` in
     /// `append`. Subsequent appends reuse the cached connection.
-    /// Never invalidated — the ledger world is never deleted by
+    /// Never invalidated -- the ledger world is never deleted by
     /// user-facing DELETE (`var/log/*` is reserved).
     conn: StdMutex<Option<Connection>>,
     /// Counter; bumped after each `None -> Some` transition.
@@ -74,7 +74,7 @@ impl LedgerWriter {
     /// Append one row to `var/log/deletes` using the cached
     /// connection. Lazy-initializes via `world::open` on the first
     /// successful call. Increments `inits` only after `world::open`
-    /// succeeds — failed opens leave the slot as `None` and do not
+    /// succeeds -- failed opens leave the slot as `None` and do not
     /// count.
     ///
     /// Caller wraps this in `tokio::task::spawn_blocking` (see

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -1,0 +1,109 @@
+//! Audit ledger writer cache.
+//!
+//! `var/log/deletes` is the hottest open() in the codebase: every
+//! DELETE used to open it 2-3 times (existence check + intent
+//! append + commit append). This module caches one write
+//! `Connection` per process and serializes appends through a
+//! single `StdMutex`. Lazy-initialized on first append.
+//!
+//! The counter (`inits`) tracks `None -> Some` transitions of the
+//! inner `Mutex<Option<Connection>>`. In steady state the value is
+//! 1 (lazy init on first DELETE in the process). Higher values
+//! surface re-init events that would otherwise be invisible from
+//! outside (e.g., a future code path resetting the writer for
+//! recovery). `/proc/pool` emits this as a `counter` metric.
+//!
+//! The wrapped types live in their own module to keep `Core`'s
+//! field surface narrow: `Core::ledger: Arc<LedgerWriter>` is one
+//! field instead of two, and the `append` body lives next to the
+//! state it touches. `state.rs` stays under the 500-line budget.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex as StdMutex;
+
+use rusqlite::Connection;
+
+use crate::audit;
+use crate::world;
+
+/// One audit append's input. Owns its strings/buffers because the
+/// `spawn_blocking` closure that runs the SQL must be `'static`.
+pub(crate) struct AuditAppendJob {
+    pub(crate) ledger_world: &'static str,
+    pub(crate) event_type: &'static str,
+    pub(crate) target: String,
+    pub(crate) body_sha256: String,
+    pub(crate) size: i64,
+    pub(crate) content_type: String,
+    pub(crate) headers: Vec<(String, String)>,
+    pub(crate) key: Vec<u8>,
+}
+
+/// Result of an audit append run inside `spawn_blocking`. Shared
+/// between the cached path here and the verb handlers
+/// (`handler::execute_delete`).
+#[derive(Debug)]
+pub(crate) enum BlockingSqliteError {
+    Sqlite(rusqlite::Error),
+    Worker,
+}
+
+/// Cached writer + init counter for `var/log/deletes`. The inner
+/// `StdMutex` is the SOLE serializer for ledger appends; the
+/// per-world write lock at `var/log/deletes` is intentionally
+/// gone (Bug 25). Don't re-add it.
+pub(crate) struct LedgerWriter {
+    /// `None` until the first successful `world::open` in
+    /// `append`. Subsequent appends reuse the cached connection.
+    /// Never invalidated — the ledger world is never deleted by
+    /// user-facing DELETE (`var/log/*` is reserved).
+    conn: StdMutex<Option<Connection>>,
+    /// Counter; bumped after each `None -> Some` transition.
+    pub(crate) inits: AtomicUsize,
+}
+
+impl LedgerWriter {
+    pub(crate) fn new() -> Self {
+        Self {
+            conn: StdMutex::new(None),
+            inits: AtomicUsize::new(0),
+        }
+    }
+
+    /// Append one row to `var/log/deletes` using the cached
+    /// connection. Lazy-initializes via `world::open` on the first
+    /// successful call. Increments `inits` only after `world::open`
+    /// succeeds — failed opens leave the slot as `None` and do not
+    /// count.
+    ///
+    /// Caller wraps this in `tokio::task::spawn_blocking` (see
+    /// `Core::append_to_ledger`) so the inner `StdMutex` doesn't
+    /// stall a Tokio worker when contended.
+    pub(crate) fn append(
+        &self,
+        data: &Path,
+        job: AuditAppendJob,
+    ) -> Result<String, BlockingSqliteError> {
+        let mut guard = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        if guard.is_none() {
+            // Lazy init. `world::open` creates the schema; safe to
+            // call whether or not the ledger DB exists on disk.
+            let conn = world::open(data, job.ledger_world).map_err(BlockingSqliteError::Sqlite)?;
+            *guard = Some(conn);
+            self.inits.fetch_add(1, Ordering::Relaxed);
+        }
+        let conn = guard.as_mut().expect("ledger connection initialized above");
+        audit::append_with_conn(
+            conn,
+            job.event_type,
+            &job.target,
+            &job.body_sha256,
+            job.size,
+            &job.content_type,
+            &job.headers,
+            &job.key,
+        )
+        .map_err(BlockingSqliteError::Sqlite)
+    }
+}

--- a/core/src/listen.rs
+++ b/core/src/listen.rs
@@ -245,7 +245,10 @@ mod tests {
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
             world_locks: Arc::new(DashMap::new()),
-            ledger_writer: Arc::new(StdMutex::new(None)),
+            ledger: Arc::new(crate::ledger::LedgerWriter::new()),
+            read_cache: Arc::new(crate::read_cache::ReadCache::new(
+                crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+            )),
         });
 
         let resp = handler(
@@ -285,7 +288,10 @@ mod tests {
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
             world_locks: Arc::new(DashMap::new()),
-            ledger_writer: Arc::new(StdMutex::new(None)),
+            ledger: Arc::new(crate::ledger::LedgerWriter::new()),
+            read_cache: Arc::new(crate::read_cache::ReadCache::new(
+                crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+            )),
         };
         {
             let mut log = core.event_log.lock().unwrap();
@@ -333,7 +339,10 @@ mod tests {
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
             world_locks: Arc::new(DashMap::new()),
-            ledger_writer: Arc::new(StdMutex::new(None)),
+            ledger: Arc::new(crate::ledger::LedgerWriter::new()),
+            read_cache: Arc::new(crate::read_cache::ReadCache::new(
+                crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+            )),
         };
         {
             let mut log = core.event_log.lock().unwrap();

--- a/core/src/listen.rs
+++ b/core/src/listen.rs
@@ -245,6 +245,7 @@ mod tests {
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
             world_locks: Arc::new(DashMap::new()),
+            ledger_writer: Arc::new(StdMutex::new(None)),
         });
 
         let resp = handler(
@@ -284,6 +285,7 @@ mod tests {
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
             world_locks: Arc::new(DashMap::new()),
+            ledger_writer: Arc::new(StdMutex::new(None)),
         };
         {
             let mut log = core.event_log.lock().unwrap();
@@ -331,6 +333,7 @@ mod tests {
             next_event: Arc::new(AtomicU64::new(0)),
             next_request: Arc::new(AtomicU64::new(0)),
             world_locks: Arc::new(DashMap::new()),
+            ledger_writer: Arc::new(StdMutex::new(None)),
         };
         {
             let mut log = core.event_log.lock().unwrap();

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -44,11 +44,13 @@ mod coap;
 mod config;
 mod handler;
 mod http_semantics;
+mod ledger;
 mod listen;
 mod middleware;
 mod path;
 mod pipeline;
 mod proc;
+mod read_cache;
 mod response;
 mod route;
 mod state;
@@ -145,7 +147,10 @@ async fn main() {
         next_event: Arc::new(AtomicU64::new(0)),
         next_request: Arc::new(AtomicU64::new(0)),
         world_locks: Arc::new(DashMap::new()),
-        ledger_writer: Arc::new(StdMutex::new(None)),
+        ledger: Arc::new(crate::ledger::LedgerWriter::new()),
+        read_cache: Arc::new(crate::read_cache::ReadCache::new(
+            crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+        )),
     });
 
     let addr = listen_addr(&host, port);
@@ -2310,7 +2315,7 @@ mod tests {
         assert!(core.read_world("home/delete-cas").unwrap().is_none());
         assert!(core.read_world("var/log/deletes").unwrap().is_some());
         assert!(matches!(
-            audit::verify_chain(&core.data, "var/log/deletes", &core.hmac_key).unwrap(),
+            core.cached_verify_chain("var/log/deletes").unwrap(),
             Some(audit::VerifyReport::Valid(_))
         ));
         let ledger = world::open_existing(&core.data, "var/log/deletes")
@@ -2981,7 +2986,10 @@ mod tests {
                     next_event: Arc::new(AtomicU64::new(0)),
                     next_request: Arc::new(AtomicU64::new(0)),
                     world_locks: Arc::new(DashMap::new()),
-                    ledger_writer: Arc::new(StdMutex::new(None)),
+                    ledger: Arc::new(crate::ledger::LedgerWriter::new()),
+                    read_cache: Arc::new(crate::read_cache::ReadCache::new(
+                        crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+                    )),
                 }
             },
             dir,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -145,6 +145,7 @@ async fn main() {
         next_event: Arc::new(AtomicU64::new(0)),
         next_request: Arc::new(AtomicU64::new(0)),
         world_locks: Arc::new(DashMap::new()),
+        ledger_writer: Arc::new(StdMutex::new(None)),
     });
 
     let addr = listen_addr(&host, port);
@@ -1779,9 +1780,9 @@ mod tests {
         let (core, dir) = test_core("if-match-hmac");
         core.write_world("home/cas", b"one", "text/plain; charset=utf-8", &[])
             .unwrap();
-        let h = audit::append(
-            &core.data,
-            "home/cas",
+        let mut conn = world::open(&core.data, "home/cas").unwrap();
+        let h = audit::append_with_conn(
+            &mut conn,
             "put",
             "home/cas",
             &world::sha256_hex(b"one"),
@@ -1791,6 +1792,7 @@ mod tests {
             &core.hmac_key,
         )
         .unwrap();
+        drop(conn);
         let etag = format!("\"{}\"", hs::hmac_etag(&h));
 
         let mut good = HeaderMap::new();
@@ -2500,6 +2502,71 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_first_deletes_increment_world_count_exactly_once() {
+        // Bug 16 race coverage. Three concurrent DELETEs on a fresh
+        // Core (delete_ledger_created starts false). The ledger gets
+        // created on the first DELETE that wins the
+        // `swap(true, AcqRel)` edge — exactly one of them sees
+        // was_first=true and bumps `durable_world_count`. The other
+        // two see the swap-already-true and skip the bump.
+        //
+        // Setup: PUT three distinct worlds (durable_world_count = 3).
+        // Then run three concurrent DELETEs in parallel.
+        // Final state: durable_world_count = 3 + 1[ledger creation,
+        // exactly once] - 3[three deletes succeed] = 1.
+        //
+        // Without Bug 16's `swap` ordering, two or all three of the
+        // racing DELETEs would each independently observe
+        // delete_ledger_created==false (via world_exists_blocking)
+        // and each bump the counter, leading to drift. With the
+        // atomic swap, only the unique false→true transition bumps.
+        let (core, dir) = test_core("concurrent-first-deletes");
+        let headers = HeaderMap::new();
+        for w in ["home/a", "home/b", "home/c"] {
+            let put = unwrap_response(
+                execute_put(
+                    headers.clone(),
+                    Bytes::from_static(b"x"),
+                    auth::Tier::Write,
+                    w.to_string(),
+                    &core,
+                    &TraceCtx::disabled(),
+                )
+                .await,
+            );
+            assert_eq!(put.status(), StatusCode::CREATED);
+        }
+        assert_eq!(core.durable_world_count.load(Ordering::Relaxed), 3);
+        assert!(!core.delete_ledger_created.load(Ordering::Relaxed));
+
+        let state = Arc::new(core);
+        let s1 = state.clone();
+        let s2 = state.clone();
+        let s3 = state.clone();
+        let h1 = headers.clone();
+        let h2 = headers.clone();
+        let h3 = headers.clone();
+        let trace1 = TraceCtx::disabled();
+        let trace2 = TraceCtx::disabled();
+        let trace3 = TraceCtx::disabled();
+        let (r1, r2, r3) = tokio::join!(
+            execute_delete(h1, auth::Tier::Approve, "home/a".to_string(), &s1, &trace1),
+            execute_delete(h2, auth::Tier::Approve, "home/b".to_string(), &s2, &trace2),
+            execute_delete(h3, auth::Tier::Approve, "home/c".to_string(), &s3, &trace3),
+        );
+        assert_eq!(unwrap_response(r1).status(), StatusCode::NO_CONTENT);
+        assert_eq!(unwrap_response(r2).status(), StatusCode::NO_CONTENT);
+        assert_eq!(unwrap_response(r3).status(), StatusCode::NO_CONTENT);
+
+        // 3 (original) + 1 (ledger creation, exactly once) - 3 (three
+        // deletes) = 1.
+        assert_eq!(state.durable_world_count.load(Ordering::Relaxed), 1);
+        assert!(state.delete_ledger_created.load(Ordering::Relaxed));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     async fn response_text(resp: Response) -> String {
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
@@ -2914,6 +2981,7 @@ mod tests {
                     next_event: Arc::new(AtomicU64::new(0)),
                     next_request: Arc::new(AtomicU64::new(0)),
                     world_locks: Arc::new(DashMap::new()),
+                    ledger_writer: Arc::new(StdMutex::new(None)),
                 }
             },
             dir,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,4 +1,4 @@
-//! elastik-core — bedrock HTTP+SQLite+HMAC.
+//! elastik-core -- bedrock HTTP+SQLite+HMAC.
 //!
 //! The core has one semantic interface: method + path + representation bytes.
 //! HTTP is the first-class surface. SCoAP is a small UDP-curl surface because
@@ -7,24 +7,24 @@
 //!
 //! v5.0 grammar:
 //!
-//!   GET    /<world>                → body bytes with stored Content-Type
-//!   HEAD   /<world>                → metadata headers, no body
-//!   PUT    /<world>                → replace body, update meta, audit
-//!   POST   /<world>                → append to body, no meta change, audit
-//!   DELETE /<world>                → drop world (sqlite) or evict (memory)
-//!   GET    /proc/worlds            → text/plain, one world per line
-//!   GET    /proc/version           → "elastik-core <ver> (rust)\n"
+//!   GET    /<world>                -> body bytes with stored Content-Type
+//!   HEAD   /<world>                -> metadata headers, no body
+//!   PUT    /<world>                -> replace body, update meta, audit
+//!   POST   /<world>                -> append to body, no meta change, audit
+//!   DELETE /<world>                -> drop world (sqlite) or evict (memory)
+//!   GET    /proc/worlds            -> text/plain, one world per line
+//!   GET    /proc/version           -> "elastik-core <ver> (rust)\n"
 //!
 //! Path prefix decides backend (one core, one port, no two daemons):
 //!
-//!   /home/* /etc/* /lib/* /boot/* /usr/* /var/*  → SQLite, durable, audited
-//!   /tmp/*  /dev/*  /sys/*                       → memory, transient
+//!   /home/* /etc/* /lib/* /boot/* /usr/* /var/*  -> SQLite, durable, audited
+//!   /tmp/*  /dev/*  /sys/*                       -> memory, transient
 //!
 //! Out of scope (deliberately):
-//!   protocol bridges      → SDK clients / external endpoint apps
-//!   AI shaping/routing    → SDK clients / external endpoint apps
-//!   /lib/* code running   → never in core; /lib is inert storage
-//!   application behavior  → outside core, expressed as HTTP
+//!   protocol bridges      -> SDK clients / external endpoint apps
+//!   AI shaping/routing    -> SDK clients / external endpoint apps
+//!   /lib/* code running   -> never in core; /lib is inert storage
+//!   application behavior  -> outside core, expressed as HTTP
 //!
 //! Env:
 //!   ELASTIK_HOST           default 127.0.0.1
@@ -115,6 +115,10 @@ async fn main() {
         env_nonzero_usize("ELASTIK_LISTEN_REPLAY_MAX", DEFAULT_LISTEN_REPLAY_MAX);
     let coap_max_in_flight =
         env_nonzero_usize("ELASTIK_COAP_MAX_IN_FLIGHT", DEFAULT_COAP_MAX_IN_FLIGHT);
+    let read_cache_max_entries = env_nonzero_usize(
+        "ELASTIK_READ_CACHE_MAX_ENTRIES",
+        crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
+    );
     std::fs::create_dir_all(&data).expect("create data dir");
     let durable_sizes = world::sizes(&data).expect("read durable storage usage");
     let storage_body_bytes = durable_sizes.iter().map(|(_, size)| *size).sum();
@@ -148,9 +152,7 @@ async fn main() {
         next_request: Arc::new(AtomicU64::new(0)),
         world_locks: Arc::new(DashMap::new()),
         ledger: Arc::new(crate::ledger::LedgerWriter::new()),
-        read_cache: Arc::new(crate::read_cache::ReadCache::new(
-            crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
-        )),
+        read_cache: Arc::new(crate::read_cache::ReadCache::new(read_cache_max_entries)),
     });
 
     let addr = listen_addr(&host, port);
@@ -358,8 +360,8 @@ mod tests {
     use std::sync::{Mutex as TestMutex, OnceLock};
 
     /// PR 4c: 50 unit tests below were renamed mechanically from
-    /// `handle_*` (sync `&Core → Response`) to `execute_*` (async
-    /// `&Core, &TraceCtx → Phase`). The verb-handler entry point
+    /// `handle_*` (sync `&Core -> Response`) to `execute_*` (async
+    /// `&Core, &TraceCtx -> Phase`). The verb-handler entry point
     /// returns `Phase`, but the assertions all operate on the
     /// underlying `Response`. This helper unwraps the three terminal
     /// `Phase` variants `execute_*` can return so tests can keep
@@ -2507,12 +2509,103 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
+    #[tokio::test]
+    async fn proc_pool_emits_metrics_with_type_labels() {
+        // Warm the cache via a PUT + GET, then assert the metrics
+        // body has the right counter / snapshot labels and tracks
+        // hits + misses correctly. After a DELETE the
+        // `ledger_writer_inits` counter must bump from 0 to 1
+        // (lazy-init fired exactly once).
+        let (core, dir) = test_core("proc-pool-metrics");
+        let headers = HeaderMap::new();
+
+        let put = unwrap_response(
+            execute_put(
+                headers.clone(),
+                Bytes::from_static(b"hello"),
+                auth::Tier::Write,
+                "home/m".to_string(),
+                &core,
+                &TraceCtx::disabled(),
+            )
+            .await,
+        );
+        assert_eq!(put.status(), StatusCode::CREATED);
+
+        // First GET = miss (Phase 3); second GET = hit (Phase 1).
+        for _ in 0..2 {
+            let get = unwrap_response(
+                execute_get(
+                    headers.clone(),
+                    auth::Tier::Read,
+                    "home/m".to_string(),
+                    &core,
+                    &TraceCtx::disabled(),
+                )
+                .await,
+            );
+            assert_eq!(get.status(), StatusCode::OK);
+        }
+
+        let state = Arc::new(core);
+        let resp = proc_pool(State(state.clone()), Method::GET, headers.clone()).await;
+        let body = response_text(resp).await;
+
+        assert!(body.contains("read_cache_entries 1 snapshot\n"));
+        assert!(body.contains("read_cache_tombstones 0 snapshot\n"));
+        assert!(body.contains("read_cache_hits 1 counter\n"));
+        assert!(body.contains("read_cache_misses 1 counter\n"));
+        assert!(body.contains("read_cache_capped 0 counter\n"));
+        assert!(body.contains("read_cache_open_fails 0 counter\n"));
+        assert!(body.contains("read_cache_max_entries "));
+        // No DELETE issued yet -- ledger writer never lazy-inited.
+        assert!(body.contains("ledger_writer_inits 0 counter\n"));
+
+        // After a DELETE, the lazy-init fires exactly once
+        // (Codex P3: counter not snapshot).
+        let _ = unwrap_response(
+            execute_delete(
+                headers.clone(),
+                auth::Tier::Approve,
+                "home/m".to_string(),
+                &state,
+                &TraceCtx::disabled(),
+            )
+            .await,
+        );
+        let resp2 = proc_pool(State(state), Method::GET, headers).await;
+        let body2 = response_text(resp2).await;
+        assert!(
+            body2.contains("ledger_writer_inits 1 counter\n"),
+            "expected counter to bump to 1 after first DELETE; body=\n{body2}"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proc_pool_requires_read_token_when_enabled() {
+        // Codex P3 sub-finding: /proc/pool exposes read-cache and
+        // ledger writer internals -- match the auth-deny coverage of
+        // /proc/du and /proc/df. With a read token configured, an
+        // unauthenticated GET must return 401, not leak metrics.
+        let (mut core, dir) = test_core("proc-pool-read-token");
+        core.tokens.read = Some(b"reader".to_vec());
+        let state = Arc::new(core);
+        let headers = HeaderMap::new();
+
+        let resp = proc_pool(State(state), Method::GET, headers).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_first_deletes_increment_world_count_exactly_once() {
         // Bug 16 race coverage. Three concurrent DELETEs on a fresh
         // Core (delete_ledger_created starts false). The ledger gets
         // created on the first DELETE that wins the
-        // `swap(true, AcqRel)` edge — exactly one of them sees
+        // `swap(true, AcqRel)` edge -- exactly one of them sees
         // was_first=true and bumps `durable_world_count`. The other
         // two see the swap-already-true and skip the bump.
         //
@@ -2525,7 +2618,7 @@ mod tests {
         // racing DELETEs would each independently observe
         // delete_ledger_created==false (via world_exists_blocking)
         // and each bump the counter, leading to drift. With the
-        // atomic swap, only the unique false→true transition bumps.
+        // atomic swap, only the unique false->true transition bumps.
         let (core, dir) = test_core("concurrent-first-deletes");
         let headers = HeaderMap::new();
         for w in ["home/a", "home/b", "home/c"] {
@@ -2583,10 +2676,10 @@ mod tests {
     //
     // The white-box tests above call `execute_get` / `execute_head`
     // / `execute_put` / `execute_post` / `execute_delete` directly
-    // (renamed mechanically from `handle_*` in PR 4c) — they cover
+    // (renamed mechanically from `handle_*` in PR 4c) -- they cover
     // verb-handler logic in isolation. The tests below call
     // `pipeline::run` with the same Core fixture, exercising the
-    // `world_handler → pipeline::run → handler::execute` route that
+    // `world_handler -> pipeline::run -> handler::execute` route that
     // every real request now takes. Without these, a bug in the
     // pipeline wiring (path canonicalization, auth threading,
     // dispatch, response construction in the handler) would not be
@@ -2718,7 +2811,7 @@ mod tests {
     /// (`State` + `Extension<RequestId>` + `Method` + `AxPath` +
     /// `HeaderMap` + `Bytes`) wires up correctly and `world_handler`
     /// routes GET to the pipeline. Goes through `tower::oneshot` so
-    /// the `add_core_response_headers` middleware fires too — that
+    /// the `add_core_response_headers` middleware fires too -- that
     /// way we can assert the unified `x-request-id` header lands on
     /// the response.
     #[tokio::test]
@@ -2752,7 +2845,7 @@ mod tests {
         // same id (`pipeline::run` reads RequestId from extensions
         // rather than allocating its own). The fact that this
         // header is present on the response is what the unification
-        // fix guarantees — without it, the bug would slip through
+        // fix guarantees -- without it, the bug would slip through
         // again silently.
         let req_id_header = resp
             .headers()

--- a/core/src/proc.rs
+++ b/core/src/proc.rs
@@ -263,10 +263,14 @@ pub(crate) async fn proc_audit_verify(
         return audit_not_applicable();
     }
 
-    let data = core.data.clone();
-    let hmac_key = core.hmac_key.clone();
+    // Bug 58 fix: route through the read cache so DELETE on the same
+    // world drains in-flight verifies via the slot's write guard.
+    // The bare `audit::verify_chain(data, world, key)` path is gone
+    // -- it opened a fresh fd outside SlotState and would have
+    // re-introduced Bug 48 / Bug 54-shape races on this admin endpoint.
+    let core_clone = core.clone();
     let verify_result = match tokio::task::spawn_blocking(move || {
-        audit::verify_chain(&data, &world_name, &hmac_key)
+        core_clone.cached_verify_chain(&world_name)
     })
     .await
     {

--- a/core/src/proc.rs
+++ b/core/src/proc.rs
@@ -222,6 +222,83 @@ pub(crate) async fn proc_df(
     proc_text_response(method, body)
 }
 
+// /proc/pool -- read connection cache + ledger writer metrics.
+//
+// One line per metric, mirroring /proc/df's text shape. Each line
+// has a `counter` or `snapshot` type label so an operator polling
+// the endpoint can tell monotonic-from-startup deltas (counter)
+// from instantaneous gauges (snapshot). Mirrors Prometheus's
+// counter/gauge convention.
+//
+// The DashMap walk for `read_cache_tombstones` (O(N) in cache size,
+// cap=5000 default) and the snapshot of `read_cache_entries` both
+// run inside `spawn_blocking`. Atomic counter loads stay on the
+// async task -- they don't block. Same pattern as `proc_du` and
+// `proc_df`. (Codex P2.)
+pub(crate) async fn proc_pool(
+    State(core): State<Arc<Core>>,
+    method: Method,
+    headers: HeaderMap,
+) -> Response {
+    if method == Method::OPTIONS {
+        return options_response(PROC_ALLOW);
+    }
+    if method != Method::GET && method != Method::HEAD {
+        return method_not_allowed(PROC_ALLOW);
+    }
+    if let Err(resp) = require_read(&core, &headers) {
+        return *resp;
+    }
+
+    let hits = core
+        .read_cache
+        .metrics
+        .read_cache_hits
+        .load(Ordering::Relaxed);
+    let misses = core
+        .read_cache
+        .metrics
+        .read_cache_misses
+        .load(Ordering::Relaxed);
+    let capped = core
+        .read_cache
+        .metrics
+        .read_cache_capped
+        .load(Ordering::Relaxed);
+    let open_fails = core
+        .read_cache
+        .metrics
+        .read_cache_open_fails
+        .load(Ordering::Relaxed);
+    let ledger_inits = core.ledger.inits.load(Ordering::Relaxed);
+    let max_entries = core.read_cache.max_entries;
+
+    let read_cache = core.read_cache.clone();
+    let snapshot = match tokio::task::spawn_blocking(move || {
+        let entries = read_cache.snapshot_entries();
+        let tombstones = read_cache.snapshot_tombstones();
+        (entries, tombstones)
+    })
+    .await
+    {
+        Ok(snap) => snap,
+        Err(_) => return server_error("proc pool worker failed".to_string()),
+    };
+    let (entries, tombstones) = snapshot;
+
+    let body = format!(
+        "read_cache_entries {entries} snapshot\n\
+         read_cache_tombstones {tombstones} snapshot\n\
+         read_cache_hits {hits} counter\n\
+         read_cache_misses {misses} counter\n\
+         read_cache_capped {capped} counter\n\
+         read_cache_open_fails {open_fails} counter\n\
+         read_cache_max_entries {max_entries} snapshot\n\
+         ledger_writer_inits {ledger_inits} counter\n"
+    );
+    proc_text_response(method, body)
+}
+
 // /proc/audit/{world}/verify
 pub(crate) async fn proc_audit_verify(
     State(core): State<Arc<Core>>,

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -1,0 +1,775 @@
+//! Per-world read connection cache.
+//!
+//! Caches one open SQLite connection per recently-read world so that
+//! GET / HEAD don't re-pay the ~456-700us `Connection::open_with_flags`
+//! cost on every request. The naive approach -- `DashMap<String,
+//! Mutex<Connection>>` -- has a race: DELETE removes the map entry,
+//! but in-flight readers holding cloned Arcs continue using their
+//! cached fd. Linux gets an orphan inode (harmless); Windows fails
+//! the unlink with sharing-violation (DELETE 500).
+//!
+//! This module is the v7.1 design distilled from ten review rounds
+//! (see `docs/architecture/sqlite-connection-pool.md`). The
+//! invariants encoded here:
+//!
+//! 1. **Slot-before-open** -- a reader reserves a slot in
+//!    `SlotState::Opening` via the DashMap Entry API BEFORE calling
+//!    `Connection::open_with_flags`, and holds the slot's
+//!    `inner.write()` guard for the duration of the open. DELETE's
+//!    drain blocks behind that guard. fd lifetime is tracked by the
+//!    synchronization primitive, not by chance.
+//! 2. **Tombstone protocol** -- DELETE replaces the slot's state with
+//!    `Tombstone` inside the write guard window, so the previous
+//!    `Ready(Mutex<Connection>)`'s Connection drops INSIDE the guard.
+//!    No fd is alive when `delete_world_blocking` runs.
+//! 3. **Drain before remove** -- at-cap "transient" slots (cap reached,
+//!    we install a slot for one read and then remove it) drain the
+//!    slot before removing -- `arc.inner.write()` waits for any
+//!    Phase-1-cache-hit clones to release their read guards, then
+//!    `mem::replace` Tombstone closes the fd. The map entry is then
+//!    safe to remove. See AGENTS.md section "Drain before remove."
+//! 4. **Type-system enforcement** -- `TrackedReadConnection` wraps
+//!    `rusqlite::Connection`. Its constructor (`from_raw`) is
+//!    module-private and called only from `OpeningTransition::promote`.
+//!    Read functions in `world.rs` consume `&mut TrackedReadConnection`,
+//!    so opening a bare `Connection` and reading through it is a
+//!    type error. See AGENTS.md section "Physics, not policy."
+//!
+//! Sync vs async -- the cache uses `std::sync::RwLock` so the read
+//! path stays sync and matches the existing
+//! `Core::read_world_with_etag` signature (no caller churn). Callers
+//! that need to install a tombstone wrap `install_tombstone_blocking`
+//! in `tokio::task::spawn_blocking` so the drain doesn't stall a
+//! Tokio worker (the same pattern DELETE already uses for
+//! `delete_world_blocking`).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use rusqlite::{ffi::ErrorCode, Connection, OpenFlags};
+
+use crate::world;
+
+/// Default ceiling on the number of cached read slots. Per-conn
+/// memory is bounded to ~250KB (PRAGMA cache_size=-200), so 5000
+/// caps resident at ~1.25 GB. Operators with larger working sets
+/// raise via `ELASTIK_READ_CACHE_MAX_ENTRIES` (wired in PR 3).
+pub(crate) const DEFAULT_READ_CACHE_MAX_ENTRIES: usize = 5000;
+
+/// SQLite busy_timeout for cached read connections. Tighter than
+/// the 5000ms `world::open` default because queued readers under
+/// writer contention compound the deadline; a per-conn 1000ms keeps
+/// the Mutex-queue tail bounded.
+const READ_CONN_BUSY_TIMEOUT_MS: u64 = 1000;
+
+/// Newtype around `rusqlite::Connection` that gates read access at
+/// the type level. The only constructor (`from_raw`) is reachable
+/// solely from `OpeningTransition::promote` below -- no other code
+/// in the crate can mint one. `world::read_with_hmac_via_conn`
+/// consumes `&mut TrackedReadConnection`, which means the bypass
+/// "open a Connection and run the SQL on it" doesn't compile.
+///
+/// See AGENTS.md section "Physics, not policy."
+pub(crate) struct TrackedReadConnection(Connection);
+
+impl TrackedReadConnection {
+    /// Module-private constructor. The only call site in the crate
+    /// is `OpeningTransition::promote`. Intentionally not exposed
+    /// outside this file.
+    fn from_raw(conn: Connection) -> Self {
+        Self(conn)
+    }
+
+    /// Mutable access to the wrapped Connection for the SQL body of
+    /// `world::read_with_hmac_via_conn`. `pub(crate)` -- callers must
+    /// already hold a `&mut TrackedReadConnection`, and the only
+    /// path to that is through `read_via_slot`. Future `world.rs`
+    /// read helpers must also take `&mut TrackedReadConnection` to
+    /// preserve the type gate.
+    pub(crate) fn as_mut_conn(&mut self) -> &mut Connection {
+        &mut self.0
+    }
+}
+
+/// Per-world read slot lifecycle state.
+///
+/// Visibility note (Codex P1): no `pub` modifier -- module-private.
+/// Sibling modules cannot construct `SlotState::Opening` and feed
+/// it through `OpeningTransition::promote` to mint a
+/// `TrackedReadConnection`. The bypass that an earlier draft of this
+/// PR allowed is now uncompilable from outside `read_cache.rs`.
+enum SlotState {
+    Opening,
+    Ready(StdMutex<TrackedReadConnection>),
+    Tombstone,
+}
+
+/// Same module-private treatment -- `Arc<ReadSlot>` is held inside
+/// `ReadCache.read_conns` (a private field), and there is no public
+/// API that exposes the inner `RwLock<SlotState>` to callers.
+struct ReadSlot {
+    inner: StdRwLock<SlotState>,
+}
+
+/// RAII guard for the Opening -> Ready/Tombstone transition. Without
+/// it, a panic during `Connection::open`, `busy_timeout`, or
+/// `pragma_update` would leave the slot stuck in `Opening`.
+///
+/// Visibility (Codex P1): no `pub` modifier. The whole point of v10
+/// is that `OpeningTransition::promote` is the only call site for
+/// `TrackedReadConnection::from_raw`; if `OpeningTransition::new`
+/// itself were `pub(crate)`, sibling modules could chain
+/// `OpeningTransition::new(&mut SlotState::Opening).promote(c)` and
+/// the type seal would be "ugly to write" rather than uncompilable.
+struct OpeningTransition<'a> {
+    state: &'a mut SlotState,
+    finalized: bool,
+}
+
+impl<'a> OpeningTransition<'a> {
+    fn new(state: &'a mut SlotState) -> Self {
+        Self {
+            state,
+            finalized: false,
+        }
+    }
+
+    /// Open succeeded. Wrap the connection (the ONLY
+    /// `TrackedReadConnection::from_raw` call site in the crate).
+    fn promote(mut self, conn: Connection) {
+        let tracked = TrackedReadConnection::from_raw(conn);
+        *self.state = SlotState::Ready(StdMutex::new(tracked));
+        self.finalized = true;
+    }
+
+    fn fail(mut self) {
+        *self.state = SlotState::Tombstone;
+        self.finalized = true;
+    }
+}
+
+impl<'a> Drop for OpeningTransition<'a> {
+    fn drop(&mut self) {
+        if !self.finalized {
+            *self.state = SlotState::Tombstone;
+        }
+    }
+}
+
+/// Test-only constructor for `TrackedReadConnection`. Available
+/// to other modules' `#[cfg(test)]` blocks (notably the schema-
+/// corruption test in `world.rs`) so a raw `Connection` can be
+/// wrapped without going through `OpeningTransition::promote`.
+///
+/// `pub(crate)` ONLY under `#[cfg(test)]`. In production builds
+/// this function does not exist; the only path to a
+/// `TrackedReadConnection` remains `OpeningTransition::promote`.
+/// The function name is deliberately verbose so any future call
+/// site is self-documenting as a test bypass.
+///
+/// See AGENTS.md section "Physics, not policy" -- production code path
+/// has zero bypasses; test code is allowed a single, named
+/// bypass that lives in `cfg(test)`.
+#[cfg(test)]
+pub(crate) fn test_only_wrap_raw_connection(conn: Connection) -> TrackedReadConnection {
+    TrackedReadConnection::from_raw(conn)
+}
+
+/// Atomic counters for /proc/pool.
+#[derive(Default)]
+pub(crate) struct ReadCacheMetrics {
+    pub(crate) read_cache_hits: AtomicUsize,
+    pub(crate) read_cache_misses: AtomicUsize,
+    pub(crate) read_cache_capped: AtomicUsize,
+    pub(crate) read_cache_open_fails: AtomicUsize,
+}
+
+/// Per-world read connection cache.
+///
+/// Visibility (Codex P1): `read_conns` is module-private. The slot
+/// state machine is internal -- all mutations go through this
+/// module's methods (`cached_read_with_hmac`, `read_transient`,
+/// `install_tombstone_blocking`, `clear_tombstone`). Two
+/// `pub(crate)` accessors (`max_entries` for /proc/pool's display;
+/// `metrics` for /proc/pool's atomic reads) expose just the
+/// observability surface -- never the slots themselves.
+pub(crate) struct ReadCache {
+    read_conns: DashMap<String, Arc<ReadSlot>>,
+    pub(crate) max_entries: usize,
+    pub(crate) metrics: ReadCacheMetrics,
+}
+
+impl ReadCache {
+    pub(crate) fn new(max_entries: usize) -> Self {
+        Self {
+            read_conns: DashMap::new(),
+            max_entries,
+            metrics: ReadCacheMetrics::default(),
+        }
+    }
+
+    /// Read body + meta + latest hmac via the cached read path.
+    /// Thin wrapper over the generic `with_tracked_conn` machinery.
+    pub(crate) fn cached_read_with_hmac(
+        &self,
+        data: &std::path::Path,
+        world: &str,
+    ) -> rusqlite::Result<Option<(world::Stage, Option<String>)>> {
+        self.with_tracked_conn(data, world, world::read_with_hmac_via_conn)
+    }
+
+    /// Verify the audit chain through the cached read path (Bug 58).
+    /// Same SlotState protocol as `cached_read_with_hmac` — DELETE
+    /// drains in-flight verifies via the slot's write guard. Closes
+    /// the v10 type-gate gap on the admin
+    /// `/proc/audit/{world}/verify` endpoint.
+    pub(crate) fn cached_verify_chain(
+        &self,
+        data: &std::path::Path,
+        world: &str,
+        key: &[u8],
+    ) -> rusqlite::Result<Option<crate::audit::VerifyReport>> {
+        let key = key.to_vec();
+        self.with_tracked_conn(data, world, move |conn| {
+            crate::audit::verify_chain_via_conn(conn, &key)
+        })
+    }
+
+    /// Run a closure with a `&mut TrackedReadConnection` obtained
+    /// through the SlotState protocol. Three-phase split:
+    ///   1. Cache hit (any state, regardless of cap)
+    ///   2. Cache miss + cap reached -> transient tracked slot
+    ///   3. Cache miss + room -> slot-before-open lazy-init
+    ///
+    /// `Ok(None)` means the world's DB is missing (404). `Err(_)`
+    /// is propagated for real storage errors. The closure runs at
+    /// most once and returns its own `rusqlite::Result<R>`.
+    fn with_tracked_conn<F, R>(
+        &self,
+        data: &std::path::Path,
+        world: &str,
+        f: F,
+    ) -> rusqlite::Result<Option<R>>
+    where
+        F: FnOnce(&mut TrackedReadConnection) -> rusqlite::Result<R>,
+    {
+        let path = world::world_db(data, world);
+
+        // PHASE 1 -- Cache hit (any state).
+        if let Some(arc) = self.read_conns.get(world).map(|e| e.value().clone()) {
+            self.metrics.read_cache_hits.fetch_add(1, Ordering::Relaxed);
+            return self.invoke_via_slot(arc, f);
+        }
+        self.metrics
+            .read_cache_misses
+            .fetch_add(1, Ordering::Relaxed);
+
+        // PHASE 2 -- Cache miss + cap reached: transient tracked slot.
+        if self.read_conns.len() >= self.max_entries {
+            self.metrics
+                .read_cache_capped
+                .fetch_add(1, Ordering::Relaxed);
+            return self.invoke_transient(&path, world, f);
+        }
+
+        // PHASE 3 -- Cache miss + room: slot-before-open lazy-init.
+        match path.try_exists() {
+            Ok(false) => return Ok(None),
+            Ok(true) => {}
+            Err(_) => {
+                // Defer to the open: if metadata is unreadable, the
+                // open itself will surface the actual error.
+            }
+        }
+
+        let new_slot = Arc::new(ReadSlot {
+            inner: StdRwLock::new(SlotState::Opening),
+        });
+        let arc = self
+            .read_conns
+            .entry(world.to_string())
+            .or_insert_with(|| new_slot.clone())
+            .value()
+            .clone();
+        let we_own_slot = Arc::ptr_eq(&arc, &new_slot);
+
+        if we_own_slot {
+            let mut g = arc.inner.write().unwrap_or_else(|p| p.into_inner());
+            if matches!(&*g, SlotState::Opening) {
+                let transition = OpeningTransition::new(&mut g);
+                let init: rusqlite::Result<Connection> = (|| {
+                    let c = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+                    c.busy_timeout(Duration::from_millis(READ_CONN_BUSY_TIMEOUT_MS))?;
+                    c.pragma_update(None, "cache_size", -200)?;
+                    Ok(c)
+                })();
+                match init {
+                    Ok(c) => transition.promote(c),
+                    Err(e) => {
+                        transition.fail();
+                        drop(g);
+                        self.read_conns
+                            .remove_if(world, |_k, v| Arc::ptr_eq(v, &arc));
+                        self.metrics
+                            .read_cache_open_fails
+                            .fetch_add(1, Ordering::Relaxed);
+                        if matches!(e.sqlite_error_code(), Some(ErrorCode::CannotOpen))
+                            && matches!(path.try_exists(), Ok(false))
+                        {
+                            return Ok(None);
+                        }
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        self.invoke_via_slot(arc, f)
+    }
+
+    fn invoke_transient<F, R>(
+        &self,
+        path: &std::path::Path,
+        world: &str,
+        f: F,
+    ) -> rusqlite::Result<Option<R>>
+    where
+        F: FnOnce(&mut TrackedReadConnection) -> rusqlite::Result<R>,
+    {
+        // Fast-path: slot already exists (concurrent reader installed
+        // one, or DELETE installed a tombstone).
+        if let Some(arc) = self.read_conns.get(world).map(|e| e.value().clone()) {
+            return self.invoke_via_slot(arc, f);
+        }
+
+        let transient_slot = Arc::new(ReadSlot {
+            inner: StdRwLock::new(SlotState::Opening),
+        });
+        let arc = self
+            .read_conns
+            .entry(world.to_string())
+            .or_insert_with(|| transient_slot.clone())
+            .value()
+            .clone();
+        let we_own_slot = Arc::ptr_eq(&arc, &transient_slot);
+
+        if we_own_slot {
+            let mut g = arc.inner.write().unwrap_or_else(|p| p.into_inner());
+            if matches!(&*g, SlotState::Opening) {
+                let transition = OpeningTransition::new(&mut g);
+                let init: rusqlite::Result<Connection> = (|| {
+                    let c = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+                    c.busy_timeout(Duration::from_millis(READ_CONN_BUSY_TIMEOUT_MS))?;
+                    c.pragma_update(None, "cache_size", -200)?;
+                    Ok(c)
+                })();
+                match init {
+                    Ok(c) => transition.promote(c),
+                    Err(e) => {
+                        transition.fail();
+                        drop(g);
+                        self.read_conns
+                            .remove_if(world, |_k, v| Arc::ptr_eq(v, &arc));
+                        self.metrics
+                            .read_cache_open_fails
+                            .fetch_add(1, Ordering::Relaxed);
+                        if matches!(e.sqlite_error_code(), Some(ErrorCode::CannotOpen))
+                            && matches!(path.try_exists(), Ok(false))
+                        {
+                            return Ok(None);
+                        }
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        let result = self.invoke_via_slot(arc.clone(), f);
+
+        // Drain-before-remove (Bug 54): write guard, mem::replace
+        // Tombstone (drops Connection inside guard window -- fd
+        // close happens here), drop guard, then remove_if.
+        if we_own_slot {
+            {
+                let mut g = arc.inner.write().unwrap_or_else(|p| p.into_inner());
+                let old = std::mem::replace(&mut *g, SlotState::Tombstone);
+                drop(old);
+                drop(g);
+            }
+            self.read_conns
+                .remove_if(world, |_k, v| Arc::ptr_eq(v, &arc));
+        }
+        result
+    }
+
+    fn invoke_via_slot<F, R>(&self, arc: Arc<ReadSlot>, f: F) -> rusqlite::Result<Option<R>>
+    where
+        F: FnOnce(&mut TrackedReadConnection) -> rusqlite::Result<R>,
+    {
+        let read_guard = arc.inner.read().unwrap_or_else(|p| p.into_inner());
+        match &*read_guard {
+            SlotState::Ready(tracked_mutex) => {
+                let mut tracked = tracked_mutex.lock().unwrap_or_else(|p| p.into_inner());
+                f(&mut tracked).map(Some)
+            }
+            SlotState::Tombstone => Ok(None),
+            SlotState::Opening => Ok(None),
+        }
+    }
+
+    /// Sync version. DELETE callers wrap this in `spawn_blocking` so
+    /// the drain wait doesn't stall a Tokio worker.
+    pub(crate) fn install_tombstone_blocking(&self, world: &str) {
+        let new_tombstone = Arc::new(ReadSlot {
+            inner: StdRwLock::new(SlotState::Tombstone),
+        });
+        let prev = self.read_conns.insert(world.to_string(), new_tombstone);
+        if let Some(prev_slot) = prev {
+            let mut g = prev_slot.inner.write().unwrap_or_else(|p| p.into_inner());
+            let old = std::mem::replace(&mut *g, SlotState::Tombstone);
+            drop(old);
+            drop(g);
+        }
+    }
+
+    /// Remove the tombstone after `delete_world_blocking` returns.
+    /// Called on BOTH success and failure (Bug 20): on failure, the
+    /// world is still on disk; the next read should lazy-init a
+    /// fresh slot rather than seeing a phantom 404.
+    pub(crate) fn clear_tombstone(&self, world: &str) {
+        self.read_conns.remove(world);
+    }
+
+    /// Snapshot accessors for /proc/pool. Marked `dead_code`-allow
+    /// because the `/proc/pool` endpoint that consumes them lands
+    /// in the next PR (PR 3, observability).
+    #[allow(dead_code)]
+    pub(crate) fn snapshot_entries(&self) -> usize {
+        self.read_conns.len()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn snapshot_tombstones(&self) -> usize {
+        self.read_conns
+            .iter()
+            .filter(|e| {
+                e.value()
+                    .inner
+                    .try_read()
+                    .map(|g| matches!(*g, SlotState::Tombstone))
+                    .unwrap_or(false)
+            })
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        let mut d = std::env::temp_dir();
+        d.push(format!(
+            "elastik-readcache-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn cache_hit_on_second_read() {
+        let dir = scratch_dir("hit");
+        let world = "home/cache-hit";
+        let _c = world::open(&dir, world).unwrap();
+        world::write(&dir, world, b"hello", "text/plain", &[]).unwrap();
+
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+
+        let r1 = cache.cached_read_with_hmac(&dir, world).unwrap();
+        assert!(r1.is_some());
+        assert_eq!(cache.metrics.read_cache_hits.load(Ordering::Relaxed), 0);
+        assert_eq!(cache.metrics.read_cache_misses.load(Ordering::Relaxed), 1);
+
+        let r2 = cache.cached_read_with_hmac(&dir, world).unwrap();
+        assert!(r2.is_some());
+        assert_eq!(cache.metrics.read_cache_hits.load(Ordering::Relaxed), 1);
+        assert_eq!(cache.metrics.read_cache_misses.load(Ordering::Relaxed), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_world_returns_none_via_phase3() {
+        let dir = scratch_dir("missing");
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+        let r = cache.cached_read_with_hmac(&dir, "home/none").unwrap();
+        assert!(r.is_none());
+        assert!(cache.read_conns.get("home/none").is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn install_tombstone_short_circuits_read_to_404() {
+        let dir = scratch_dir("tombstone");
+        let world = "home/tomb";
+        let _c = world::open(&dir, world).unwrap();
+        world::write(&dir, world, b"x", "text/plain", &[]).unwrap();
+
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+        let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
+        cache.install_tombstone_blocking(world);
+        let r = cache.cached_read_with_hmac(&dir, world).unwrap();
+        assert!(r.is_none());
+
+        cache.clear_tombstone(world);
+        let r2 = cache.cached_read_with_hmac(&dir, world).unwrap();
+        assert!(r2.is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cap_uses_transient_slot_then_drains_and_removes() {
+        let dir = scratch_dir("cap-transient");
+        for w in ["home/a", "home/b", "home/c"] {
+            let _c = world::open(&dir, w).unwrap();
+            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+        }
+
+        let cache = ReadCache::new(2);
+        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        assert_eq!(cache.read_conns.len(), 2);
+        assert_eq!(cache.metrics.read_cache_capped.load(Ordering::Relaxed), 0);
+
+        let r = cache.cached_read_with_hmac(&dir, "home/c").unwrap();
+        assert!(r.is_some());
+        assert!(cache.read_conns.get("home/c").is_none());
+        assert!(cache.read_conns.get("home/a").is_some());
+        assert!(cache.read_conns.get("home/b").is_some());
+        assert_eq!(cache.metrics.read_cache_capped.load(Ordering::Relaxed), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_hit_serves_from_cache_even_at_cap() {
+        let dir = scratch_dir("cap-hit");
+        for w in ["home/a", "home/b"] {
+            let _c = world::open(&dir, w).unwrap();
+            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+        }
+
+        let cache = ReadCache::new(2);
+        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        let hits_before = cache.metrics.read_cache_hits.load(Ordering::Relaxed);
+        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let hits_after = cache.metrics.read_cache_hits.load(Ordering::Relaxed);
+        assert_eq!(hits_after, hits_before + 1);
+        assert_eq!(cache.metrics.read_cache_capped.load(Ordering::Relaxed), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn opening_transition_drop_sets_tombstone_on_panic_path() {
+        let slot = Arc::new(ReadSlot {
+            inner: StdRwLock::new(SlotState::Opening),
+        });
+        {
+            let mut g = slot.inner.write().unwrap();
+            let _t = OpeningTransition::new(&mut g);
+            // Drop _t without finalize.
+        }
+        let g = slot.inner.read().unwrap();
+        assert!(matches!(*g, SlotState::Tombstone));
+    }
+
+    // -- Bug 58 (audit verify routes through SlotState) -------------
+    //
+    // Verifies that `cached_verify_chain` uses the same slot-before-
+    // open dance as `cached_read_with_hmac`: a verify after a write
+    // populates the cache, a tombstone short-circuits to None, and
+    // a fresh verify after clear_tombstone re-opens. If
+    // `proc_audit_verify` were still calling the bare
+    // `audit::verify_chain` path, this test would still pass for
+    // happy cases but the SlotState protocol's drain guarantee
+    // would not hold for the admin endpoint -- the test pins the
+    // routing, not just the SQL semantics.
+    #[test]
+    fn cached_verify_chain_uses_slot_protocol() {
+        let dir = scratch_dir("verify-slot");
+        let world = "home/audited";
+        // Seed an audit chain: a single write_with_audit_checked
+        // produces a `put` event whose hmac chains to a synthetic
+        // genesis (prev = ""). `WriteAuditError` doesn't derive
+        // Debug, so don't .unwrap() on it -- match instead.
+        match world::write_with_audit_checked(
+            &dir,
+            world,
+            b"hello",
+            "text/plain",
+            &[],
+            b"key",
+            None,
+        ) {
+            Ok(_) => {}
+            Err(_) => panic!("seed write_with_audit_checked failed"),
+        }
+
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+
+        // Phase 3 lazy-init: first verify warms the cache.
+        let r1 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        assert!(matches!(r1, Some(crate::audit::VerifyReport::Valid(_))));
+        assert!(
+            cache.read_conns.get(world).is_some(),
+            "expected the verify to populate the SlotState cache; \
+             a regression to the bare audit::verify_chain path would \
+             leave the map empty"
+        );
+
+        // Phase 1 cache hit: second verify reuses the cached slot.
+        let r2 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        assert!(matches!(r2, Some(crate::audit::VerifyReport::Valid(_))));
+
+        // Tombstone short-circuits verify (DELETE intent).
+        cache.install_tombstone_blocking(world);
+        let r3 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        assert!(r3.is_none());
+
+        // After clear_tombstone the next verify re-opens through
+        // Phase 3 lazy-init.
+        cache.clear_tombstone(world);
+        let r4 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        assert!(matches!(r4, Some(crate::audit::VerifyReport::Valid(_))));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -- Bug 54 (drain-before-remove for transient slots) ----------
+    //
+    // Single-threaded `cap_uses_transient_slot_then_drains_and_removes`
+    // above covers the install + cleanup ordering on one thread. It
+    // does NOT cover the actual race the v9 round closed: a Phase 1
+    // cache hit lands on the same transient Arc while the owner is
+    // mid-cleanup. The owner's `mem::replace(Tombstone)` must drop the
+    // Connection inside the write-guard window, so any clone the
+    // hitter still holds either finishes before drain (sees Ready,
+    // succeeds) or arrives after drain (sees Tombstone, returns
+    // `Ok(None)`). Neither case leaves an fd alive past the cleanup.
+    #[test]
+    fn cap_transient_slot_concurrent_readers_safe_under_cleanup() {
+        use std::sync::Arc as StdArc;
+        use std::thread;
+
+        let dir = StdArc::new(scratch_dir("cap-transient-concurrent"));
+        for w in ["home/a", "home/b", "home/c"] {
+            let _c = world::open(&dir, w).unwrap();
+            world::write(&dir, w, b"hello world", "text/plain", &[]).unwrap();
+        }
+
+        // cap=2 -> A and B fill it; C must go through transient.
+        let cache = StdArc::new(ReadCache::new(2));
+        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+
+        // Spawn 4 concurrent readers all targeting world C. Whoever
+        // wins the Entry race owns the transient slot and runs the
+        // drain-before-remove cleanup; the others either cache-hit
+        // the same Arc (Phase 1) or arrive after cleanup (cache miss
+        // -> install fresh transient). All must succeed without
+        // returning a torn / partial body.
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let cache = cache.clone();
+            let dir = dir.clone();
+            handles.push(thread::spawn(move || {
+                cache
+                    .cached_read_with_hmac(&dir, "home/c")
+                    .expect("read")
+                    .expect("body")
+            }));
+        }
+        for h in handles {
+            let (stage, _hmac) = h.join().expect("thread");
+            assert_eq!(stage.body, b"hello world");
+            assert_eq!(stage.content_type, "text/plain");
+        }
+
+        // After all readers complete, the transient slot should be
+        // gone (cleanup ran). A and B remain (persistent slots).
+        assert!(cache.read_conns.get("home/c").is_none());
+        assert!(cache.read_conns.get("home/a").is_some());
+        assert!(cache.read_conns.get("home/b").is_some());
+
+        let _ = std::fs::remove_dir_all(&*dir);
+    }
+
+    // -- Bug 43 CANTOPEN classification ----------------------------
+    //
+    // `path.try_exists()` returning `Ok(false)` -> 404 (file is
+    // genuinely gone). Other variants (`Ok(true)` for unreadable
+    // file, `Err(_)` for metadata failure) -> propagate the SQLite
+    // error so the verb maps to 500/507 via
+    // `is_insufficient_storage_error`. v6 collapsed all CANTOPEN
+    // into 404; v7 introduced the recheck; v9 (Bug 49) tightened
+    // `path.exists()` -> `path.try_exists()` so metadata errors stop
+    // collapsing into a spurious 404.
+    //
+    // The missing-file -> 404 case is exercised by
+    // `missing_world_returns_none_via_phase3` above. The
+    // existing-but-unreadable case requires Unix file mode flips
+    // and is therefore `cfg(unix)`-gated.
+    #[cfg(unix)]
+    #[test]
+    fn cantopen_with_existing_unreadable_file_propagates_500_not_404() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = scratch_dir("cantopen-existing");
+        let world = "home/locked";
+        let _c = world::open(&dir, world).unwrap();
+        world::write(&dir, world, b"hello", "text/plain", &[]).unwrap();
+
+        // chmod 000 the universe.db so SQLite returns CANTOPEN even
+        // though the file is genuinely on disk.
+        let db_path = world::world_db(&dir, world);
+        let mut perms = std::fs::metadata(&db_path).unwrap().permissions();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&db_path, perms).unwrap();
+
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+        let result = cache.cached_read_with_hmac(&dir, world);
+
+        // path.try_exists() returns Ok(true) for the still-on-disk
+        // (but unreadable) file. The CANTOPEN error must propagate
+        // as Err, not collapse into Ok(None). Don't format `result`
+        // with {:?} -- `world::Stage` does not derive Debug, so a
+        // Linux test compile would fail; map to a small status
+        // string instead.
+        let outcome = match &result {
+            Ok(Some(_)) => "Ok(Some(_)) <- spurious read",
+            Ok(None) => "Ok(None) <- spurious 404",
+            Err(_) => "Err(_)",
+        };
+        assert!(
+            result.is_err(),
+            "CANTOPEN on existing-but-unreadable file must propagate as Err(_); \
+             got {outcome} (a future regression to bare path.exists() would land here)"
+        );
+
+        // Restore perms so cleanup works.
+        let mut perms = std::fs::metadata(&db_path).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&db_path, perms).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -221,7 +221,7 @@ impl ReadCache {
     }
 
     /// Verify the audit chain through the cached read path (Bug 58).
-    /// Same SlotState protocol as `cached_read_with_hmac` — DELETE
+    /// Same SlotState protocol as `cached_read_with_hmac` -- DELETE
     /// drains in-flight verifies via the slot's write guard. Closes
     /// the v10 type-gate gap on the admin
     /// `/proc/audit/{world}/verify` endpoint.

--- a/core/src/route.rs
+++ b/core/src/route.rs
@@ -20,8 +20,8 @@ use axum::{
 };
 
 use crate::{
-    listen, options_response, pipeline, proc_audit_verify, proc_df, proc_du, proc_reserved,
-    proc_version, proc_worlds, root_hint, Core, WORLD_ALLOW,
+    listen, options_response, pipeline, proc_audit_verify, proc_df, proc_du, proc_pool,
+    proc_reserved, proc_version, proc_worlds, root_hint, Core, WORLD_ALLOW,
 };
 
 pub(crate) fn build_app(state: Arc<Core>, max_world_bytes: usize) -> Router {
@@ -32,6 +32,7 @@ pub(crate) fn build_app(state: Arc<Core>, max_world_bytes: usize) -> Router {
         .route("/proc/worlds", any(proc_worlds))
         .route("/proc/du", any(proc_du))
         .route("/proc/df", any(proc_df))
+        .route("/proc/pool", any(proc_pool))
         .route("/proc/audit/*audit_path", any(proc_audit_verify))
         .route("/proc", any(proc_reserved))
         .route("/proc/*reserved", any(proc_reserved))

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -32,7 +32,7 @@ use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 use crate::http_semantics as hs;
 use crate::world::Stage;
 use crate::{
-    auth, can_write, listen, payload_too_large, server_error, storage_error,
+    audit, auth, can_write, listen, payload_too_large, server_error, storage_error,
     storage_quota_exceeded, store, unauthorized, world,
 };
 
@@ -78,6 +78,46 @@ pub(crate) struct Core {
     /// unsafe when waiters hold a clone of the Arc). DashMap shards
     /// reads, so lookup is mostly lock-free.
     pub(crate) world_locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
+    /// Cached writer for the `var/log/deletes` audit ledger. The
+    /// ledger is the hottest open() in the codebase — every DELETE
+    /// opens it 2-3 times under the pre-cache flow (existence
+    /// check, intent append, commit append). One cached connection
+    /// covers all of them.
+    ///
+    /// The inner `StdMutex<Option<Connection>>` is the SOLE
+    /// serializer for ledger appends. Earlier drafts of `Core`
+    /// also held the per-world lock at `var/log/deletes` for the
+    /// same purpose; that lock is removed by this PR as redundant
+    /// with this Mutex. Don't re-add it.
+    ///
+    /// Lazy init: `None` until the first `append_to_ledger`
+    /// succeeds; from then on, every append reuses the cached
+    /// connection. Never invalidated (the ledger world is never
+    /// deleted by user-facing DELETE — `var/log/*` is reserved).
+    pub(crate) ledger_writer: Arc<StdMutex<Option<rusqlite::Connection>>>,
+}
+
+/// Result of an audit append run inside `spawn_blocking`. Shared
+/// between `Core::append_to_ledger` (this module) and
+/// `handler::delete::execute_delete` (which is the only caller in
+/// the FSM today).
+#[derive(Debug)]
+pub(crate) enum BlockingSqliteError {
+    Sqlite(rusqlite::Error),
+    Worker,
+}
+
+/// One audit append's input. Owns its strings/buffers because the
+/// `spawn_blocking` closure that runs the SQL must be `'static`.
+pub(crate) struct AuditAppendJob {
+    pub(crate) ledger_world: &'static str,
+    pub(crate) event_type: &'static str,
+    pub(crate) target: String,
+    pub(crate) body_sha256: String,
+    pub(crate) size: i64,
+    pub(crate) content_type: String,
+    pub(crate) headers: Vec<(String, String)>,
+    pub(crate) key: Vec<u8>,
 }
 
 impl Core {
@@ -176,6 +216,51 @@ impl Core {
             Ok(self.mem.metadata(world))
         } else {
             world::metadata(&self.data, world)
+        }
+    }
+
+    /// Append one row to the `var/log/deletes` audit ledger using the
+    /// cached `ledger_writer` connection. Lazy-initializes the
+    /// connection on first call (`world::open` creates the schema if
+    /// needed; idempotent on subsequent restarts because of
+    /// `CREATE TABLE IF NOT EXISTS`).
+    ///
+    /// Replaces the prior pattern of `world::open` per append (2-3
+    /// opens per DELETE today). The inner `StdMutex` serializes
+    /// concurrent appends — appends happen inside a blocking task,
+    /// so this parks an OS thread when contended; the surrounding
+    /// per-world write lock at `var/log/deletes` is gone, traded for
+    /// this single mutex.
+    pub(crate) async fn append_to_ledger(
+        &self,
+        job: AuditAppendJob,
+    ) -> Result<String, BlockingSqliteError> {
+        let data = self.data.clone();
+        let writer = self.ledger_writer.clone();
+        let result = tokio::task::spawn_blocking(move || -> rusqlite::Result<String> {
+            let mut guard = writer.lock().unwrap_or_else(|p| p.into_inner());
+            if guard.is_none() {
+                // Lazy init. `world::open` creates the schema; safe to
+                // call whether or not the ledger DB exists on disk.
+                *guard = Some(world::open(&data, job.ledger_world)?);
+            }
+            let conn = guard.as_mut().expect("ledger_writer initialized above");
+            audit::append_with_conn(
+                conn,
+                job.event_type,
+                &job.target,
+                &job.body_sha256,
+                job.size,
+                &job.content_type,
+                &job.headers,
+                &job.key,
+            )
+        })
+        .await;
+        match result {
+            Ok(Ok(h)) => Ok(h),
+            Ok(Err(err)) => Err(BlockingSqliteError::Sqlite(err)),
+            Err(_) => Err(BlockingSqliteError::Worker),
         }
     }
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -249,7 +249,7 @@ impl Core {
 
     /// Append one row to the `var/log/deletes` audit ledger using
     /// the cached `LedgerWriter`. Thin wrapper that runs the
-    /// blocking append on the spawn_blocking pool — the inner
+    /// blocking append on the spawn_blocking pool -- the inner
     /// StdMutex on `LedgerWriter::conn` serializes concurrent
     /// appends without holding a Tokio worker.
     pub(crate) async fn append_to_ledger(

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -30,6 +30,9 @@ use dashmap::DashMap;
 use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 
 use crate::http_semantics as hs;
+use crate::ledger::LedgerWriter;
+pub(crate) use crate::ledger::{AuditAppendJob, BlockingSqliteError};
+use crate::read_cache::ReadCache;
 use crate::world::Stage;
 use crate::{
     audit, auth, can_write, listen, payload_too_large, server_error, storage_error,
@@ -78,46 +81,20 @@ pub(crate) struct Core {
     /// unsafe when waiters hold a clone of the Arc). DashMap shards
     /// reads, so lookup is mostly lock-free.
     pub(crate) world_locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
-    /// Cached writer for the `var/log/deletes` audit ledger. The
-    /// ledger is the hottest open() in the codebase — every DELETE
-    /// opens it 2-3 times under the pre-cache flow (existence
-    /// check, intent append, commit append). One cached connection
-    /// covers all of them.
-    ///
-    /// The inner `StdMutex<Option<Connection>>` is the SOLE
-    /// serializer for ledger appends. Earlier drafts of `Core`
-    /// also held the per-world lock at `var/log/deletes` for the
-    /// same purpose; that lock is removed by this PR as redundant
-    /// with this Mutex. Don't re-add it.
-    ///
-    /// Lazy init: `None` until the first `append_to_ledger`
-    /// succeeds; from then on, every append reuses the cached
-    /// connection. Never invalidated (the ledger world is never
-    /// deleted by user-facing DELETE — `var/log/*` is reserved).
-    pub(crate) ledger_writer: Arc<StdMutex<Option<rusqlite::Connection>>>,
-}
-
-/// Result of an audit append run inside `spawn_blocking`. Shared
-/// between `Core::append_to_ledger` (this module) and
-/// `handler::delete::execute_delete` (which is the only caller in
-/// the FSM today).
-#[derive(Debug)]
-pub(crate) enum BlockingSqliteError {
-    Sqlite(rusqlite::Error),
-    Worker,
-}
-
-/// One audit append's input. Owns its strings/buffers because the
-/// `spawn_blocking` closure that runs the SQL must be `'static`.
-pub(crate) struct AuditAppendJob {
-    pub(crate) ledger_world: &'static str,
-    pub(crate) event_type: &'static str,
-    pub(crate) target: String,
-    pub(crate) body_sha256: String,
-    pub(crate) size: i64,
-    pub(crate) content_type: String,
-    pub(crate) headers: Vec<(String, String)>,
-    pub(crate) key: Vec<u8>,
+    /// Cached writer + init counter for the `var/log/deletes` audit
+    /// ledger. See `crate::ledger::LedgerWriter` for the semantics
+    /// (lazy init, `inits` counter, no `acquire_world_lock` needed
+    /// because the inner StdMutex is the sole serializer).
+    pub(crate) ledger: Arc<LedgerWriter>,
+    /// Per-world read connection cache. Implements the slot-before-open,
+    /// tombstone, and drain-before-remove protocols. See
+    /// `crate::read_cache` for the full design and the v7.1 design
+    /// doc for the ten-round review history. All read paths route
+    /// through `Core::read_world_with_etag`, which delegates to
+    /// `read_cache.cached_read_with_hmac`. DELETE installs a tombstone
+    /// before `delete_world_blocking` and clears it on both success
+    /// and failure paths.
+    pub(crate) read_cache: Arc<ReadCache>,
 }
 
 impl Core {
@@ -154,6 +131,11 @@ impl Core {
         Ok(self.read_world_with_etag(world)?.map(|(stage, _)| stage))
     }
 
+    /// Read body + meta + ETag. Routes durable worlds through the
+    /// `read_cache` (slot-before-open, tombstone-aware) so GET / HEAD
+    /// don't pay `Connection::open_with_flags` per request. Memory
+    /// worlds bypass the cache. Synchronous: the cache uses
+    /// `std::sync::RwLock`, matching the existing handler call shape.
     pub(crate) fn read_world_with_etag(
         &self,
         world: &str,
@@ -164,15 +146,61 @@ impl Core {
                 .read_with_hash(world)
                 .map(|(stage, hash)| (stage, format!("sha256-{hash}"))))
         } else {
-            Ok(
-                world::read_with_hmac(&self.data, world)?.map(|(stage, hmac)| {
+            Ok(self
+                .read_cache
+                .cached_read_with_hmac(&self.data, world)?
+                .map(|(stage, hmac)| {
                     let etag = hmac
                         .map(|h| hs::hmac_etag(&h))
                         .unwrap_or_else(|| hs::body_etag(&stage.body));
                     (stage, etag)
-                }),
-            )
+                }))
         }
+    }
+
+    /// DELETE-side: drain in-flight readers, close the cached
+    /// connection inside the slot's write guard window, install a
+    /// tombstone slot. After this returns, no fd is alive on
+    /// `world`'s DB -- `delete_world_blocking` is safe to call.
+    /// Memory worlds: no-op. The blocking drain runs inside
+    /// `spawn_blocking` so it doesn't stall a Tokio worker.
+    pub(crate) async fn install_tombstone(&self, world: &str) {
+        if store::is_memory_world(world) {
+            return;
+        }
+        let cache = self.read_cache.clone();
+        let world = world.to_string();
+        let _ = tokio::task::spawn_blocking(move || cache.install_tombstone_blocking(&world)).await;
+    }
+
+    /// Remove the tombstone after `delete_world_blocking` returns.
+    /// Called on BOTH success and failure (Bug 20): on failure the
+    /// world is still on disk, and the next read must lazy-init a
+    /// fresh slot rather than seeing a phantom 404.
+    pub(crate) fn clear_tombstone(&self, world: &str) {
+        if store::is_memory_world(world) {
+            return;
+        }
+        self.read_cache.clear_tombstone(world);
+    }
+
+    /// Verify the audit chain through the read-cache SlotState
+    /// protocol (Bug 58). Closes the gap that the bare
+    /// `audit::verify_chain` path left: DELETE on the same world
+    /// drains in-flight verifies via the slot's write guard, just
+    /// like a regular GET. Memory worlds have no audit chain;
+    /// callers (proc_audit_verify) filter those before reaching
+    /// here.
+    pub(crate) fn cached_verify_chain(
+        &self,
+        world: &str,
+    ) -> rusqlite::Result<Option<audit::VerifyReport>> {
+        debug_assert!(
+            !store::is_memory_world(world),
+            "cached_verify_chain only applies to durable worlds"
+        );
+        self.read_cache
+            .cached_verify_chain(&self.data, world, &self.hmac_key)
     }
 
     /// Test-only fixture: seed a world directly without going through
@@ -219,47 +247,19 @@ impl Core {
         }
     }
 
-    /// Append one row to the `var/log/deletes` audit ledger using the
-    /// cached `ledger_writer` connection. Lazy-initializes the
-    /// connection on first call (`world::open` creates the schema if
-    /// needed; idempotent on subsequent restarts because of
-    /// `CREATE TABLE IF NOT EXISTS`).
-    ///
-    /// Replaces the prior pattern of `world::open` per append (2-3
-    /// opens per DELETE today). The inner `StdMutex` serializes
-    /// concurrent appends — appends happen inside a blocking task,
-    /// so this parks an OS thread when contended; the surrounding
-    /// per-world write lock at `var/log/deletes` is gone, traded for
-    /// this single mutex.
+    /// Append one row to the `var/log/deletes` audit ledger using
+    /// the cached `LedgerWriter`. Thin wrapper that runs the
+    /// blocking append on the spawn_blocking pool — the inner
+    /// StdMutex on `LedgerWriter::conn` serializes concurrent
+    /// appends without holding a Tokio worker.
     pub(crate) async fn append_to_ledger(
         &self,
         job: AuditAppendJob,
     ) -> Result<String, BlockingSqliteError> {
         let data = self.data.clone();
-        let writer = self.ledger_writer.clone();
-        let result = tokio::task::spawn_blocking(move || -> rusqlite::Result<String> {
-            let mut guard = writer.lock().unwrap_or_else(|p| p.into_inner());
-            if guard.is_none() {
-                // Lazy init. `world::open` creates the schema; safe to
-                // call whether or not the ledger DB exists on disk.
-                *guard = Some(world::open(&data, job.ledger_world)?);
-            }
-            let conn = guard.as_mut().expect("ledger_writer initialized above");
-            audit::append_with_conn(
-                conn,
-                job.event_type,
-                &job.target,
-                &job.body_sha256,
-                job.size,
-                &job.content_type,
-                &job.headers,
-                &job.key,
-            )
-        })
-        .await;
-        match result {
-            Ok(Ok(h)) => Ok(h),
-            Ok(Err(err)) => Err(BlockingSqliteError::Sqlite(err)),
+        let ledger = self.ledger.clone();
+        match tokio::task::spawn_blocking(move || ledger.append(&data, job)).await {
+            Ok(result) => result,
             Err(_) => Err(BlockingSqliteError::Worker),
         }
     }
@@ -382,6 +382,12 @@ impl Core {
             return Err(payload_too_large(self.max_world_bytes));
         }
         let _write_guard = self.acquire_world_lock(world_name).await;
+        // Defence-in-depth tombstone clear (Bug 19). Same rationale
+        // as `handler::execute_put`'s clear: PUT/POST and DELETE
+        // serialize on the same per-world lock, so a prior DELETE
+        // either cleared its own tombstone (success/failure path)
+        // or panicked. This call covers the panic case.
+        self.clear_tombstone(world_name);
         if let Some(req_headers) = preconditions {
             hs::check_write_preconditions(self, world_name, req_headers)?;
         }

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -239,17 +239,21 @@ pub fn sizes(data_root: &Path) -> rusqlite::Result<Vec<(String, usize)>> {
     Ok(out)
 }
 
-/// Read body/meta and latest audit hmac through one SQLite connection.
-/// This keeps GET/HEAD from pairing an old body with a newer ETag when
-/// a write lands between two independent reads.
-pub fn read_with_hmac(
-    data_root: &Path,
-    world: &str,
-) -> rusqlite::Result<Option<(Stage, Option<String>)>> {
-    let Some(mut c) = open_existing(data_root, world)? else {
-        return Ok(None);
-    };
-    let tx = c.transaction()?;
+/// Read body/meta and latest audit hmac via a `TrackedReadConnection`
+/// owned by the SlotState cache (`Core::read_cache`). Inputs are
+/// type-gated: the only way to obtain `&mut TrackedReadConnection` is
+/// through the slot-before-open dance in `crate::read_cache`. This is
+/// the v10 enforcement -- a future contributor opening a bare
+/// `Connection` and trying to read through it gets a type error.
+///
+/// One SQLite tx covers body, headers, and the latest audit hmac, so
+/// GET/HEAD never pair an old body with a newer ETag when a write
+/// lands between independent reads.
+pub fn read_with_hmac_via_conn(
+    tracked: &mut crate::read_cache::TrackedReadConnection,
+) -> rusqlite::Result<(Stage, Option<String>)> {
+    let conn = tracked.as_mut_conn();
+    let tx = conn.transaction()?;
     let (body, content_type) = {
         let mut stmt = tx.prepare("SELECT body, content_type FROM stage_meta WHERE id=1")?;
         stmt.query_row([], |r| {
@@ -277,14 +281,14 @@ pub fn read_with_hmac(
         }
     };
     tx.commit()?;
-    Ok(Some((
+    Ok((
         Stage {
             body,
             content_type,
             headers,
         },
         latest_hmac,
-    )))
+    ))
 }
 
 /// Test-only seed primitive: write body + headers without touching the
@@ -630,7 +634,17 @@ mod tests {
         assert!(body_len(&root, "home/plain").is_err());
         assert!(metadata(&root, "home/plain").is_err());
         assert!(sizes(&root).is_err());
-        assert!(read_with_hmac(&root, "home/plain").is_err());
+        // Read path goes through ReadCache now. Wrap the bare
+        // Connection via the test-only helper exported from
+        // `read_cache` and call `read_with_hmac_via_conn` on it.
+        // The helper is `#[cfg(test)] pub(crate) fn` -- production
+        // code cannot construct a `TrackedReadConnection` outside
+        // `OpeningTransition::promote`. v10 type gate intact.
+        {
+            let conn = open(&root, "home/plain").unwrap();
+            let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+            assert!(read_with_hmac_via_conn(&mut tracked).is_err());
+        }
         assert!(append(&root, "home/plain", b"!").is_err());
 
         write(
@@ -662,10 +676,10 @@ mod tests {
     //              sqlite_bench_sketch -- --ignored --nocapture
     //
     // Used to bench-gate the v7.1 read-cache PR. Decision criteria
-    // (from §10 / Appendix A of the design doc):
-    //   < 50 µs warm  -> drop read cache, ship ledger-only fallback
-    //   50-200 µs     -> ship full plan
-    //   > 200 µs      -> ship full plan with confidence
+    // (from section10 / Appendix A of the design doc):
+    //   < 50 us warm  -> drop read cache, ship ledger-only fallback
+    //   50-200 us     -> ship full plan
+    //   > 200 us      -> ship full plan with confidence
     mod sqlite_bench_sketch {
         use super::*;
         use std::time::Instant;


### PR DESCRIPTION
## Why

PRs #117/#118/#119/#120 used a stacked-base cascade pattern. After #117 squash-merged to master, the GitHub auto-rebase did not retarget #118/#119/#120's bases to master — they stayed pointed at their predecessor cascade branches. So the squash-merges of #118/#119/#120 landed on those predecessor branches rather than on master. Master ended up with #117 only.

This PR cherry-picks the three squash commits onto a fresh branch from master and brings the cascade home.

## Cascade content (preserved as separate squash commits)

\`\`\`
c73d792  feat(core): cache var/log/deletes audit ledger writer; remove redundant world lock (#118)
02820dc  feat(core): per-world SQLite read connection cache with SlotState protocol (#119)
5fa80f5  feat(core): /proc/pool observability + ELASTIK_READ_CACHE_MAX_ENTRIES env (#120)
\`\`\`

The em-dash sweep was already incorporated into the squashes, so the cascade tip has zero non-ASCII em-dashes/arrows in the five files that the cleanup targeted.

## Verification (local Windows)

- \`cargo fmt --manifest-path core/Cargo.toml -- --check\`: clean
- \`cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings\`: clean
- \`cargo test --manifest-path core/Cargo.toml\`: **135 passed / 0 failed / 2 ignored** (the bench sketches)

## What landed across the cascade

- AGENTS.md gains three rules: "No fallback to unguarded paths", "Drain before remove", "Physics, not policy"
- Bench sketch in \`core/src/world.rs\` (\`#[cfg(test)] mod sqlite_bench_sketch\`)
- Per-world SQLite read connection cache with SlotState protocol (\`core/src/read_cache.rs\`, ~469 prod lines)
- TrackedReadConnection newtype: bypass uncompilable from production code (\`error[E0603]: struct OpeningTransition is private\`)
- Drain-before-remove for transient slots (Bug 54)
- CANTOPEN classification via \`try_exists()\` (Bug 49)
- Audit verify routes through SlotState (\`Core::cached_verify_chain\`, Bug 58)
- Ledger writer cache (\`core/src/ledger.rs\`, lazy-init counter)
- \`/proc/pool\` observability with 8 metrics (counter/snapshot labeled, spawn_blocking-wrapped)
- \`ELASTIK_READ_CACHE_MAX_ENTRIES\` env var (default 5000)
- README + .env.example updated
- 12+ new tests covering happy path, race, error, panic, auth deny, counter semantics

## Test plan

- [x] Local cargo fmt / clippy / test green
- [ ] CI green
- [ ] Squash-merge to master (or merge-commit if maintainer prefers preserving the three sub-squashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)