### PR TITLE
feat(ffi): bind Engine verbs and introspection

### DIFF
--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -78,6 +78,11 @@ pub struct Representation {
     pub content_type: String,
     /// Arbitrary metadata header pairs. Header-name de-duplication and
     /// allow/deny policy belong to the adapter that constructs this struct.
+    ///
+    /// The HTTP adapter applies a layered filter at write time and an L1
+    /// hard-deny filter at read time because browsers execute response headers
+    /// as security policy. Non-browser adapters (FFI, MQTT, CoAP) may pass
+    /// headers through as opaque key-value metadata.
     pub headers: Vec<(String, String)>,
 }
 

--- a/ffi/STACK.md
+++ b/ffi/STACK.md
@@ -57,6 +57,23 @@ Forbidden:
 - server/router/handler types
 - adapter-specific auth/header/pipeline concepts
 
+## Header Persistence
+
+The FFI adapter passes representation headers through to the Engine without
+filtering. This is by design:
+
+- The Engine treats headers as opaque metadata.
+- Only the HTTP adapter applies a persistence allowlist because browsers
+  interpret response headers as security directives.
+- The HTTP read path applies an L1 hard-deny filter on output regardless of
+  which adapter wrote the data.
+- Non-browser consumers (FFI, MQTT, CoAP) treat headers as plain key-value
+  metadata with no execution semantics.
+
+FFI callers are responsible for the content they store. If an FFI-written
+header is later served through the HTTP adapter, the HTTP output filter is the
+safety net, not the FFI write path.
+
 ## Coverage Discipline
 
 FFI should keep a strict coverage habit from layer 1 onward. The coverage goal

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,8 +1,8 @@
 //! UniFFI adapter for Elastik's protocol-neutral Engine.
 //!
 //! This crate is intentionally separate from `elastik-core`: it is an adapter
-//! peer of HTTP and CoAP, not a new core surface. This layer adds the
-//! Engine-owned FFI handle; later stack layers bind Engine methods.
+//! peer of HTTP and CoAP, not a new core surface. This stack binds Engine
+//! methods directly and keeps HTTP route/status vocabulary out of the ABI.
 
 // UniFFI's export macro references deprecated smoke exports inside this crate.
 // The deprecation remains part of the generated ABI for downstream consumers.
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use elastik_core::{Engine, SecretBytes};
+use elastik_core::{Engine, SecretBytes, ValidatedWorldPath};
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 
 mod types;
@@ -110,6 +110,111 @@ impl FfiEngine {
         let _ = self.runtime.handle();
         "embedded Tokio runtime; async Engine verbs block inside the FFI handle".to_owned()
     }
