### PR TITLE
feat(ffi): add blocking subscription receiver

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 elastik-core = { path = "../core", default-features = false, features = ["bundled-sqlite", "unstable-engine"] }
-tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 uniffi = { version = "0.31.1", features = ["cli"] }
 
 [[bin]]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -8,10 +8,16 @@
 // The deprecation remains part of the generated ABI for downstream consumers.
 #![allow(deprecated)]
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use elastik_core::{Engine, SecretBytes, ValidatedWorldPath};
-use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
+use elastik_core::{
+    ChangeEvent, Engine, SecretBytes, SubscribePattern, SubscriptionRecvError, ValidatedWorldPath,
+};
+use tokio::{
+    runtime::{Builder as RuntimeBuilder, Handle, Runtime},
+    sync::{mpsc, watch, Mutex},
+    time::timeout,
+};
 
 mod types;
 
@@ -26,6 +32,16 @@ pub struct FfiEngine {
     runtime: Runtime,
     config: FfiEngineConfigSummary,
 }
+
+/// UniFFI-owned blocking receiver for Engine subscription events.
+#[derive(uniffi::Object)]
+pub struct FfiSubscription {
+    events: Mutex<mpsc::Receiver<FfiSubscriptionNext>>,
+    cancel: watch::Sender<bool>,
+    runtime: Handle,
+}
+
+const FFI_SUBSCRIPTION_BUFFER: usize = 1024;
 
 #[uniffi::export]
 impl FfiEngine {
@@ -215,6 +231,83 @@ impl FfiEngine {
         let world = validated_world(world)?;
         Ok(self.engine.verify_audit(&world, tier.try_into()?)?.into())
     }
+
+    /// Opens a protocol-neutral Engine subscription.
+    ///
+    /// `pattern` is an Engine subscription pattern such as `*` or
+    /// `home/tasks/*`; it is not a `/listen/*` HTTP route.
+    pub fn subscribe(
+        &self,
+        pattern: String,
+        tier: FfiAccessTier,
+        since: Option<u64>,
+    ) -> Result<Arc<FfiSubscription>, FfiError> {
+        let pattern = SubscribePattern::new(pattern);
+        let mut subscription = self.engine.subscribe(&pattern, tier.try_into()?, since)?;
+        let (events_tx, events_rx) = mpsc::channel(FFI_SUBSCRIPTION_BUFFER);
+        let (cancel, mut cancel_rx) = watch::channel(false);
+        self.runtime.spawn(async move {
+            loop {
+                tokio::select! {
+                    changed = cancel_rx.changed() => {
+                        let _ = changed;
+                        break;
+                    }
+                    item = subscription.recv() => {
+                        let (next, terminal) = subscription_next_from_recv(item);
+                        let sent = tokio::select! {
+                            changed = cancel_rx.changed() => {
+                                let _ = changed;
+                                break;
+                            }
+                            sent = events_tx.send(next) => sent,
+                        };
+                        if sent.is_err() || terminal {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        Ok(Arc::new(FfiSubscription {
+            events: Mutex::new(events_rx),
+            cancel,
+            runtime: self.runtime.handle().clone(),
+        }))
+    }
+}
+
+#[uniffi::export]
+impl FfiSubscription {
+    /// Blocks until the next event, timeout, lag, or close.
+    ///
+    /// This is a blocking receive, not busy polling. A timeout returns
+    /// `Timeout` so foreign callers can periodically check their own
+    /// cancellation condition without crossing a callback boundary.
+    pub fn next(&self, timeout_ms: u64) -> FfiSubscriptionNext {
+        match self.runtime.block_on(async {
+            let mut events = self.events.lock().await;
+            timeout(Duration::from_millis(timeout_ms), events.recv()).await
+        }) {
+            Ok(Some(next)) => next,
+            Ok(None) => FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Closed,
+                event: None,
+                skipped: None,
+            },
+            Err(_) => FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Timeout,
+                event: None,
+                skipped: None,
+            },
+        }
+    }
+}
+
+impl Drop for FfiSubscription {
+    fn drop(&mut self) {
+        let _ = self.cancel.send(true);
+    }
 }
 
 impl Drop for FfiEngine {
@@ -254,6 +347,45 @@ fn validated_world(world: String) -> Result<ValidatedWorldPath, FfiError> {
     ValidatedWorldPath::new(world.clone()).map_err(|err| FfiError::InvalidWorld {
         message: format!("{err}: {world}"),
     })
+}
+
+fn subscription_next_from_recv(
+    result: Result<ChangeEvent, SubscriptionRecvError>,
+) -> (FfiSubscriptionNext, bool) {
+    match result {
+        Ok(event) => (
+            FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Event,
+                event: Some(event.into()),
+                skipped: None,
+            },
+            false,
+        ),
+        Err(SubscriptionRecvError::Lagged { skipped }) => (
+            FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Lagged,
+                event: None,
+                skipped: Some(skipped),
+            },
+            false,
+        ),
+        Err(SubscriptionRecvError::Closed) => (
+            FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Closed,
+                event: None,
+                skipped: None,
+            },
+            true,
+        ),
+        Err(_) => (
+            FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Unknown,
+                event: None,
+                skipped: None,
+            },
+            false,
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -505,6 +637,67 @@ mod tests {
             )
             .expect_err("stale If-Match rejected");
         assert!(matches!(err, FfiError::PreconditionFailed { .. }));
+    }
+
+    #[test]
+    fn subscription_next_drains_replay_then_live_events() {
+        let engine = test_engine("subscribe");
+        let none = FfiPreconditions {
+            if_match: Vec::new(),
+            if_none_match: Vec::new(),
+        };
+        engine
+            .replace(
+                "home/events/a".to_owned(),
+                FfiRepresentation {
+                    body: b"first".to_vec(),
+                    content_type: "text/plain".to_owned(),
+                    headers: Vec::new(),
+                },
+                none.clone(),
+                FfiAccessTier::Write,
+            )
+            .expect("first write succeeds");
+
+        let subscription = engine
+            .subscribe("home/events/*".to_owned(), FfiAccessTier::Read, Some(0))
+            .expect("subscription opens");
+        let replay = subscription.next(1_000);
+        assert_eq!(replay.kind, FfiSubscriptionNextKind::Event);
+        let event = replay.event.expect("replay event");
+        assert_eq!(event.verb, FfiChangeVerb::Replace);
+        assert_eq!(event.path, "home/events/a");
+
+        let timeout = subscription.next(1);
+        assert_eq!(timeout.kind, FfiSubscriptionNextKind::Timeout);
+        assert!(timeout.event.is_none());
+
+        engine
+            .append(
+                "home/events/a".to_owned(),
+                b" live".to_vec(),
+                none,
+                FfiAccessTier::Write,
+            )
+            .expect("append succeeds");
+        let live = subscription.next(1_000);
+        assert_eq!(live.kind, FfiSubscriptionNextKind::Event);
+        let event = live.event.expect("live event");
+        assert_eq!(event.verb, FfiChangeVerb::Append);
+        assert_eq!(event.path, "home/events/a");
+    }
+
+    #[test]
+    fn subscription_next_reports_closed_after_shutdown() {
+        let engine = test_engine("subscribe-closed");
+        let subscription = engine
+            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .expect("subscription opens");
+        engine.shutdown();
+
+        let closed = subscription.next(1_000);
+        assert_eq!(closed.kind, FfiSubscriptionNextKind::Closed);
+        assert!(closed.event.is_none());
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -16,6 +16,7 @@ use elastik_core::{
 use tokio::{
     runtime::{Builder as RuntimeBuilder, Runtime},
     sync::{mpsc, watch, Mutex},
+    task::JoinHandle,
     time::timeout,
 };
 
@@ -38,6 +39,7 @@ pub struct FfiEngine {
 pub struct FfiSubscription {
     events: Mutex<mpsc::Receiver<FfiSubscriptionNext>>,
     cancel: watch::Sender<bool>,
+    pump: Mutex<Option<JoinHandle<()>>>,
     runtime: Arc<Runtime>,
 }
 
@@ -248,7 +250,7 @@ impl FfiEngine {
         let mut subscription = self.engine.subscribe(&pattern, tier.try_into()?, since)?;
         let (events_tx, events_rx) = mpsc::channel(FFI_SUBSCRIPTION_BUFFER);
         let (cancel, mut cancel_rx) = watch::channel(false);
-        self.runtime.spawn(async move {
+        let pump = self.runtime.spawn(async move {
             loop {
                 tokio::select! {
                     changed = cancel_rx.changed() => {
@@ -274,6 +276,7 @@ impl FfiEngine {
         Ok(Arc::new(FfiSubscription {
             events: Mutex::new(events_rx),
             cancel,
+            pump: Mutex::new(Some(pump)),
             runtime: Arc::clone(&self.runtime),
         }))
     }
@@ -304,11 +307,32 @@ impl FfiSubscription {
             },
         }
     }
+
+    /// Closes the subscription and releases the underlying Engine listen slot.
+    ///
+    /// Foreign-language callers should use this for deterministic cleanup
+    /// instead of waiting for GC/finalization to drop the object.
+    pub fn close(&self) {
+        let _ = self.cancel.send(true);
+        self.runtime.block_on(async {
+            if let Some(pump) = self.pump.lock().await.take() {
+                let _ = pump.await;
+            }
+            let mut events = self.events.lock().await;
+            events.close();
+            while events.try_recv().is_ok() {}
+        });
+    }
 }
 
 impl Drop for FfiSubscription {
     fn drop(&mut self) {
         let _ = self.cancel.send(true);
+        if let Ok(mut pump) = self.pump.try_lock() {
+            if let Some(pump) = pump.take() {
+                pump.abort();
+            }
+        }
     }
 }
 
@@ -385,7 +409,7 @@ fn subscription_next_from_recv(
                 event: None,
                 skipped: None,
             },
-            false,
+            true,
         ),
     }
 }
@@ -700,6 +724,43 @@ mod tests {
         let closed = subscription.next(1_000);
         assert_eq!(closed.kind, FfiSubscriptionNextKind::Closed);
         assert!(closed.event.is_none());
+    }
+
+    #[test]
+    fn subscription_close_releases_receiver_without_waiting_for_drop() {
+        let engine = FfiEngine::open(FfiEngineConfig {
+            data_root: unique_test_dir("subscribe-explicit-close"),
+            hmac_key: b"ffi-test-key".to_vec(),
+            read_token: None,
+            write_token: None,
+            approve_token: None,
+            max_world_bytes: None,
+            max_memory_bytes: None,
+            max_storage_bytes: None,
+            max_listen_connections: Some(1),
+            listen_replay_max: None,
+            read_cache_max_entries: Some(2),
+        })
+        .expect("engine opens");
+
+        let subscription = engine
+            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .expect("first subscription opens");
+        assert!(
+            engine
+                .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+                .is_err(),
+            "listen slot cap should be held while subscription is open"
+        );
+
+        subscription.close();
+        let closed = subscription.next(100);
+        assert_eq!(closed.kind, FfiSubscriptionNextKind::Closed);
+
+        let replacement = engine
+            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .expect("explicit close releases listen slot");
+        replacement.close();
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -14,7 +14,7 @@ use elastik_core::{
     ChangeEvent, Engine, SecretBytes, SubscribePattern, SubscriptionRecvError, ValidatedWorldPath,
 };
 use tokio::{
-    runtime::{Builder as RuntimeBuilder, Handle, Runtime},
+    runtime::{Builder as RuntimeBuilder, Runtime},
     sync::{mpsc, watch, Mutex},
     time::timeout,
 };
@@ -29,7 +29,7 @@ uniffi::setup_scaffolding!();
 #[derive(uniffi::Object)]
 pub struct FfiEngine {
     engine: Engine,
-    runtime: Runtime,
+    runtime: Arc<Runtime>,
     config: FfiEngineConfigSummary,
 }
 
@@ -38,7 +38,7 @@ pub struct FfiEngine {
 pub struct FfiSubscription {
     events: Mutex<mpsc::Receiver<FfiSubscriptionNext>>,
     cancel: watch::Sender<bool>,
-    runtime: Handle,
+    runtime: Arc<Runtime>,
 }
 
 const FFI_SUBSCRIPTION_BUFFER: usize = 1024;
@@ -89,13 +89,15 @@ impl FfiEngine {
         }
 
         let engine = builder.build()?;
-        let runtime = RuntimeBuilder::new_multi_thread()
-            .enable_all()
-            .thread_name("elastik-ffi")
-            .build()
-            .map_err(|err| FfiError::RuntimeInitFailed {
-                message: err.to_string(),
-            })?;
+        let runtime = Arc::new(
+            RuntimeBuilder::new_multi_thread()
+                .enable_all()
+                .thread_name("elastik-ffi")
+                .build()
+                .map_err(|err| FfiError::RuntimeInitFailed {
+                    message: err.to_string(),
+                })?,
+        );
 
         Ok(Arc::new(Self {
             engine,
@@ -272,7 +274,7 @@ impl FfiEngine {
         Ok(Arc::new(FfiSubscription {
             events: Mutex::new(events_rx),
             cancel,
-            runtime: self.runtime.handle().clone(),
+            runtime: Arc::clone(&self.runtime),
         }))
     }
 }
@@ -698,6 +700,24 @@ mod tests {
         let closed = subscription.next(1_000);
         assert_eq!(closed.kind, FfiSubscriptionNextKind::Closed);
         assert!(closed.event.is_none());
+    }
+
+    #[test]
+    fn subscription_next_survives_engine_handle_drop() {
+        let engine = test_engine("subscribe-drop-engine");
+        let subscription = engine
+            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .expect("subscription opens");
+
+        drop(engine);
+
+        let next = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| subscription.next(10)))
+            .expect("subscription next must not panic after engine handle drop");
+        assert!(matches!(
+            next.kind,
+            FfiSubscriptionNextKind::Closed | FfiSubscriptionNextKind::Timeout
+        ));
+        assert!(next.event.is_none());
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -1,9 +1,9 @@
 use std::{collections::BTreeMap, fmt};
 
 use elastik_core::{
-    is_valid_token, AccessTier, AuditVerify, AuthGate, DfSnapshot, EngineBuildError, EngineError,
-    EtagMatcher, PoolSnapshot, Preconditions, ReadResult, Representation, WorldUsage, WriteKind,
-    WriteResult,
+    is_valid_token, AccessTier, AuditVerify, AuthGate, ChangeEvent, DfSnapshot, EngineBuildError,
+    EngineError, EtagMatcher, PoolSnapshot, Preconditions, ReadResult, Representation, WorldUsage,
+    WriteKind, WriteResult,
 };
 
 /// Engine construction options for the FFI adapter.
@@ -138,13 +138,33 @@ pub enum FfiChangeVerb {
     Unknown,
 }
 
-/// Future subscription event DTO.
+/// Subscription event DTO returned by Engine subscriptions.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct FfiChangeEvent {
     pub id: u64,
     pub verb: FfiChangeVerb,
     pub path: String,
     pub etag: String,
+}
+
+/// Result kind returned by `FfiSubscription.next`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiSubscriptionNextKind {
+    Event,
+    Timeout,
+    Lagged,
+    Closed,
+    /// The Engine returned a subscription state this FFI binding does not yet
+    /// recognize. Treat as indeterminate and upgrade the binding.
+    Unknown,
+}
+
+/// Blocking subscription receive result.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiSubscriptionNext {
+    pub kind: FfiSubscriptionNextKind,
+    pub event: Option<FfiChangeEvent>,
+    pub skipped: Option<u64>,
 }
 
 /// Per-world body byte usage DTO.
@@ -447,6 +467,26 @@ impl From<WorldUsage> for FfiWorldUsage {
             world: value.world.to_string(),
             bytes: value.bytes as u64,
         }
+    }
+}
+
+impl From<ChangeEvent> for FfiChangeEvent {
+    fn from(value: ChangeEvent) -> Self {
+        Self {
+            id: value.id,
+            verb: change_verb(value.method),
+            path: value.path.to_string(),
+            etag: value.etag,
+        }
+    }
+}
+
+fn change_verb(method: &str) -> FfiChangeVerb {
+    match method {
+        "PUT" => FfiChangeVerb::Replace,
+        "POST" => FfiChangeVerb::Append,
+        "DELETE" => FfiChangeVerb::Delete,
+        _ => FfiChangeVerb::Unknown,
     }
 }
 


### PR DESCRIPTION
## Layer

Layer 4 of the UniFFI Engine adapter stack.

Base: `feat/ffi-engine-verbs` (#170)

## Scope

Adds subscription support as a separate receiver object:

- `FfiEngine.subscribe(pattern, tier, since) -> FfiSubscription`
- `FfiSubscription.next(timeout_ms) -> FfiSubscriptionNext`
- `FfiSubscriptionNextKind::{Event, Timeout, Lagged, Closed, Unknown}`
- `FfiChangeEvent` conversion from protocol-neutral Engine change events

## Boundary

This remains Engine-bound:

- binds `Engine::subscribe` and `EngineSubscription::recv`
- does not expose `/listen/*`
- does not expose SSE framing
- does not expose HTTP status codes
- uses Engine subscription patterns such as `*` or `home/tasks/*`

## Design notes

`next(timeout_ms)` is a blocking receive, not busy polling.

The FFI layer does **not** implement timeout by cancelling `EngineSubscription::recv()`, because the core receiver state machine is not a timeout primitive. Instead, a background runtime task owns the `EngineSubscription` and forwards typed receive results into a bounded Tokio channel. `next(timeout_ms)` waits on that channel, so timeout returns `Timeout` without mutating the core subscription state.

The channel is bounded (`1024`) so a foreign caller that stops draining cannot accumulate unbounded events.

## Validation

- `cargo fmt --manifest-path ffi\Cargo.toml --check`
- `cargo check --manifest-path ffi\Cargo.toml`
- `cargo test --manifest-path ffi\Cargo.toml` (8 passed)
- `cargo build` from `ffi/`
- `cargo clippy --manifest-path ffi\Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
- `cargo run --bin uniffi-bindgen -- generate target\debug\elastik_ffi.dll --language python --out-dir target\bindings\python`
- Python binding smoke: replay event, timeout, live event, and closed-after-shutdown all passed.
- Push hook: all Elastik local gates passed, including Rust core tests, Python SDK smoke, header policy scanner, JS syntax, and whitespace check.

## Review notes

The main bug avoided here: wrapping `EngineSubscription::recv()` directly in `tokio::time::timeout` closes the subscription on timeout because cancelling that future can leave the core recv state in its defensive closed state. The worker/channel boundary avoids that.