### PR TITLE
feat(ffi): add Engine handle boundary

### DIFF
--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -74,6 +74,16 @@ impl NonEmptyBytes {
     }
 }
 
+/// Returns true when raw token bytes can represent a configured or candidate
+/// Engine token.
+///
+/// Empty and UTF-8 whitespace-only values are invalid. Non-UTF-8 bytes are
+/// allowed so language runtimes can pass opaque credential bytes without
+/// losing information.
+pub fn is_valid_token(bytes: &[u8]) -> bool {
+    NonEmptyBytes::is_valid(bytes)
+}
+
 impl Drop for NonEmptyBytes {
     fn drop(&mut self) {
         wipe_vec_allocation(&mut self.0);
@@ -313,6 +323,14 @@ mod tests {
         assert_eq!(tokens.check(Some("Bearer \t\r\n")), Tier::Anon);
         assert_eq!(tokens.check(Some(&bearer("\u{2003}"))), Tier::Anon);
         assert_eq!(tokens.check(Some("Basic Og==")), Tier::Anon);
+    }
+
+    #[test]
+    fn public_token_validity_matches_core_token_gate() {
+        assert!(is_valid_token(b"reader"));
+        assert!(is_valid_token(&[0xff, 0xfe]));
+        assert!(!is_valid_token(b""));
+        assert!(!is_valid_token(b" \t\r\n"));
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -153,10 +153,10 @@ pub(crate) use crate::proc::*;
 pub(crate) use crate::response::*;
 pub(crate) use crate::state::*;
 pub(crate) use crate::storage_class::*;
-#[cfg(feature = "unstable-engine")]
-pub use auth::AuthGate;
 #[cfg(not(feature = "unstable-engine"))]
 pub(crate) use auth::AuthGate;
+#[cfg(feature = "unstable-engine")]
+pub use auth::{is_valid_token, AuthGate};
 #[cfg(feature = "unstable-engine")]
 #[doc(hidden)]
 pub use engine::ShutdownToken;

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -261,6 +261,7 @@ name = "elastik-ffi"
 version = "8.0.1"
 dependencies = [
  "elastik-core",
+ "tokio",
  "uniffi",
 ]
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 elastik-core = { path = "../core", default-features = false, features = ["bundled-sqlite", "unstable-engine"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 uniffi = { version = "0.31.1", features = ["cli"] }
 
 [[bin]]

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -6,24 +6,84 @@ This crate is deliberately not an HTTP binding. Its upstream is the Rust
 `Engine` facade from `elastik-core`; HTTP, CoAP, SDK wire clients, and this FFI
 crate are sibling adapters.
 
-Layer 1 of the FFI stack only proves the native library scaffold:
+## Current Surface (Layer 2: Handle + Type Boundary)
 
-- `crate-type = ["lib", "cdylib"]`
-- UniFFI scaffolding compiles
-- exported smoke functions are available for binding generation
+- `FfiEngine.open(config)` — construct an Engine with an embedded Tokio runtime
+- `engine.config_summary()` — non-secret configuration accepted by the adapter
+- `engine.verify_token(token)` — check caller access tier without side effects
+- `engine.shutdown()` — orderly Engine shutdown (also called automatically on drop)
+- 24-variant `FfiError` with structured payloads (quota numbers, sqlite codes,
+  auth gate identity) — errors cross the FFI boundary without information loss
 
-Because the repository root is not a Cargo workspace, run binding generation
-from this directory:
+## Quick Start
+
+Generate Python bindings from this directory (the repository root is not a
+Cargo workspace):
 
 ```powershell
 cargo build
 cargo run --bin uniffi-bindgen -- generate target\debug\elastik_ffi.dll --language python --out-dir target\bindings\python
 ```
 
-Later stacked PRs add the actual Engine-bound surface:
+## Python-Shaped Usage
 
-- Engine handle, config, DTOs, and typed errors
-- `read`, `replace`, `append`, `delete`
-- typed introspection (`worlds`, `du`, `df`, `pool`, `audit_verify(world)`)
-- subscription receiver object
-- CI/release build matrix for `.so`, `.dylib`, and `.dll`
+Names can vary slightly by generated binding language, but the current FFI
+surface intentionally stays limited to handle construction, token verification,
+configuration summary, shutdown, and typed errors.
+
+```python
+from elastik_ffi import FfiAccessTier, FfiEngine, FfiEngineConfig
+
+# Open an Engine
+engine = FfiEngine.open(FfiEngineConfig(
+    data_root="/var/lib/elastik",
+    hmac_key=b"my-secret-key",
+    read_token=b"reader",
+    write_token=b"writer",
+    approve_token=b"admin",
+    max_world_bytes=None,
+    max_memory_bytes=None,
+    max_storage_bytes=None,
+    max_listen_connections=None,
+    listen_replay_max=None,
+    read_cache_max_entries=None,
+))
+
+# Inspect non-secret configuration
+summary = engine.config_summary()
+assert summary.has_read_token is True
+
+# Verify a caller token
+tier = engine.verify_token(b"reader")
+assert tier == FfiAccessTier.READ
+
+tier = engine.verify_token(b"wrong")
+assert tier == FfiAccessTier.ANON
+
+# Shutdown (also happens automatically when the object is collected)
+engine.shutdown()
+```
+
+## Error Handling
+
+Errors carry structured data, not flattened strings:
+
+```python
+from elastik_ffi import FfiEngine, FfiError
+
+try:
+    engine = FfiEngine.open(bad_config)
+except FfiError.InvalidSecret as e:
+    print(e.message)
+except FfiError.BuildDataRootLockHeld as e:
+    print(f"locked: {e.path}")
+```
+
+## Not Yet Bound
+
+These Engine capabilities have FFI DTOs defined but are not yet wired:
+
+- `read`, `replace`, `append`, `delete` — Engine verbs
+- `worlds`, `du`, `df`, `pool`, `audit_verify(world)` — typed introspection
+- `subscribe(pattern, tier, since) -> FfiSubscription` — change event receiver
+- CI/release build matrix for `.so`, `.dylib`, `.dll`, and language bindings

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -4,6 +4,10 @@
 //! peer of HTTP and CoAP, not a new core surface. This layer adds the
 //! Engine-owned FFI handle; later stack layers bind Engine methods.
 
+// UniFFI's export macro references deprecated smoke exports inside this crate.
+// The deprecation remains part of the generated ABI for downstream consumers.
+#![allow(deprecated)]
+
 use std::sync::Arc;
 
 use elastik_core::{Engine, SecretBytes};
@@ -100,9 +104,17 @@ impl FfiEngine {
     }
 
     /// Names the runtime model this handle owns.
+    #[allow(deprecated)]
+    #[deprecated(note = "Layer 2 smoke export only; real Engine verbs replace this surface.")]
     pub fn runtime_model(&self) -> String {
         let _ = self.runtime.handle();
         "embedded Tokio runtime; async Engine verbs block inside the FFI handle".to_owned()
+    }
+}
+
+impl Drop for FfiEngine {
+    fn drop(&mut self) {
+        self.engine.shutdown();
     }
 }
 
@@ -117,6 +129,8 @@ pub fn ffi_version() -> String {
 /// This smoke export exists to make Layer 1 reviewable without binding any
 /// Engine verbs yet. Future layers should replace this with real Engine-bound
 /// types and keep HTTP/server vocabulary out of the FFI API.
+#[allow(deprecated)]
+#[deprecated(note = "Layer 1/2 smoke export only; use real Engine-bound FFI methods.")]
 #[uniffi::export]
 pub fn ffi_engine_boundary() -> String {
     "Engine adapter only: no HTTP routes, no /proc paths, no status codes".to_owned()
@@ -135,15 +149,18 @@ fn optional_usize(name: &'static str, value: Option<u64>) -> Result<Option<usize
 #[cfg(test)]
 mod tests {
     use super::*;
+    use elastik_core::{AuditVerify, EngineBuildError, EngineError};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
+    #[allow(deprecated)]
     fn scaffold_reports_version_and_boundary() {
         assert_eq!(ffi_version(), env!("CARGO_PKG_VERSION"));
         assert!(ffi_engine_boundary().contains("Engine adapter only"));
     }
 
     #[test]
+    #[allow(deprecated)]
     fn engine_handle_opens_and_verifies_tokens() {
         let dir = unique_test_dir("opens");
         let engine = FfiEngine::open(FfiEngineConfig {
@@ -171,6 +188,71 @@ mod tests {
         assert_eq!(engine.verify_token(b"bad".to_vec()), FfiAccessTier::Anon);
         assert!(engine.runtime_model().contains("embedded Tokio runtime"));
         engine.shutdown();
+    }
+
+    #[test]
+    fn engine_handle_drop_shuts_down_cleanly() {
+        let engine = FfiEngine::open(FfiEngineConfig {
+            data_root: unique_test_dir("drop-shutdown"),
+            hmac_key: b"ffi-test-key".to_vec(),
+            read_token: None,
+            write_token: None,
+            approve_token: None,
+            max_world_bytes: None,
+            max_memory_bytes: None,
+            max_storage_bytes: None,
+            max_listen_connections: None,
+            listen_replay_max: None,
+            read_cache_max_entries: None,
+        })
+        .expect("engine opens");
+
+        drop(engine);
+    }
+
+    #[test]
+    fn config_summary_uses_engine_normalization_rules() {
+        let engine = FfiEngine::open(FfiEngineConfig {
+            data_root: unique_test_dir("summary-normalization"),
+            hmac_key: b"ffi-test-key".to_vec(),
+            read_token: Some(b" \t\n".to_vec()),
+            write_token: Some(Vec::new()),
+            approve_token: Some(vec![0xff, 0xfe]),
+            max_world_bytes: Some(0),
+            max_memory_bytes: Some(0),
+            max_storage_bytes: Some(0),
+            max_listen_connections: Some(0),
+            listen_replay_max: Some(0),
+            read_cache_max_entries: Some(0),
+        })
+        .expect("engine opens");
+        let summary = engine.config_summary();
+
+        assert!(!summary.has_read_token);
+        assert!(!summary.has_write_token);
+        assert!(summary.has_approve_token);
+        assert_eq!(summary.max_world_bytes, Some(0));
+        assert_eq!(summary.max_memory_bytes, Some(0));
+        assert_eq!(summary.max_storage_bytes, None);
+        assert_eq!(summary.max_listen_connections, None);
+        assert_eq!(summary.listen_replay_max, None);
+        assert_eq!(summary.read_cache_max_entries, None);
+        assert_eq!(
+            engine.verify_token(vec![0xff, 0xfe]),
+            FfiAccessTier::Approve
+        );
+    }
+
+    #[test]
+    fn change_event_uses_engine_verb_enum() {
+        let event = FfiChangeEvent {
+            id: 1,
+            verb: FfiChangeVerb::Replace,
+            path: "home/doc".to_owned(),
+            etag: "abc".to_owned(),
+        };
+
+        assert_eq!(event.verb, FfiChangeVerb::Replace);
     }
 
     #[test]
@@ -202,6 +284,90 @@ mod tests {
         let err = optional_usize("read_cache_max_entries", Some(u64::MAX))
             .expect_err("oversized usize should fail");
         assert!(matches!(err, FfiError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn engine_errors_cross_ffi_with_structured_details() {
+        let not_found: FfiError = EngineError::NotFound.into();
+        assert!(matches!(not_found, FfiError::NotFound));
+
+        let quota: FfiError = EngineError::QuotaExceeded {
+            used: 80,
+            quota: 100,
+            projected: 120,
+        }
+        .into();
+        match quota {
+            FfiError::QuotaExceeded {
+                used,
+                quota,
+                projected,
+            } => {
+                assert_eq!(used, 80);
+                assert_eq!(quota, 100);
+                assert_eq!(projected, 120);
+            }
+            other => panic!("expected structured quota error, got {other:?}"),
+        }
+
+        let transient: FfiError = EngineError::TransientStorage {
+            sqlite_code: Some(5),
+        }
+        .into();
+        assert!(matches!(
+            transient,
+            FfiError::TransientStorage {
+                sqlite_code: Some(5)
+            }
+        ));
+        assert!(!transient.to_string().contains("Some(5)"));
+        assert!(transient.to_string().contains("code 5"));
+    }
+
+    #[test]
+    fn auth_gate_crosses_ffi_with_structured_variant() {
+        use elastik_core::AuthGate;
+
+        for (core_gate, ffi_gate) in [
+            (AuthGate::Read, FfiAuthGate::Read),
+            (AuthGate::Write, FfiAuthGate::Write),
+            (AuthGate::WriteApprove, FfiAuthGate::WriteApprove),
+            (AuthGate::Delete, FfiAuthGate::Delete),
+        ] {
+            let err: FfiError = EngineError::Auth(core_gate).into();
+            assert!(matches!(err, FfiError::Auth { gate } if gate == ffi_gate));
+        }
+
+        assert_eq!(FfiAuthGate::Delete.to_string(), "delete");
+    }
+
+    #[test]
+    fn build_errors_cross_ffi_with_stable_variant() {
+        let err: FfiError = EngineBuildError::HmacKeyMissing.into();
+        assert!(matches!(err, FfiError::BuildHmacKeyMissing));
+        assert_eq!(err.to_string(), "hmac key missing");
+    }
+
+    #[test]
+    fn audit_verify_crosses_ffi_as_data_carrying_enum() {
+        let not_applicable: FfiAuditVerify = AuditVerify::NotApplicable.into();
+        assert!(matches!(not_applicable, FfiAuditVerify::NotApplicable));
+
+        let valid = FfiAuditVerify::Valid {
+            valid: FfiAuditValid {
+                events: 2,
+                genesis: "g".to_owned(),
+                latest: "l".to_owned(),
+            },
+        };
+        match valid {
+            FfiAuditVerify::Valid { valid } => {
+                assert_eq!(valid.events, 2);
+                assert_eq!(valid.genesis, "g");
+                assert_eq!(valid.latest, "l");
+            }
+            other => panic!("expected valid audit variant, got {other:?}"),
+        }
     }
 
     fn unique_test_dir(label: &str) -> String {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -4,7 +4,107 @@
 //! peer of HTTP and CoAP, not a new core surface. Layer 1 only proves the
 //! UniFFI scaffold builds. Later stack layers will bind Engine methods.
 
+use std::sync::Arc;
+
+use elastik_core::{Engine, SecretBytes};
+use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
+
+mod types;
+
+pub use types::*;
+
 uniffi::setup_scaffolding!();
+
+/// UniFFI-owned handle around Elastik's protocol-neutral Engine.
+#[derive(uniffi::Object)]
+pub struct FfiEngine {
+    engine: Engine,
+    runtime: Runtime,
+    config: FfiEngineConfigSummary,
+}
+
+#[uniffi::export]
+impl FfiEngine {
+    /// Opens an Engine and embeds a Tokio runtime for future async verbs.
+    #[uniffi::constructor]
+    pub fn open(config: FfiEngineConfig) -> Result<Arc<Self>, FfiError> {
+        let summary = config.summary();
+        let mut builder = Engine::builder().data_root(config.data_root);
+        let key = SecretBytes::new(config.hmac_key).map_err(|err| FfiError::InvalidSecret {
+            message: err.to_string(),
+        })?;
+        builder = builder.key(key);
+
+        if let Some(token) = config.read_token {
+            builder = builder.read_token(token);
+        }
+        if let Some(token) = config.write_token {
+            builder = builder.write_token(token);
+        }
+        if let Some(token) = config.approve_token {
+            builder = builder.approve_token(token);
+        }
+        if let Some(value) = optional_usize("max_world_bytes", config.max_world_bytes)? {
+            builder = builder.max_world_bytes(value);
+        }
+        if let Some(value) = optional_usize("max_memory_bytes", config.max_memory_bytes)? {
+            builder = builder.max_memory_bytes(value);
+        }
+        builder = builder.max_storage_bytes(optional_usize(
+            "max_storage_bytes",
+            config.max_storage_bytes,
+        )?);
+        if let Some(value) =
+            optional_usize("max_listen_connections", config.max_listen_connections)?
+        {
+            builder = builder.max_listen_connections(value);
+        }
+        if let Some(value) = optional_usize("listen_replay_max", config.listen_replay_max)? {
+            builder = builder.listen_replay_max(value);
+        }
+        if let Some(value) =
+            optional_usize("read_cache_max_entries", config.read_cache_max_entries)?
+        {
+            builder = builder.read_cache_max_entries(value);
+        }
+
+        let engine = builder.build()?;
+        let runtime = RuntimeBuilder::new_multi_thread()
+            .enable_all()
+            .thread_name("elastik-ffi")
+            .build()
+            .map_err(|err| FfiError::RuntimeInitFailed {
+                message: err.to_string(),
+            })?;
+
+        Ok(Arc::new(Self {
+            engine,
+            runtime,
+            config: summary,
+        }))
+    }
+
+    /// Returns non-secret configuration accepted by the adapter.
+    pub fn config_summary(&self) -> FfiEngineConfigSummary {
+        self.config.clone()
+    }
+
+    /// Verifies raw token bytes against the Engine token tiers.
+    pub fn verify_token(&self, token: Vec<u8>) -> FfiAccessTier {
+        self.engine.verify_token(&token).into()
+    }
+
+    /// Starts orderly Engine shutdown.
+    pub fn shutdown(&self) {
+        self.engine.shutdown();
+    }
+
+    /// Names the runtime model this handle owns.
+    pub fn runtime_model(&self) -> String {
+        let _ = self.runtime.handle();
+        "embedded Tokio runtime; async Engine verbs block inside the FFI handle".to_owned()
+    }
+}
 
 /// Returns the FFI adapter package version.
 #[uniffi::export]
@@ -22,13 +122,96 @@ pub fn ffi_engine_boundary() -> String {
     "Engine adapter only: no HTTP routes, no /proc paths, no status codes".to_owned()
 }
 
+fn optional_usize(name: &'static str, value: Option<u64>) -> Result<Option<usize>, FfiError> {
+    value
+        .map(|value| {
+            usize::try_from(value).map_err(|_| FfiError::InvalidConfig {
+                message: format!("{name} exceeds this platform's usize range"),
+            })
+        })
+        .transpose()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn scaffold_reports_version_and_boundary() {
         assert_eq!(ffi_version(), env!("CARGO_PKG_VERSION"));
         assert!(ffi_engine_boundary().contains("Engine adapter only"));
+    }
+
+    #[test]
+    fn engine_handle_opens_and_verifies_tokens() {
+        let dir = unique_test_dir("opens");
+        let engine = FfiEngine::open(FfiEngineConfig {
+            data_root: dir.clone(),
+            hmac_key: b"ffi-test-key".to_vec(),
+            read_token: Some(b"read".to_vec()),
+            write_token: Some(b"write".to_vec()),
+            approve_token: Some(b"approve".to_vec()),
+            max_world_bytes: None,
+            max_memory_bytes: None,
+            max_storage_bytes: None,
+            max_listen_connections: None,
+            listen_replay_max: None,
+            read_cache_max_entries: Some(2),
+        })
+        .expect("engine opens");
+
+        assert_eq!(engine.config_summary().data_root, dir);
+        assert_eq!(engine.verify_token(b"read".to_vec()), FfiAccessTier::Read);
+        assert_eq!(engine.verify_token(b"write".to_vec()), FfiAccessTier::Write);
+        assert_eq!(
+            engine.verify_token(b"approve".to_vec()),
+            FfiAccessTier::Approve
+        );
+        assert_eq!(engine.verify_token(b"bad".to_vec()), FfiAccessTier::Anon);
+        assert!(engine.runtime_model().contains("embedded Tokio runtime"));
+        engine.shutdown();
+    }
+
+    #[test]
+    fn engine_handle_rejects_empty_key() {
+        let result = FfiEngine::open(FfiEngineConfig {
+            data_root: unique_test_dir("empty-key"),
+            hmac_key: b"   ".to_vec(),
+            read_token: None,
+            write_token: None,
+            approve_token: None,
+            max_world_bytes: None,
+            max_memory_bytes: None,
+            max_storage_bytes: None,
+            max_listen_connections: None,
+            listen_replay_max: None,
+            read_cache_max_entries: None,
+        });
+        let Err(err) = result else {
+            panic!("empty key should fail");
+        };
+        assert!(matches!(err, FfiError::InvalidSecret { .. }));
+    }
+
+    #[test]
+    fn numeric_config_rejects_values_outside_usize_range() {
+        if usize::BITS >= 64 {
+            return;
+        }
+        let err = optional_usize("read_cache_max_entries", Some(u64::MAX))
+            .expect_err("oversized usize should fail");
+        assert!(matches!(err, FfiError::InvalidConfig { .. }));
+    }
+
+    fn unique_test_dir(label: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("elastik-ffi-{label}-{nanos}"))
+            .to_string_lossy()
+            .into_owned()
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,8 +1,8 @@
 //! UniFFI adapter for Elastik's protocol-neutral Engine.
 //!
 //! This crate is intentionally separate from `elastik-core`: it is an adapter
-//! peer of HTTP and CoAP, not a new core surface. Layer 1 only proves the
-//! UniFFI scaffold builds. Later stack layers will bind Engine methods.
+//! peer of HTTP and CoAP, not a new core surface. This layer adds the
+//! Engine-owned FFI handle; later stack layers bind Engine methods.
 
 use std::sync::Arc;
 

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -1,0 +1,291 @@
+use std::fmt;
+
+use elastik_core::{
+    AccessTier, AuditVerify, DfSnapshot, EngineBuildError, EngineError, PoolSnapshot, WriteKind,
+};
+
+/// Engine construction options for the FFI adapter.
+#[derive(Clone, uniffi::Record)]
+pub struct FfiEngineConfig {
+    pub data_root: String,
+    pub hmac_key: Vec<u8>,
+    pub read_token: Option<Vec<u8>>,
+    pub write_token: Option<Vec<u8>>,
+    pub approve_token: Option<Vec<u8>>,
+    pub max_world_bytes: Option<u64>,
+    pub max_memory_bytes: Option<u64>,
+    pub max_storage_bytes: Option<u64>,
+    pub max_listen_connections: Option<u64>,
+    pub listen_replay_max: Option<u64>,
+    pub read_cache_max_entries: Option<u64>,
+}
+
+/// Non-secret Engine settings accepted by the FFI adapter.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiEngineConfigSummary {
+    pub data_root: String,
+    pub has_read_token: bool,
+    pub has_write_token: bool,
+    pub has_approve_token: bool,
+    pub max_world_bytes: Option<u64>,
+    pub max_memory_bytes: Option<u64>,
+    pub max_storage_bytes: Option<u64>,
+    pub max_listen_connections: Option<u64>,
+    pub listen_replay_max: Option<u64>,
+    pub read_cache_max_entries: Option<u64>,
+}
+
+/// Caller access tier after token verification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiAccessTier {
+    Anon,
+    Read,
+    Write,
+    Approve,
+    Unknown,
+}
+
+/// Stored metadata header pair.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiHeader {
+    pub name: String,
+    pub value: String,
+}
+
+/// Stored representation for future write/read bindings.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiRepresentation {
+    pub body: Vec<u8>,
+    pub content_type: String,
+    pub headers: Vec<FfiHeader>,
+}
+
+/// Future read result DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiReadResult {
+    pub representation: FfiRepresentation,
+    pub etag: String,
+}
+
+/// Future write result kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiWriteKind {
+    Created,
+    Updated,
+    Unknown,
+}
+
+/// Future write result DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiWriteResult {
+    pub kind: FfiWriteKind,
+    pub etag: String,
+}
+
+/// Future subscription event DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiChangeEvent {
+    pub id: u64,
+    pub method: String,
+    pub path: String,
+    pub etag: String,
+}
+
+/// Aggregate storage/memory snapshot DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiDfSnapshot {
+    pub storage_used: u64,
+    pub storage_quota: Option<u64>,
+    pub memory_used: u64,
+    pub memory_quota: u64,
+    pub worlds: u64,
+}
+
+/// Read-cache + ledger-writer snapshot DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiPoolSnapshot {
+    pub read_cache_entries: u64,
+    pub read_cache_tombstones: u64,
+    pub read_cache_hits: u64,
+    pub read_cache_misses: u64,
+    pub read_cache_capped: u64,
+    pub read_cache_evictions: u64,
+    pub read_cache_open_fails: u64,
+    pub read_cache_max_entries: u64,
+    pub ledger_writer_inits: u64,
+}
+
+/// Successful audit verification DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiAuditValid {
+    pub events: u64,
+    pub genesis: String,
+    pub latest: String,
+}
+
+/// Broken audit verification DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiAuditBroken {
+    pub break_at: u64,
+    pub expected: String,
+    pub actual: String,
+}
+
+/// Audit verification DTO. Exactly one detail field is populated.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiAuditVerify {
+    pub kind: FfiAuditVerifyKind,
+    pub valid: Option<FfiAuditValid>,
+    pub broken: Option<FfiAuditBroken>,
+}
+
+/// Audit verification result kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiAuditVerifyKind {
+    Valid,
+    Broken,
+    NotApplicable,
+    Unknown,
+}
+
+/// Errors raised by the FFI adapter.
+#[derive(Debug, uniffi::Error)]
+pub enum FfiError {
+    InvalidConfig { message: String },
+    InvalidSecret { message: String },
+    BuildFailed { message: String },
+    RuntimeInitFailed { message: String },
+    EngineFailed { message: String },
+}
+
+impl FfiEngineConfig {
+    pub(crate) fn summary(&self) -> FfiEngineConfigSummary {
+        FfiEngineConfigSummary {
+            data_root: self.data_root.clone(),
+            has_read_token: self.read_token.is_some(),
+            has_write_token: self.write_token.is_some(),
+            has_approve_token: self.approve_token.is_some(),
+            max_world_bytes: self.max_world_bytes,
+            max_memory_bytes: self.max_memory_bytes,
+            max_storage_bytes: self.max_storage_bytes,
+            max_listen_connections: self.max_listen_connections,
+            listen_replay_max: self.listen_replay_max,
+            read_cache_max_entries: self.read_cache_max_entries,
+        }
+    }
+}
+
+impl From<AccessTier> for FfiAccessTier {
+    fn from(value: AccessTier) -> Self {
+        match value {
+            AccessTier::Anon => Self::Anon,
+            AccessTier::Read => Self::Read,
+            AccessTier::Write => Self::Write,
+            AccessTier::Approve => Self::Approve,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<WriteKind> for FfiWriteKind {
+    fn from(value: WriteKind) -> Self {
+        match value {
+            WriteKind::Created => Self::Created,
+            WriteKind::Updated => Self::Updated,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<DfSnapshot> for FfiDfSnapshot {
+    fn from(value: DfSnapshot) -> Self {
+        Self {
+            storage_used: value.storage_used as u64,
+            storage_quota: value.storage_quota.map(|value| value as u64),
+            memory_used: value.memory_used as u64,
+            memory_quota: value.memory_quota as u64,
+            worlds: value.worlds as u64,
+        }
+    }
+}
+
+impl From<PoolSnapshot> for FfiPoolSnapshot {
+    fn from(value: PoolSnapshot) -> Self {
+        Self {
+            read_cache_entries: value.read_cache_entries as u64,
+            read_cache_tombstones: value.read_cache_tombstones as u64,
+            read_cache_hits: value.read_cache_hits as u64,
+            read_cache_misses: value.read_cache_misses as u64,
+            read_cache_capped: value.read_cache_capped as u64,
+            read_cache_evictions: value.read_cache_evictions as u64,
+            read_cache_open_fails: value.read_cache_open_fails as u64,
+            read_cache_max_entries: value.read_cache_max_entries as u64,
+            ledger_writer_inits: value.ledger_writer_inits as u64,
+        }
+    }
+}
+
+impl From<AuditVerify> for FfiAuditVerify {
+    fn from(value: AuditVerify) -> Self {
+        match value {
+            AuditVerify::Valid(valid) => Self {
+                kind: FfiAuditVerifyKind::Valid,
+                valid: Some(FfiAuditValid {
+                    events: valid.events as u64,
+                    genesis: valid.genesis,
+                    latest: valid.latest,
+                }),
+                broken: None,
+            },
+            AuditVerify::Broken(broken) => Self {
+                kind: FfiAuditVerifyKind::Broken,
+                valid: None,
+                broken: Some(FfiAuditBroken {
+                    break_at: broken.break_at as u64,
+                    expected: broken.expected,
+                    actual: broken.actual,
+                }),
+            },
+            AuditVerify::NotApplicable => Self {
+                kind: FfiAuditVerifyKind::NotApplicable,
+                valid: None,
+                broken: None,
+            },
+            _ => Self {
+                kind: FfiAuditVerifyKind::Unknown,
+                valid: None,
+                broken: None,
+            },
+        }
+    }
+}
+
+impl From<EngineBuildError> for FfiError {
+    fn from(value: EngineBuildError) -> Self {
+        Self::BuildFailed {
+            message: format!("{value:?}"),
+        }
+    }
+}
+
+impl From<EngineError> for FfiError {
+    fn from(value: EngineError) -> Self {
+        Self::EngineFailed {
+            message: format!("{value:?}"),
+        }
+    }
+}
+
+impl fmt::Display for FfiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfig { message }
+            | Self::InvalidSecret { message }
+            | Self::BuildFailed { message }
+            | Self::RuntimeInitFailed { message }
+            | Self::EngineFailed { message } => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for FfiError {}

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
 use elastik_core::{
-    AccessTier, AuditVerify, DfSnapshot, EngineBuildError, EngineError, PoolSnapshot, WriteKind,
+    AccessTier, AuditVerify, AuthGate, DfSnapshot, EngineBuildError, EngineError, PoolSnapshot,
+    WriteKind,
 };
 
 /// Engine construction options for the FFI adapter.
@@ -42,7 +43,33 @@ pub enum FfiAccessTier {
     Read,
     Write,
     Approve,
+    /// The Engine returned a tier this FFI binding does not yet recognize.
+    /// Treat as deny-by-default and upgrade the binding.
     Unknown,
+}
+
+/// Engine auth gate that rejected an FFI operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiAuthGate {
+    Read,
+    Write,
+    WriteApprove,
+    Delete,
+    /// The Engine returned an auth gate this FFI binding does not yet recognize.
+    /// Treat as deny-by-default and upgrade the binding.
+    Unknown,
+}
+
+impl fmt::Display for FfiAuthGate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::WriteApprove => "write-approve",
+            Self::Delete => "delete",
+            Self::Unknown => "unknown",
+        })
+    }
 }
 
 /// Stored metadata header pair.
@@ -72,6 +99,8 @@ pub struct FfiReadResult {
 pub enum FfiWriteKind {
     Created,
     Updated,
+    /// The Engine returned a write kind this FFI binding does not yet recognize.
+    /// Treat as successful but unknown and upgrade the binding.
     Unknown,
 }
 
@@ -82,11 +111,22 @@ pub struct FfiWriteResult {
     pub etag: String,
 }
 
+/// Engine verb that produced a subscription change event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiChangeVerb {
+    Replace,
+    Append,
+    Delete,
+    /// The Engine returned a change verb this FFI binding does not yet recognize.
+    /// Treat as an unknown change and upgrade the binding.
+    Unknown,
+}
+
 /// Future subscription event DTO.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct FfiChangeEvent {
     pub id: u64,
-    pub method: String,
+    pub verb: FfiChangeVerb,
     pub path: String,
     pub etag: String,
 }
@@ -131,48 +171,122 @@ pub struct FfiAuditBroken {
     pub actual: String,
 }
 
-/// Audit verification DTO. Exactly one detail field is populated.
-#[derive(Clone, Debug, uniffi::Record)]
-pub struct FfiAuditVerify {
-    pub kind: FfiAuditVerifyKind,
-    pub valid: Option<FfiAuditValid>,
-    pub broken: Option<FfiAuditBroken>,
-}
-
-/// Audit verification result kind.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
-pub enum FfiAuditVerifyKind {
-    Valid,
-    Broken,
+/// Audit verification result.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum FfiAuditVerify {
+    Valid {
+        valid: FfiAuditValid,
+    },
+    Broken {
+        broken: FfiAuditBroken,
+    },
     NotApplicable,
+    /// The Engine returned an audit state this FFI binding does not yet recognize.
+    /// Treat as indeterminate and upgrade the binding.
     Unknown,
 }
 
 /// Errors raised by the FFI adapter.
 #[derive(Debug, uniffi::Error)]
 pub enum FfiError {
-    InvalidConfig { message: String },
-    InvalidSecret { message: String },
-    BuildFailed { message: String },
-    RuntimeInitFailed { message: String },
-    EngineFailed { message: String },
+    InvalidConfig {
+        message: String,
+    },
+    InvalidSecret {
+        message: String,
+    },
+    BuildDataRootIo {
+        message: String,
+    },
+    BuildDataRootLockHeld {
+        path: String,
+    },
+    BuildHmacKeyMissing,
+    BuildAuditChainCorrupted {
+        world: String,
+        detail: String,
+    },
+    BuildStorage {
+        sqlite_code: Option<i32>,
+        detail: String,
+    },
+    /// Unmapped Engine build error variant. Indicates this FFI binding is
+    /// older than the core that produced the error.
+    UnknownBuildError {
+        detail: String,
+    },
+    RuntimeInitFailed {
+        message: String,
+    },
+    Auth {
+        gate: FfiAuthGate,
+    },
+    InvalidWorldName,
+    NotFound,
+    AppendOnly,
+    PayloadTooLarge {
+        max: u64,
+    },
+    PreconditionFailed {
+        message: String,
+    },
+    QuotaExceeded {
+        used: u64,
+        quota: u64,
+        projected: u64,
+    },
+    TransientStorage {
+        sqlite_code: Option<i32>,
+    },
+    InsufficientStorage {
+        sqlite_code: Option<i32>,
+    },
+    Storage {
+        sqlite_code: Option<i32>,
+    },
+    SubscriptionLimit,
+    ShuttingDown,
+    InternalInvariant {
+        message: String,
+    },
+    /// Unmapped Engine error variant. Indicates this FFI binding is older than
+    /// the core that produced the error.
+    UnknownEngineError {
+        detail: String,
+    },
 }
 
 impl FfiEngineConfig {
     pub(crate) fn summary(&self) -> FfiEngineConfigSummary {
         FfiEngineConfigSummary {
             data_root: self.data_root.clone(),
-            has_read_token: self.read_token.is_some(),
-            has_write_token: self.write_token.is_some(),
-            has_approve_token: self.approve_token.is_some(),
+            has_read_token: token_configured(&self.read_token),
+            has_write_token: token_configured(&self.write_token),
+            has_approve_token: token_configured(&self.approve_token),
             max_world_bytes: self.max_world_bytes,
             max_memory_bytes: self.max_memory_bytes,
-            max_storage_bytes: self.max_storage_bytes,
-            max_listen_connections: self.max_listen_connections,
-            listen_replay_max: self.listen_replay_max,
-            read_cache_max_entries: self.read_cache_max_entries,
+            max_storage_bytes: nonzero_override(self.max_storage_bytes),
+            max_listen_connections: nonzero_override(self.max_listen_connections),
+            listen_replay_max: nonzero_override(self.listen_replay_max),
+            read_cache_max_entries: nonzero_override(self.read_cache_max_entries),
         }
     }
+}
+
+fn token_configured(token: &Option<Vec<u8>>) -> bool {
+    token
+        .as_deref()
+        .map(|bytes| {
+            !bytes.is_empty()
+                && std::str::from_utf8(bytes)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(true)
+        })
+        .unwrap_or(false)
+}
+
+fn nonzero_override(value: Option<u64>) -> Option<u64> {
+    value.filter(|value| *value > 0)
 }
 
 impl From<AccessTier> for FfiAccessTier {
@@ -182,6 +296,18 @@ impl From<AccessTier> for FfiAccessTier {
             AccessTier::Read => Self::Read,
             AccessTier::Write => Self::Write,
             AccessTier::Approve => Self::Approve,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<AuthGate> for FfiAuthGate {
+    fn from(value: AuthGate) -> Self {
+        match value {
+            AuthGate::Read => Self::Read,
+            AuthGate::Write => Self::Write,
+            AuthGate::WriteApprove => Self::WriteApprove,
+            AuthGate::Delete => Self::Delete,
             _ => Self::Unknown,
         }
     }
@@ -228,50 +354,86 @@ impl From<PoolSnapshot> for FfiPoolSnapshot {
 impl From<AuditVerify> for FfiAuditVerify {
     fn from(value: AuditVerify) -> Self {
         match value {
-            AuditVerify::Valid(valid) => Self {
-                kind: FfiAuditVerifyKind::Valid,
-                valid: Some(FfiAuditValid {
+            AuditVerify::Valid(valid) => Self::Valid {
+                valid: FfiAuditValid {
                     events: valid.events as u64,
                     genesis: valid.genesis,
                     latest: valid.latest,
-                }),
-                broken: None,
+                },
             },
-            AuditVerify::Broken(broken) => Self {
-                kind: FfiAuditVerifyKind::Broken,
-                valid: None,
-                broken: Some(FfiAuditBroken {
+            AuditVerify::Broken(broken) => Self::Broken {
+                broken: FfiAuditBroken {
                     break_at: broken.break_at as u64,
                     expected: broken.expected,
                     actual: broken.actual,
-                }),
+                },
             },
-            AuditVerify::NotApplicable => Self {
-                kind: FfiAuditVerifyKind::NotApplicable,
-                valid: None,
-                broken: None,
-            },
-            _ => Self {
-                kind: FfiAuditVerifyKind::Unknown,
-                valid: None,
-                broken: None,
-            },
+            AuditVerify::NotApplicable => Self::NotApplicable,
+            _ => Self::Unknown,
         }
     }
 }
 
 impl From<EngineBuildError> for FfiError {
     fn from(value: EngineBuildError) -> Self {
-        Self::BuildFailed {
-            message: format!("{value:?}"),
+        match value {
+            EngineBuildError::DataRootIo(err) => Self::BuildDataRootIo {
+                message: err.to_string(),
+            },
+            EngineBuildError::DataRootLockHeld { path } => Self::BuildDataRootLockHeld {
+                path: path.to_string_lossy().into_owned(),
+            },
+            EngineBuildError::HmacKeyMissing => Self::BuildHmacKeyMissing,
+            EngineBuildError::AuditChainCorrupted { world, detail } => {
+                Self::BuildAuditChainCorrupted { world, detail }
+            }
+            EngineBuildError::Storage {
+                sqlite_code,
+                detail,
+            } => Self::BuildStorage {
+                sqlite_code,
+                detail,
+            },
+            _ => Self::UnknownBuildError {
+                detail: "unknown engine build error".to_owned(),
+            },
         }
     }
 }
 
 impl From<EngineError> for FfiError {
     fn from(value: EngineError) -> Self {
-        Self::EngineFailed {
-            message: format!("{value:?}"),
+        match value {
+            EngineError::Auth(gate) => Self::Auth { gate: gate.into() },
+            EngineError::InvalidWorldName => Self::InvalidWorldName,
+            EngineError::NotFound => Self::NotFound,
+            EngineError::AppendOnly => Self::AppendOnly,
+            EngineError::PayloadTooLarge { max } => Self::PayloadTooLarge { max: max as u64 },
+            EngineError::PreconditionFailed { message } => Self::PreconditionFailed {
+                message: message.to_owned(),
+            },
+            EngineError::QuotaExceeded {
+                used,
+                quota,
+                projected,
+            } => Self::QuotaExceeded {
+                used: used as u64,
+                quota: quota as u64,
+                projected: projected as u64,
+            },
+            EngineError::TransientStorage { sqlite_code } => Self::TransientStorage { sqlite_code },
+            EngineError::InsufficientStorage { sqlite_code } => {
+                Self::InsufficientStorage { sqlite_code }
+            }
+            EngineError::Storage { sqlite_code } => Self::Storage { sqlite_code },
+            EngineError::SubscriptionLimit => Self::SubscriptionLimit,
+            EngineError::ShuttingDown => Self::ShuttingDown,
+            EngineError::InternalInvariant(message) => Self::InternalInvariant {
+                message: message.to_owned(),
+            },
+            _ => Self::UnknownEngineError {
+                detail: "unknown engine error".to_owned(),
+            },
         }
     }
 }
@@ -281,11 +443,64 @@ impl fmt::Display for FfiError {
         match self {
             Self::InvalidConfig { message }
             | Self::InvalidSecret { message }
-            | Self::BuildFailed { message }
             | Self::RuntimeInitFailed { message }
-            | Self::EngineFailed { message } => f.write_str(message),
+            | Self::BuildDataRootIo { message }
+            | Self::PreconditionFailed { message }
+            | Self::InternalInvariant { message } => f.write_str(message),
+            Self::UnknownBuildError { detail } | Self::UnknownEngineError { detail } => {
+                f.write_str(detail)
+            }
+            Self::BuildDataRootLockHeld { path } => {
+                write!(f, "data root writer lock is held: {path}")
+            }
+            Self::BuildHmacKeyMissing => f.write_str("hmac key missing"),
+            Self::BuildAuditChainCorrupted { world, detail } => {
+                write!(f, "audit chain corrupted for {world}: {detail}")
+            }
+            Self::BuildStorage {
+                sqlite_code,
+                detail,
+            } => write!(
+                f,
+                "storage build failed ({}): {detail}",
+                code_label(*sqlite_code)
+            ),
+            Self::Auth { gate } => write!(f, "auth gate rejected operation: {gate}"),
+            Self::InvalidWorldName => f.write_str("invalid world name"),
+            Self::NotFound => f.write_str("world not found"),
+            Self::AppendOnly => f.write_str("world is append-only"),
+            Self::PayloadTooLarge { max } => write!(f, "payload too large (max {max} bytes)"),
+            Self::QuotaExceeded {
+                used,
+                quota,
+                projected,
+            } => write!(
+                f,
+                "storage quota exceeded (used {used}, quota {quota}, projected {projected})"
+            ),
+            Self::TransientStorage { sqlite_code } => {
+                write!(
+                    f,
+                    "storage temporarily unavailable ({})",
+                    code_label(*sqlite_code)
+                )
+            }
+            Self::InsufficientStorage { sqlite_code } => {
+                write!(f, "insufficient storage ({})", code_label(*sqlite_code))
+            }
+            Self::Storage { sqlite_code } => {
+                write!(f, "storage failed ({})", code_label(*sqlite_code))
+            }
+            Self::SubscriptionLimit => f.write_str("subscription limit reached"),
+            Self::ShuttingDown => f.write_str("engine is shutting down"),
         }
     }
+}
+
+fn code_label(sqlite_code: Option<i32>) -> String {
+    sqlite_code
+        .map(|code| format!("code {code}"))
+        .unwrap_or_else(|| "no sqlite code".to_owned())
 }
 
 impl std::error::Error for FfiError {}

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use elastik_core::{
-    AccessTier, AuditVerify, AuthGate, DfSnapshot, EngineBuildError, EngineError, PoolSnapshot,
-    WriteKind,
+    is_valid_token, AccessTier, AuditVerify, AuthGate, DfSnapshot, EngineBuildError, EngineError,
+    PoolSnapshot, WriteKind,
 };
 
 /// Engine construction options for the FFI adapter.
@@ -263,8 +263,12 @@ impl FfiEngineConfig {
             has_read_token: token_configured(&self.read_token),
             has_write_token: token_configured(&self.write_token),
             has_approve_token: token_configured(&self.approve_token),
+            // World and memory byte caps are literal Engine caps, so Some(0)
+            // remains visible as an explicit "zero bytes allowed" override.
             max_world_bytes: self.max_world_bytes,
             max_memory_bytes: self.max_memory_bytes,
+            // These builder knobs define zero as "use the Engine default" or
+            // "no durable quota"; the summary reports the normalized setting.
             max_storage_bytes: nonzero_override(self.max_storage_bytes),
             max_listen_connections: nonzero_override(self.max_listen_connections),
             listen_replay_max: nonzero_override(self.listen_replay_max),
@@ -274,15 +278,7 @@ impl FfiEngineConfig {
 }
 
 fn token_configured(token: &Option<Vec<u8>>) -> bool {
-    token
-        .as_deref()
-        .map(|bytes| {
-            !bytes.is_empty()
-                && std::str::from_utf8(bytes)
-                    .map(|value| !value.trim().is_empty())
-                    .unwrap_or(true)
-        })
-        .unwrap_or(false)
+    token.as_deref().map(is_valid_token).unwrap_or(false)
 }
 
 fn nonzero_override(value: Option<u64>) -> Option<u64> {

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -390,8 +390,8 @@ impl From<EngineBuildError> for FfiError {
                 sqlite_code,
                 detail,
             },
-            _ => Self::UnknownBuildError {
-                detail: "unknown engine build error".to_owned(),
+            other => Self::UnknownBuildError {
+                detail: format!("{other:?}"),
             },
         }
     }
@@ -427,8 +427,8 @@ impl From<EngineError> for FfiError {
             EngineError::InternalInvariant(message) => Self::InternalInvariant {
                 message: message.to_owned(),
             },
-            _ => Self::UnknownEngineError {
-                detail: "unknown engine error".to_owned(),
+            other => Self::UnknownEngineError {
+                detail: format!("{other:?}"),
             },
         }
     }


### PR DESCRIPTION
## Layer

Layer 2 of the UniFFI FFI stack. Base branch: `feat/ffi-uniffi-scaffold` (#168).

This PR adds the Engine handle and type boundary only. It intentionally does **not** bind `read`, `replace`, `append`, `delete`, or `subscribe` yet.

## Scope

- Adds `FfiEngine`, a UniFFI object that owns:
  - protocol-neutral `elastik_core::Engine`
  - an embedded Tokio runtime for later async Engine verbs
  - a non-secret config summary
- Adds `FfiEngineConfig` for construction.
- Adds UniFFI DTOs for later Engine-bound layers:
  - access tiers
  - representations and headers
  - read/write results
  - change events
  - df/pool snapshots
  - audit verify results
  - FFI errors
- Adds boundary smoke methods only:
  - `FfiEngine.open(config)`
  - `config_summary()`
  - `verify_token(bytes)`
  - `shutdown()`
  - `runtime_model()`

## Boundary

Still Engine-only. No HTTP routes, no `/proc/*` paths, no HTTP status-code model, no server/router/handler types.

`verify_token` is included as a boundary sanity check because token-tier mapping is part of the Engine facade; storage verbs remain for the next layer.

## Diff shape

- `ffi/src/lib.rs`: handle + constructor + tests
- `ffi/src/types.rs`: DTO/error boundary
- `ffi/Cargo.toml`: adds direct `tokio` runtime dependency
- `ffi/Cargo.lock`: generated one-line dependency update

Layer diff: 476 insertions, under the 500-line PR budget. Test code is included in that number; production review surface is smaller.

## Validation

- `cargo fmt --manifest-path ffi\Cargo.toml --check`
- `cargo check --manifest-path ffi\Cargo.toml`
- `cargo test --manifest-path ffi\Cargo.toml` (4 passed)
- `cargo build --manifest-path ffi\Cargo.toml`
- From `ffi/`: `cargo run --bin uniffi-bindgen -- generate target\debug\elastik_ffi.dll --language python --out-dir target\bindings\python`
- Python binding smoke against generated `elastik_ffi.py` + local DLL:
  - `FfiEngine.open`
  - `config_summary`
  - `verify_token`
  - `runtime_model`
  - `shutdown`
- `git diff --check`
- pre-push fast gates passed: Rust fmt/clippy/tests, Python SDK smoke, header scanner, JS syntax, whitespace