+
+    /// Reads a world's full representation.
+    pub fn read(
+        &self,
+        world: String,
+        tier: FfiAccessTier,
+    ) -> Result<Option<FfiReadResult>, FfiError> {
+        let world = validated_world(world)?;
+        Ok(self.engine.read(&world, tier.try_into()?)?.map(Into::into))
+    }
+
+    /// Replaces a world with the provided representation.
+    pub fn replace(
+        &self,
+        world: String,
+        representation: FfiRepresentation,
+        preconditions: FfiPreconditions,
+        tier: FfiAccessTier,
+    ) -> Result<FfiWriteResult, FfiError> {
+        let world = validated_world(world)?;
+        let result = self.runtime.block_on(self.engine.replace(
+            &world,
+            representation.into(),
+            preconditions.into(),
+            tier.try_into()?,
+        ))?;
+        Ok(result.into())
+    }
+
+    /// Appends bytes to a world's body.
+    pub fn append(
+        &self,
+        world: String,
+        body: Vec<u8>,
+        preconditions: FfiPreconditions,
+        tier: FfiAccessTier,
+    ) -> Result<FfiWriteResult, FfiError> {
+        let world = validated_world(world)?;
+        let result = self.runtime.block_on(self.engine.append(
+            &world,
+            body.into(),
+            preconditions.into(),
+            tier.try_into()?,
+        ))?;
+        Ok(result.into())
+    }
+
+    /// Deletes a world.
+    pub fn delete(
+        &self,
+        world: String,
+        preconditions: FfiPreconditions,
+        tier: FfiAccessTier,
+    ) -> Result<(), FfiError> {
+        let world = validated_world(world)?;
+        Ok(self.runtime.block_on(self.engine.delete(
+            &world,
+            preconditions.into(),
+            tier.try_into()?,
+        ))?)
+    }
+
+    /// Lists every canonical world known to the Engine.
+    ///
+    /// Returned strings are canonical Engine worlds that round-trip through
+    /// `read`, `replace`, `append`, `delete`, and `audit_verify` without
+    /// validation failure.
+    pub fn worlds(&self, tier: FfiAccessTier) -> Result<Vec<String>, FfiError> {
+        Ok(self
+            .engine
+            .list_worlds(tier.try_into()?)?
+            .into_iter()
+            .map(|world| world.to_string())
+            .collect())
+    }
+
+    /// Returns per-world byte usage.
+    pub fn du(&self, tier: FfiAccessTier) -> Result<Vec<FfiWorldUsage>, FfiError> {
+        Ok(self
+            .engine
+            .du(tier.try_into()?)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
+    /// Returns aggregate storage and memory usage.
+    pub fn df(&self, tier: FfiAccessTier) -> Result<FfiDfSnapshot, FfiError> {
+        Ok(self.engine.df(tier.try_into()?)?.into())
+    }
+
+    /// Returns read-cache and ledger-writer counters.
+    pub fn pool(&self, tier: FfiAccessTier) -> Result<FfiPoolSnapshot, FfiError> {
+        Ok(self.engine.pool(tier.try_into()?)?.into())
+    }
+
+    /// Verifies one world's HMAC audit chain.
+    pub fn audit_verify(
+        &self,
+        world: String,
+        tier: FfiAccessTier,
+    ) -> Result<FfiAuditVerify, FfiError> {
+        let world = validated_world(world)?;
+        Ok(self.engine.verify_audit(&world, tier.try_into()?)?.into())
+    }
 }
 
 impl Drop for FfiEngine {
@@ -126,9 +231,8 @@ pub fn ffi_version() -> String {
 
 /// Names the architectural boundary this adapter is allowed to cross.
 ///
-/// This smoke export exists to make Layer 1 reviewable without binding any
-/// Engine verbs yet. Future layers should replace this with real Engine-bound
-/// types and keep HTTP/server vocabulary out of the FFI API.
+/// This smoke export remains as a cheap boundary check alongside the real
+/// Engine-bound methods: HTTP/server vocabulary must stay out of the FFI API.
 #[allow(deprecated)]
 #[deprecated(note = "Layer 1/2 smoke export only; use real Engine-bound FFI methods.")]
 #[uniffi::export]
@@ -144,6 +248,12 @@ fn optional_usize(name: &'static str, value: Option<u64>) -> Result<Option<usize
             })
         })
         .transpose()
