### PR TITLE
Verify audit chains before durable writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,13 @@ These are not preferences. They are the contract every change must keep.
   scopes, HMAC chain, change events, ETag/CAS, byte storage. Business logic
   (validation, transactional flows, schema evolution) lives in reactors and
   SDK code, not in core. Adding policy to core is a Phoenix violation.
+- **Audit chains fail loud before write.** Durable writes must verify the
+  existing HMAC chain before mutating bytes or appending an event. A missing
+  audit table, unreadable previous HMAC, broken HMAC, dropped row, schema
+  mismatch, or startup verification failure is a stop condition, never a
+  reason to recreate tables or begin a fresh chain. Enforce this as
+  mechanism: production append paths take a verified audit transaction type,
+  not a raw SQLite transaction.
 - **FSM pipeline is the contract for new verbs.** Every new HTTP verb on
   `/<world>` is one `pub(crate) async fn execute_*` exported from
   `core/src/handler.rs`. Implementations live in `handler.rs`

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,26 +4,37 @@
 //! the HTTP write.
 
 use hmac::{Hmac, Mac};
-use rusqlite::{Connection, OptionalExtension, Transaction};
+use rusqlite::{ffi, Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
-// `#[cfg(test)]` items below (`latest_hmac`, the in-module tests) need
-// `Path` and `world::world_db`. Production code reaches the audit chain
-// only via `append_with_conn` and `verify_chain_via_conn`, which both
-// take a tracked Connection from the caller and never open one.
-#[cfg(test)]
 use crate::world;
-#[cfg(test)]
 use std::path::Path;
+
+const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
+                  e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
+                  h.name, h.value
+           FROM events e
+           LEFT JOIN event_headers h ON h.event_id=e.id
+           ORDER BY e.id ASC, h.name ASC, h.value ASC"#;
+
+pub struct VerifiedAuditTx<'tx, 'conn> {
+    tx: &'tx Transaction<'conn>,
+}
+
+#[derive(Clone, Copy)]
+enum EmptyChain {
+    Allow,
+    Reject,
+}
 
 /// Append a single row to the audit chain, reusing an already-open
 /// `Connection`. Cached writers (the ledger writer
 /// `Mutex<Option<Connection>>` on `Core`) call this directly so the
 /// hot DELETE path doesn't re-open `var/log/deletes` 2-3 times per
 /// request. Per-write paths that don't cache a connection compose
-/// `world::open` + `append_with_conn` directly.
+/// `world::open` + the explicit existing/genesis append entrypoint.
 #[allow(clippy::too_many_arguments)]
-pub fn append_with_conn(
+pub fn append_with_conn_existing(
     conn: &mut Connection,
     event_type: &str,
     target: &str,
@@ -33,9 +44,59 @@ pub fn append_with_conn(
     headers: &[(String, String)],
     key: &[u8],
 ) -> rusqlite::Result<String> {
+    append_with_conn_verified(
+        conn,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+        key,
+        EmptyChain::Reject,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn append_with_conn_genesis(
+    conn: &mut Connection,
+    event_type: &str,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+    key: &[u8],
+) -> rusqlite::Result<String> {
+    append_with_conn_verified(
+        conn,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+        key,
+        EmptyChain::Allow,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_with_conn_verified(
+    conn: &mut Connection,
+    event_type: &str,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+    key: &[u8],
+    empty_chain: EmptyChain,
+) -> rusqlite::Result<String> {
     let tx = conn.transaction()?;
+    let audit_tx = verify_appendable_tx(&tx, key, empty_chain)?;
     let h = append_tx(
-        &tx,
+        &audit_tx,
         event_type,
         target,
         body_sha256,
@@ -50,7 +111,7 @@ pub fn append_with_conn(
 
 #[allow(clippy::too_many_arguments)]
 pub fn append_tx(
-    tx: &Transaction<'_>,
+    audit_tx: &VerifiedAuditTx<'_, '_>,
     event_type: &str,
     target: &str,
     body_sha256: &str,
@@ -59,6 +120,7 @@ pub fn append_tx(
     headers: &[(String, String)],
     key: &[u8],
 ) -> rusqlite::Result<String> {
+    let tx = audit_tx.tx;
     let canonical = canonical_headers(headers);
     let meta_sha256 = meta_sha256_canonical(content_type, &canonical);
     let prev = tx
@@ -125,6 +187,45 @@ pub enum VerifyReport {
     Broken(VerifyBreak),
 }
 
+pub fn verify_all_worlds(data_root: &Path, key: &[u8]) -> rusqlite::Result<()> {
+    for world_name in world::list(data_root)? {
+        verify_world(data_root, &world_name, key)?;
+    }
+    Ok(())
+}
+
+pub fn verify_world(data_root: &Path, world_name: &str, key: &[u8]) -> rusqlite::Result<()> {
+    let Some(c) = world::open_existing(data_root, world_name)? else {
+        return Ok(());
+    };
+    require_intact(verify_connection(&c, key)?)
+}
+
+pub fn verify_appendable_tx_existing<'tx, 'conn>(
+    tx: &'tx Transaction<'conn>,
+    key: &[u8],
+) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
+    verify_appendable_tx(tx, key, EmptyChain::Reject)
+}
+
+pub fn verify_appendable_tx_genesis<'tx, 'conn>(
+    tx: &'tx Transaction<'conn>,
+    key: &[u8],
+) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
+    verify_appendable_tx(tx, key, EmptyChain::Allow)
+}
+
+fn verify_appendable_tx<'tx, 'conn>(
+    tx: &'tx Transaction<'conn>,
+    key: &[u8],
+    empty_chain: EmptyChain,
+) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
+    let mut stmt = tx.prepare(AUDIT_SELECT)?;
+    let allow_empty = matches!(empty_chain, EmptyChain::Allow);
+    require_intact(verify_statement(&mut stmt, key, allow_empty)?)?;
+    Ok(VerifiedAuditTx { tx })
+}
+
 struct EventRow {
     id: i64,
     event_type: String,
@@ -163,14 +264,15 @@ pub fn verify_chain_via_conn(
 }
 
 fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyReport> {
-    let mut stmt = c.prepare(
-        r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
-                  e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
-                  h.name, h.value
-           FROM events e
-           LEFT JOIN event_headers h ON h.event_id=e.id
-           ORDER BY e.id ASC, h.name ASC, h.value ASC"#,
-    )?;
+    let mut stmt = c.prepare(AUDIT_SELECT)?;
+    verify_statement(&mut stmt, key, false)
+}
+
+fn verify_statement(
+    stmt: &mut Statement<'_>,
+    key: &[u8],
+    allow_empty: bool,
+) -> rusqlite::Result<VerifyReport> {
     let mut prev = String::new();
     let mut genesis = String::new();
     let mut events = 0usize;
@@ -218,6 +320,13 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
     }
 
     if events == 0 {
+        if allow_empty {
+            return Ok(VerifyReport::Valid(VerifyOk {
+                events: 0,
+                genesis: hmac_label(""),
+                latest: hmac_label(""),
+            }));
+        }
         return Ok(VerifyReport::Broken(VerifyBreak {
             break_at: 0,
             expected: "at-least-one-event".to_owned(),
@@ -230,6 +339,23 @@ fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyRepor
         genesis: hmac_label(&genesis),
         latest: hmac_label(&prev),
     }))
+}
+
+fn require_intact(report: VerifyReport) -> rusqlite::Result<()> {
+    match report {
+        VerifyReport::Valid(_) => Ok(()),
+        VerifyReport::Broken(break_report) => Err(audit_chain_broken_error(&break_report)),
+    }
+}
+
+fn audit_chain_broken_error(break_report: &VerifyBreak) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error::new(ffi::SQLITE_CORRUPT),
+        Some(format!(
+            "audit chain broken at event {}: expected {}, actual {}",
+            break_report.break_at, break_report.expected, break_report.actual
+        )),
+    )
 }
 
 fn verify_event(
@@ -392,7 +518,18 @@ mod tests {
     fn hmac_for(event_type: &str, target: &str) -> String {
         let c = test_connection();
         let tx = c.unchecked_transaction().unwrap();
-        append_tx(&tx, event_type, target, "abc", 3, "text/plain", &[], b"key").unwrap()
+        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        append_tx(
+            &audit_tx,
+            event_type,
+            target,
+            "abc",
+            3,
+            "text/plain",
+            &[],
+            b"key",
+        )
+        .unwrap()
     }
 
     #[test]
@@ -404,8 +541,9 @@ mod tests {
     fn verify_connection_accepts_intact_chain() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
+        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
         let h1 = append_tx(
-            &tx,
+            &audit_tx,
             "put",
             "home/a",
             "abc",
@@ -415,7 +553,17 @@ mod tests {
             b"key",
         )
         .unwrap();
-        let h2 = append_tx(&tx, "append", "home/a", "def", 6, "text/plain", &[], b"key").unwrap();
+        let h2 = append_tx(
+            &audit_tx,
+            "append",
+            "home/a",
+            "def",
+            6,
+            "text/plain",
+            &[],
+            b"key",
+        )
+        .unwrap();
         tx.commit().unwrap();
 
         let report = verify_connection(&c, b"key").unwrap();
@@ -460,8 +608,10 @@ mod tests {
         .unwrap();
 
         let tx = c.transaction().unwrap();
-        let err = append_tx(&tx, "append", "home/a", "def", 6, "text/plain", &[], b"key")
-            .expect_err("corrupt latest hmac must not be treated as an empty chain");
+        let err = match verify_appendable_tx_genesis(&tx, b"key") {
+            Ok(_) => panic!("corrupt latest hmac must not be treated as an empty chain"),
+            Err(e) => e,
+        };
 
         assert!(matches!(err, rusqlite::Error::InvalidColumnType(..)));
         let count: i64 = tx
@@ -474,7 +624,18 @@ mod tests {
     fn verify_connection_rejects_tampered_event_hmac() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        append_tx(&tx, "put", "home/a", "abc", 3, "text/plain", &[], b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        append_tx(
+            &audit_tx,
+            "put",
+            "home/a",
+            "abc",
+            3,
+            "text/plain",
+            &[],
+            b"key",
+        )
+        .unwrap();
         tx.commit().unwrap();
         c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
             .unwrap();
@@ -491,11 +652,28 @@ mod tests {
     }
 
     #[test]
+    fn startup_verification_rejects_tampered_world() {
+        let root =
+            std::env::temp_dir().join(format!("elastik-audit-startup-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        world::write_with_audit(&root, "home/a", b"abc", "text/plain", &[], b"key").unwrap();
+        {
+            let c = Connection::open(world::world_db(&root, "home/a")).unwrap();
+            c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
+                .unwrap();
+        }
+
+        assert!(verify_all_worlds(&root, b"key").is_err());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn verify_connection_rejects_tampered_event_headers() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
+        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
         append_tx(
-            &tx,
+            &audit_tx,
             "put",
             "home/a",
             "abc",

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -86,15 +86,22 @@ impl LedgerWriter {
         job: AuditAppendJob,
     ) -> Result<String, BlockingSqliteError> {
         let mut guard = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let mut created_ledger = false;
         if guard.is_none() {
             // Lazy init. `world::open` creates the schema; safe to
             // call whether or not the ledger DB exists on disk.
+            created_ledger = !world::world_db(data, job.ledger_world).exists();
             let conn = world::open(data, job.ledger_world).map_err(BlockingSqliteError::Sqlite)?;
             *guard = Some(conn);
             self.inits.fetch_add(1, Ordering::Relaxed);
         }
         let conn = guard.as_mut().expect("ledger connection initialized above");
-        audit::append_with_conn(
+        let append = if created_ledger {
+            audit::append_with_conn_genesis
+        } else {
+            audit::append_with_conn_existing
+        };
+        append(
             conn,
             job.event_type,
             &job.target,

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -69,11 +69,12 @@ pub(crate) use crate::state::*;
 
 use std::collections::VecDeque;
 use std::net::IpAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, AtomicUsize},
     Arc, Mutex as StdMutex,
 };
+use std::time::Duration;
 
 use dashmap::DashMap;
 use tokio::sync::{broadcast, watch, Semaphore};
@@ -120,15 +121,17 @@ async fn main() {
         crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES,
     );
     std::fs::create_dir_all(&data).expect("create data dir");
+    let data_lock = acquire_data_root_writer_lock(&data).expect("acquire data-root writer lock");
+    let hmac_key = hmac_key_from_env_value(std::env::var("ELASTIK_KEY").ok()).expect(
+        "ELASTIK_KEY must be a non-empty string; the audit chain has no meaning without it",
+    );
+    audit::verify_all_worlds(&data, &hmac_key).expect("verify audit chains at startup");
     let durable_sizes = world::sizes(&data).expect("read durable storage usage");
     let storage_body_bytes = durable_sizes.iter().map(|(_, size)| *size).sum();
     let durable_world_count = durable_sizes.len();
     let delete_ledger_created = durable_sizes
         .iter()
         .any(|(world_name, _)| world_name == "var/log/deletes");
-    let hmac_key = hmac_key_from_env_value(std::env::var("ELASTIK_KEY").ok()).expect(
-        "ELASTIK_KEY must be a non-empty string; the audit chain has no meaning without it",
-    );
 
     let (events, _) = broadcast::channel(listen_replay_max);
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -175,10 +178,32 @@ async fn main() {
     }
     let app = route::build_app(state, max_world_bytes);
 
-    axum::serve(listener, app)
+    let serve_result = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(shutdown_tx))
-        .await
-        .unwrap();
+        .await;
+    drop(data_lock);
+    serve_result.unwrap();
+}
+
+fn acquire_data_root_writer_lock(data: &Path) -> rusqlite::Result<rusqlite::Connection> {
+    let c = rusqlite::Connection::open(data.join(".elastik-writer-lock.sqlite3"))?;
+    c.busy_timeout(Duration::from_millis(0))?;
+    c.execute_batch(
+        r#"
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE IF NOT EXISTS writer_lock(
+            id INTEGER PRIMARY KEY CHECK(id=1),
+            holder TEXT NOT NULL DEFAULT ''
+        );
+        INSERT OR IGNORE INTO writer_lock(id, holder) VALUES(1, '');
+        BEGIN IMMEDIATE;
+        "#,
+    )?;
+    c.execute(
+        "UPDATE writer_lock SET holder=?1 WHERE id=1",
+        [std::process::id().to_string()],
+    )?;
+    Ok(c)
 }
 
 fn print_auth_summary(tokens: &auth::Tokens, bind_ip: IpAddr) {
@@ -455,6 +480,22 @@ mod tests {
         std::env::set_var(&key, "10GB");
         assert!(std::panic::catch_unwind(|| env_optional_usize(&key)).is_err());
         std::env::remove_var(&key);
+    }
+
+    #[test]
+    fn data_root_writer_lock_is_exclusive() {
+        let dir =
+            std::env::temp_dir().join(format!("elastik-data-lock-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let first = acquire_data_root_writer_lock(&dir).unwrap();
+        assert!(acquire_data_root_writer_lock(&dir).is_err());
+        drop(first);
+        let second = acquire_data_root_writer_lock(&dir).unwrap();
+        drop(second);
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
@@ -1790,7 +1831,7 @@ mod tests {
         core.write_world("home/cas", b"one", "text/plain; charset=utf-8", &[])
             .unwrap();
         let mut conn = world::open(&core.data, "home/cas").unwrap();
-        let h = audit::append_with_conn(
+        let h = audit::append_with_conn_existing(
             &mut conn,
             "put",
             "home/cas",

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -240,7 +240,14 @@ impl Core {
             Ok(())
         } else {
             let current_len = world::body_len(&self.data, world)?;
-            world::write(&self.data, world, body, content_type, headers)?;
+            world::write_with_audit(
+                &self.data,
+                world,
+                body,
+                content_type,
+                headers,
+                &self.hmac_key,
+            )?;
             let prev = current_len.unwrap_or(0);
             let _ = self.storage_body_bytes.fetch_update(
                 Ordering::Relaxed,

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -25,7 +25,7 @@
 
 use crate::audit;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-use rusqlite::{ffi, params, Connection, OpenFlags};
+use rusqlite::{ffi, params, Connection, OpenFlags, OptionalExtension, Transaction};
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -74,12 +74,21 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
     let dir = world_dir(data_root, world);
     std::fs::create_dir_all(&dir).map_err(create_dir_error)?;
-    let c = Connection::open(world_db(data_root, world))?;
+    let db = world_db(data_root, world);
+    let db_existed = db.exists();
+    let c = Connection::open(db)?;
     c.busy_timeout(Duration::from_millis(5000))?;
     c.execute_batch(
         r#"
         PRAGMA journal_mode=WAL;
         PRAGMA synchronous=FULL;
+        "#,
+    )?;
+    if db_existed {
+        verify_schema(&c)?;
+    } else {
+        c.execute_batch(
+            r#"
         CREATE TABLE IF NOT EXISTS stage_meta(
             id INTEGER PRIMARY KEY CHECK(id=1),
             body BLOB DEFAULT x'',
@@ -109,8 +118,30 @@ pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
             value TEXT NOT NULL
         );
         "#,
-    )?;
+        )?;
+    }
     Ok(c)
+}
+
+fn verify_schema(c: &Connection) -> rusqlite::Result<()> {
+    for table in ["stage_meta", "meta_headers", "events", "event_headers"] {
+        let exists = c
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                [table],
+                |r| r.get::<_, i64>(0),
+            )
+            .optional()?
+            .is_some();
+        if !exists {
+            return Err(schema_error(format!("missing required table: {table}")));
+        }
+    }
+    Ok(())
+}
+
+fn schema_error(msg: String) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), Some(msg))
 }
 
 fn create_dir_error(err: std::io::Error) -> rusqlite::Error {
@@ -379,6 +410,7 @@ pub fn write_with_audit_checked(
             });
         }
     }
+    let audit_tx = verify_appendable_world_tx(&tx, key, existed)?;
     tx.execute(
         r#"UPDATE stage_meta
            SET body=?,
@@ -394,7 +426,7 @@ pub fn write_with_audit_checked(
         }
     }
     let h = audit::append_tx(
-        &tx,
+        &audit_tx,
         "put",
         world,
         &sha256_hex(body),
@@ -460,6 +492,7 @@ pub fn append_with_audit(
     }
     let mut c = open(data_root, world)?;
     let tx = c.transaction()?;
+    let audit_tx = verify_appendable_world_tx(&tx, key, true)?;
     let current = tx.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
         r.get::<_, Vec<u8>>(0)
     })?;
@@ -474,7 +507,7 @@ pub fn append_with_audit(
         params![new_body],
     )?;
     let h = audit::append_tx(
-        &tx,
+        &audit_tx,
         "append",
         world,
         &after,
@@ -490,6 +523,31 @@ pub fn append_with_audit(
         },
         h,
     )))
+}
+
+fn verify_appendable_world_tx<'tx, 'conn>(
+    tx: &'tx Transaction<'conn>,
+    key: &[u8],
+    existed_before_open: bool,
+) -> rusqlite::Result<audit::VerifiedAuditTx<'tx, 'conn>> {
+    if !existed_before_open || is_empty_bootstrap_tx(tx)? {
+        audit::verify_appendable_tx_genesis(tx, key)
+    } else {
+        audit::verify_appendable_tx_existing(tx, key)
+    }
+}
+
+fn is_empty_bootstrap_tx(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
+    let events: i64 = tx.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))?;
+    let event_headers: i64 =
+        tx.query_row("SELECT COUNT(*) FROM event_headers", [], |r| r.get(0))?;
+    let meta_headers: i64 = tx.query_row("SELECT COUNT(*) FROM meta_headers", [], |r| r.get(0))?;
+    let body_len: i64 = tx.query_row(
+        "SELECT CASE WHEN typeof(body) = 'blob' THEN length(body) ELSE -1 END FROM stage_meta WHERE id=1",
+        [],
+        |r| r.get(0),
+    )?;
+    Ok(events == 0 && event_headers == 0 && meta_headers == 0 && body_len == 0)
 }
 
 pub fn delete(data_root: &Path, world: &str) -> bool {
@@ -666,6 +724,77 @@ mod tests {
         )
         .is_err());
 
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_write_rejects_tampered_existing_chain() {
+        let root = test_root("tampered-audit-chain");
+        let _ = std::fs::remove_dir_all(&root);
+        write_with_audit(&root, "home/tamper", b"one", "text/plain", &[], b"key").unwrap();
+        {
+            let c = Connection::open(world_db(&root, "home/tamper")).unwrap();
+            c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
+                .unwrap();
+        }
+
+        assert!(
+            write_with_audit(&root, "home/tamper", b"two", "text/plain", &[], b"key",).is_err()
+        );
+
+        let c = Connection::open(world_db(&root, "home/tamper")).unwrap();
+        let count: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_write_recovers_empty_bootstrap_db() {
+        let root = test_root("empty-bootstrap-db");
+        let _ = std::fs::remove_dir_all(&root);
+        drop(open(&root, "home/retry").unwrap());
+
+        write_with_audit(&root, "home/retry", b"one", "text/plain", &[], b"key").unwrap();
+
+        let c = Connection::open(world_db(&root, "home/retry")).unwrap();
+        let count: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_write_rejects_empty_chain_with_body() {
+        let root = test_root("empty-chain-with-body");
+        let _ = std::fs::remove_dir_all(&root);
+        {
+            let c = open(&root, "home/orphan").unwrap();
+            c.execute("UPDATE stage_meta SET body=x'6f727068616e' WHERE id=1", [])
+                .unwrap();
+        }
+
+        assert!(write_with_audit(&root, "home/orphan", b"two", "text/plain", &[], b"key").is_err());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn existing_world_missing_audit_table_is_not_recreated() {
+        let root = test_root("missing-audit-table");
+        let _ = std::fs::remove_dir_all(&root);
+        write_with_audit(&root, "home/drop-events", b"one", "text/plain", &[], b"key").unwrap();
+        {
+            let c = Connection::open(world_db(&root, "home/drop-events")).unwrap();
+            c.execute("DROP TABLE events", []).unwrap();
+        }
+
+        assert!(open(&root, "home/drop-events").is_err());
+        assert!(
+            write_with_audit(&root, "home/drop-events", b"two", "text/plain", &[], b"key",)
+                .is_err()
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 


### PR DESCRIPTION
## Summary
- add the audit POST invariant to `AGENTS.md`: durable writes fail loud and require verified audit transactions
- introduce `VerifiedAuditTx` so production audit appends can only happen after chain verification
- verify all durable worlds during boot before listening, and stop existing DBs from silently recreating missing audit/schema tables
- hold a data-root SQLite writer lease for the lifetime of the server to block multiple writer processes
- make durable test fixtures seed through the audit chain

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (144 passed, 2 ignored)
- blackbox probe: tampered chain PUT returned 500; dropped `events` table PUT returned 500; second process on same data-root logged lock failure
- pre-push local gates: Rust format, Rust clippy, Rust tests, Python SDK smoke, header policy scanner, JS syntax, whitespace check

Diff size: 316 total lines changed, under the 600-line sign-off budget.