+}
+
+fn validated_world(world: String) -> Result<ValidatedWorldPath, FfiError> {
+    ValidatedWorldPath::new(world).map_err(|err| FfiError::InvalidWorld {
+        message: err.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -253,6 +363,142 @@ mod tests {
         };
 
         assert_eq!(event.verb, FfiChangeVerb::Replace);
+    }
+
+    #[test]
+    fn engine_verbs_roundtrip_bytes_and_introspection() {
+        let engine = test_engine("verbs");
+        let none = FfiPreconditions {
+            if_match: Vec::new(),
+            if_none_match: Vec::new(),
+        };
+
+        assert!(engine
+            .read("home/doc".to_owned(), FfiAccessTier::Read)
+            .expect("read missing succeeds")
+            .is_none());
+
+        let created = engine
+            .replace(
+                "home/doc".to_owned(),
+                FfiRepresentation {
+                    body: b"hello".to_vec(),
+                    content_type: "text/plain".to_owned(),
+                    headers: vec![FfiHeader {
+                        name: "x-meta".to_owned(),
+                        value: "one".to_owned(),
+                    }],
+                },
+                none.clone(),
+                FfiAccessTier::Write,
+            )
+            .expect("replace succeeds");
+        assert_eq!(created.kind, FfiWriteKind::Created);
+
+        let appended = engine
+            .append(
+                "home/doc".to_owned(),
+                b" world".to_vec(),
+                none.clone(),
+                FfiAccessTier::Write,
+            )
+            .expect("append succeeds");
+        assert_eq!(appended.kind, FfiWriteKind::Updated);
+
+        let read = engine
+            .read("home/doc".to_owned(), FfiAccessTier::Read)
+            .expect("read succeeds")
+            .expect("world exists");
+        assert_eq!(read.representation.body, b"hello world");
+        assert_eq!(read.representation.content_type, "text/plain");
+
+        assert_eq!(
+            engine.worlds(FfiAccessTier::Read).expect("worlds"),
+            vec!["home/doc".to_owned()]
+        );
+        for world in engine.worlds(FfiAccessTier::Read).expect("worlds") {
+            assert!(engine
+                .read(world, FfiAccessTier::Read)
+                .expect("listed world round-trips")
+                .is_some());
+        }
+        assert_eq!(
+            engine.du(FfiAccessTier::Read).expect("du")[0].world,
+            "home/doc"
+        );
+        assert_eq!(engine.df(FfiAccessTier::Read).expect("df").worlds, 1);
+        assert_eq!(
+            engine
+                .pool(FfiAccessTier::Read)
+                .expect("pool")
+                .read_cache_max_entries,
+            2
+        );
+        assert!(matches!(
+            engine
+                .audit_verify("home/doc".to_owned(), FfiAccessTier::Read)
+                .expect("audit verify"),
+            FfiAuditVerify::Valid { .. }
+        ));
+
+        engine
+            .delete("home/doc".to_owned(), none, FfiAccessTier::Approve)
+            .expect("delete succeeds");
+        assert!(engine
+            .read("home/doc".to_owned(), FfiAccessTier::Read)
+            .expect("read deleted succeeds")
+            .is_none());
+    }
+
+    #[test]
+    fn engine_verbs_reject_noncanonical_worlds() {
+        let engine = test_engine("invalid-world");
+        let err = engine
+            .read("/home/doc".to_owned(), FfiAccessTier::Read)
+            .expect_err("wire paths are not Engine worlds");
+        assert!(matches!(err, FfiError::InvalidWorld { .. }));
+    }
+
+    #[test]
+    fn unknown_tier_is_rejected_at_boundary() {
+        let engine = test_engine("unknown-tier");
+        let err = engine
+            .read("home/doc".to_owned(), FfiAccessTier::Unknown)
+            .expect_err("unknown tier must not silently downgrade");
+        assert!(matches!(err, FfiError::InvalidConfig { .. }));
+    }
+
+    #[test]
+    fn write_preconditions_reject_stale_etags() {
+        let engine = test_engine("precondition-if-match");
+        let none = FfiPreconditions {
+            if_match: Vec::new(),
+            if_none_match: Vec::new(),
+        };
+        engine
+            .replace(
+                "home/doc".to_owned(),
+                small_representation(b"first"),
+                none,
+                FfiAccessTier::Write,
+            )
+            .expect("create succeeds");
+
+        let stale = FfiPreconditions {
+            if_match: vec![FfiEtagMatcher::Strong {
+                etag: "\"wrong-etag\"".to_owned(),
+            }],
+            if_none_match: Vec::new(),
+        };
+        let err = engine
+            .replace(
+                "home/doc".to_owned(),
+                small_representation(b"second"),
+                stale,
+                FfiAccessTier::Write,
+            )
+            .expect_err("stale If-Match rejected");
+        assert!(matches!(err, FfiError::PreconditionFailed { .. }));
     }
 
     #[test]
@@ -379,5 +625,30 @@ mod tests {
             .join(format!("elastik-ffi-{label}-{nanos}"))
             .to_string_lossy()
             .into_owned()
+    }
+
+    fn test_engine(label: &str) -> Arc<FfiEngine> {
+        FfiEngine::open(FfiEngineConfig {
+            data_root: unique_test_dir(label),
+            hmac_key: b"ffi-test-key".to_vec(),
+            read_token: None,
+            write_token: None,
+            approve_token: None,
+            max_world_bytes: None,
+            max_memory_bytes: None,
+            max_storage_bytes: None,
+            max_listen_connections: None,
+            listen_replay_max: None,
+            read_cache_max_entries: Some(2),
+        })
+        .expect("engine opens")
+    }
+
+    fn small_representation(body: &[u8]) -> FfiRepresentation {
+        FfiRepresentation {
+            body: body.to_vec(),
+            content_type: "text/plain".to_owned(),
+            headers: Vec::new(),
+        }
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -251,8 +251,8 @@ fn optional_usize(name: &'static str, value: Option<u64>) -> Result<Option<usize
 }
 
 fn validated_world(world: String) -> Result<ValidatedWorldPath, FfiError> {
-    ValidatedWorldPath::new(world).map_err(|err| FfiError::InvalidWorld {
-        message: err.to_string(),
+    ValidatedWorldPath::new(world.clone()).map_err(|err| FfiError::InvalidWorld {
+        message: format!("{err}: {world}"),
     })
 }
 
@@ -456,7 +456,13 @@ mod tests {
         let err = engine
             .read("/home/doc".to_owned(), FfiAccessTier::Read)
             .expect_err("wire paths are not Engine worlds");
-        assert!(matches!(err, FfiError::InvalidWorld { .. }));
+        match err {
+            FfiError::InvalidWorld { message } => {
+                assert!(message.contains("invalid world path"));
+                assert!(message.contains("/home/doc"));
+            }
+            other => panic!("expected invalid world error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -486,7 +492,7 @@ mod tests {
 
         let stale = FfiPreconditions {
             if_match: vec![FfiEtagMatcher::Strong {
-                etag: "\"wrong-etag\"".to_owned(),
+                etag: "wrong-etag".to_owned(),
             }],
             if_none_match: Vec::new(),
         };

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use elastik_core::{
     is_valid_token, AccessTier, AuditVerify, AuthGate, DfSnapshot, EngineBuildError, EngineError,
@@ -376,6 +376,14 @@ impl From<FfiHeader> for (String, String) {
     }
 }
 
+fn representation_headers(headers: Vec<FfiHeader>) -> Vec<(String, String)> {
+    let mut out = BTreeMap::new();
+    for header in headers {
+        out.insert(header.name.to_ascii_lowercase(), header.value);
+    }
+    out.into_iter().collect()
+}
+
 /// Converts an FFI representation into the Engine's protocol-neutral form.
 ///
 /// Headers pass through without filtering. This is intentional: the Engine
@@ -384,6 +392,11 @@ impl From<FfiHeader> for (String, String) {
 /// Non-browser adapters such as FFI, MQTT, and CoAP treat headers as plain
 /// key-value metadata with no execution semantics.
 ///
+/// Header names are still normalized and de-duplicated with deterministic
+/// last-wins semantics so durable storage never sees duplicate `meta_headers`
+/// primary keys. This mirrors the HTTP adapter's storage-facing shape without
+/// importing HTTP allow/deny policy into FFI.
+///
 /// The HTTP read path applies its L1 hard-deny output filter before serving any
 /// stored header to a browser, regardless of which adapter originally wrote it.
 impl From<FfiRepresentation> for Representation {
@@ -391,7 +404,7 @@ impl From<FfiRepresentation> for Representation {
         Self::new(
             value.body,
             value.content_type,
-            value.headers.into_iter().map(Into::into).collect(),
+            representation_headers(value.headers),
         )
     }
 }
@@ -629,3 +642,38 @@ fn code_label(sqlite_code: Option<i32>) -> String {
 }
 
 impl std::error::Error for FfiError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn representation_headers_deduplicate_names_last_wins() {
+        let representation = Representation::from(FfiRepresentation {
+            body: b"body".to_vec(),
+            content_type: "text/plain".to_owned(),
+            headers: vec![
+                FfiHeader {
+                    name: "X-Custom".to_owned(),
+                    value: "old".to_owned(),
+                },
+                FfiHeader {
+                    name: "x-other".to_owned(),
+                    value: "kept".to_owned(),
+                },
+                FfiHeader {
+                    name: "x-custom".to_owned(),
+                    value: "new".to_owned(),
+                },
+            ],
+        });
+
+        assert_eq!(
+            representation.headers,
+            vec![
+                ("x-custom".to_owned(), "new".to_owned()),
+                ("x-other".to_owned(), "kept".to_owned()),
+            ]
+        );
+    }
+}

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -376,6 +376,16 @@ impl From<FfiHeader> for (String, String) {
     }
 }
 
+/// Converts an FFI representation into the Engine's protocol-neutral form.
+///
+/// Headers pass through without filtering. This is intentional: the Engine
+/// treats headers as opaque metadata, while the HTTP adapter applies persistence
+/// filtering because browsers execute response headers as security policy.
+/// Non-browser adapters such as FFI, MQTT, and CoAP treat headers as plain
+/// key-value metadata with no execution semantics.
+///
+/// The HTTP read path applies its L1 hard-deny output filter before serving any
+/// stored header to a browser, regardless of which adapter originally wrote it.
 impl From<FfiRepresentation> for Representation {
     fn from(value: FfiRepresentation) -> Self {
         Self::new(

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -2,7 +2,8 @@ use std::fmt;
 
 use elastik_core::{
     is_valid_token, AccessTier, AuditVerify, AuthGate, DfSnapshot, EngineBuildError, EngineError,
-    PoolSnapshot, WriteKind,
+    EtagMatcher, PoolSnapshot, Preconditions, ReadResult, Representation, WorldUsage, WriteKind,
+    WriteResult,
 };
 
 /// Engine construction options for the FFI adapter.
@@ -79,7 +80,22 @@ pub struct FfiHeader {
     pub value: String,
 }
 
-/// Stored representation for future write/read bindings.
+/// ETag matcher used by FFI write preconditions.
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiEtagMatcher {
+    Any,
+    Strong { etag: String },
+    Weak { etag: String },
+}
+
+/// Protocol-neutral write preconditions.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiPreconditions {
+    pub if_match: Vec<FfiEtagMatcher>,
+    pub if_none_match: Vec<FfiEtagMatcher>,
+}
+
+/// Stored representation passed through Engine read/write verbs.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct FfiRepresentation {
     pub body: Vec<u8>,
@@ -87,14 +103,14 @@ pub struct FfiRepresentation {
     pub headers: Vec<FfiHeader>,
 }
 
-/// Future read result DTO.
+/// Read result DTO returned by Engine read.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct FfiReadResult {
     pub representation: FfiRepresentation,
     pub etag: String,
 }
 
-/// Future write result kind.
+/// Write result kind returned by Engine write verbs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
 pub enum FfiWriteKind {
     Created,
@@ -104,7 +120,7 @@ pub enum FfiWriteKind {
     Unknown,
 }
 
-/// Future write result DTO.
+/// Write result DTO returned by Engine write verbs.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct FfiWriteResult {
     pub kind: FfiWriteKind,
@@ -129,6 +145,13 @@ pub struct FfiChangeEvent {
     pub verb: FfiChangeVerb,
     pub path: String,
     pub etag: String,
+}
+
+/// Per-world body byte usage DTO.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiWorldUsage {
+    pub world: String,
+    pub bytes: u64,
 }
 
 /// Aggregate storage/memory snapshot DTO.
@@ -193,6 +216,9 @@ pub enum FfiError {
         message: String,
     },
     InvalidSecret {
+        message: String,
+    },
+    InvalidWorld {
         message: String,
     },
     BuildDataRootIo {
@@ -285,6 +311,22 @@ fn nonzero_override(value: Option<u64>) -> Option<u64> {
     value.filter(|value| *value > 0)
 }
 
+impl TryFrom<FfiAccessTier> for AccessTier {
+    type Error = FfiError;
+
+    fn try_from(value: FfiAccessTier) -> Result<Self, Self::Error> {
+        match value {
+            FfiAccessTier::Anon => Ok(Self::Anon),
+            FfiAccessTier::Read => Ok(Self::Read),
+            FfiAccessTier::Write => Ok(Self::Write),
+            FfiAccessTier::Approve => Ok(Self::Approve),
+            FfiAccessTier::Unknown => Err(FfiError::InvalidConfig {
+                message: "unknown access tier".to_owned(),
+            }),
+        }
+    }
+}
+
 impl From<AccessTier> for FfiAccessTier {
     fn from(value: AccessTier) -> Self {
         match value {
@@ -305,6 +347,82 @@ impl From<AuthGate> for FfiAuthGate {
             AuthGate::WriteApprove => Self::WriteApprove,
             AuthGate::Delete => Self::Delete,
             _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<FfiEtagMatcher> for EtagMatcher {
+    fn from(value: FfiEtagMatcher) -> Self {
+        match value {
+            FfiEtagMatcher::Any => Self::Any,
+            FfiEtagMatcher::Strong { etag } => Self::Strong(etag),
+            FfiEtagMatcher::Weak { etag } => Self::Weak(etag),
+        }
+    }
+}
+
+impl From<FfiPreconditions> for Preconditions {
+    fn from(value: FfiPreconditions) -> Self {
+        Self::new(
+            value.if_match.into_iter().map(Into::into).collect(),
+            value.if_none_match.into_iter().map(Into::into).collect(),
+        )
+    }
+}
+
+impl From<FfiHeader> for (String, String) {
+    fn from(value: FfiHeader) -> Self {
+        (value.name, value.value)
+    }
+}
+
+impl From<FfiRepresentation> for Representation {
+    fn from(value: FfiRepresentation) -> Self {
+        Self::new(
+            value.body,
+            value.content_type,
+            value.headers.into_iter().map(Into::into).collect(),
+        )
+    }
+}
+
+impl From<Representation> for FfiRepresentation {
+    fn from(value: Representation) -> Self {
+        Self {
+            body: value.body.to_vec(),
+            content_type: value.content_type,
+            headers: value
+                .headers
+                .into_iter()
+                .map(|(name, value)| FfiHeader { name, value })
+                .collect(),
+        }
+    }
+}
+
+impl From<ReadResult> for FfiReadResult {
+    fn from(value: ReadResult) -> Self {
+        Self {
+            representation: value.representation.into(),
+            etag: value.etag,
+        }
+    }
+}
+
+impl From<WriteResult> for FfiWriteResult {
+    fn from(value: WriteResult) -> Self {
+        Self {
+            kind: value.kind.into(),
+            etag: value.etag,
+        }
+    }
+}
+
+impl From<WorldUsage> for FfiWorldUsage {
+    fn from(value: WorldUsage) -> Self {
+        Self {
+            world: value.world.to_string(),
+            bytes: value.bytes as u64,
         }
     }
 }
@@ -439,6 +557,7 @@ impl fmt::Display for FfiError {
         match self {
             Self::InvalidConfig { message }
             | Self::InvalidSecret { message }
+            | Self::InvalidWorld { message }
             | Self::RuntimeInitFailed { message }
             | Self::BuildDataRootIo { message }
             | Self::PreconditionFailed { message }


### PR DESCRIPTION
## Layer

Layer 3 of the UniFFI Engine adapter stack.

Base: `feat/ffi-engine-boundary` (#169)

## Scope

This binds Engine methods through the existing UniFFI handle:

- `read`
- `replace`
- `append`
- `delete`
- `worlds`
- `du`
- `df`
- `pool`
- `audit_verify`

It also adds protocol-neutral DTO conversions for representations, write preconditions, ETag matchers, read/write results, world usage, pool snapshots, and audit verification.

## Boundary

This remains an Engine adapter, sibling to HTTP and CoAP:

- no HTTP methods are exposed as FFI API
- no `/proc/*` route strings are exposed as FFI API
- no HTTP status codes are exposed as FFI API
- `audit_verify(world, tier)` is typed Engine introspection, not `/proc/audit/...`
- subscribe is intentionally left for a later stacked layer

## Validation

- `cargo fmt --manifest-path ffi\Cargo.toml --check`
- `cargo check --manifest-path ffi\Cargo.toml`
- `cargo test --manifest-path ffi\Cargo.toml` (6 passed)
- `cargo build --manifest-path ffi\Cargo.toml`
- `cargo clippy --manifest-path ffi\Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
- `cargo run --bin uniffi-bindgen -- generate target\debug\elastik_ffi.dll --language python --out-dir target\bindings\python`
- Python binding smoke: imported generated `elastik_ffi.py`, loaded DLL, then exercised `open -> replace -> append -> read -> worlds -> du -> df -> pool -> audit_verify -> delete` successfully.
- Push hook: all Elastik local gates passed, including Rust core tests, Python SDK smoke, header policy scanner, JS syntax, and whitespace check.

## Review notes

Diff in FFI: `ffi/src/lib.rs` and `ffi/src/types.rs`.

In core, clarify the header policy is for http.

