### PR TITLE
ci(ffi): build multi-platform artifacts

### DIFF
--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -33,15 +33,15 @@ jobs:
             os: macos-14
             library-path: target/release/libelastik_ffi.dylib
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             library-path: target/release/elastik_ffi.dll
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -175,7 +175,7 @@ jobs:
           PY
 
       - name: upload FFI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: elastik-ffi-${{ matrix.name }}
           path: ffi/elastik-ffi-${{ matrix.name }}.zip

--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -15,6 +15,7 @@ jobs:
   build-ffi-artifact:
     name: build ffi artifact (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -50,11 +51,14 @@ jobs:
       - name: generate Python UniFFI binding
         shell: bash
         working-directory: ffi
-        run: >
-          cargo run --bin uniffi-bindgen --
-          generate "${{ matrix.library-path }}"
-          --language python
-          --out-dir target/bindings/python
+        run: |
+          bindgen="target/release/uniffi-bindgen"
+          if [ -x "target/release/uniffi-bindgen.exe" ]; then
+            bindgen="target/release/uniffi-bindgen.exe"
+          fi
+          "$bindgen" generate "${{ matrix.library-path }}" \
+            --language python \
+            --out-dir target/bindings/python
 
       - name: smoke generated Python binding
         shell: bash

--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -1,0 +1,178 @@
+name: ffi artifacts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/ffi-artifacts.yml"
+      - "core/**"
+      - "ffi/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-ffi-artifact:
+    name: build ffi artifact (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            os: ubuntu-latest
+            library-path: target/release/libelastik_ffi.so
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            library-path: target/release/libelastik_ffi.so
+          - name: macos-x64
+            os: macos-13
+            library-path: target/release/libelastik_ffi.dylib
+          - name: macos-arm64
+            os: macos-14
+            library-path: target/release/libelastik_ffi.dylib
+          - name: windows-x64
+            os: windows-latest
+            library-path: target/release/elastik_ffi.dll
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: build native FFI library
+        run: cargo build --release --manifest-path ffi/Cargo.toml
+
+      - name: generate Python UniFFI binding
+        shell: bash
+        working-directory: ffi
+        run: >
+          cargo run --bin uniffi-bindgen --
+          generate "${{ matrix.library-path }}"
+          --language python
+          --out-dir target/bindings/python
+
+      - name: smoke generated Python binding
+        shell: bash
+        working-directory: ffi
+        env:
+          ELASTIK_FFI_LIBRARY: ${{ matrix.library-path }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import shutil
+          import sys
+          import tempfile
+
+          bindings = pathlib.Path("target/bindings/python").resolve()
+          library = pathlib.Path(os.environ["ELASTIK_FFI_LIBRARY"]).resolve()
+          if not library.exists():
+              raise SystemExit(f"missing FFI library: {library}")
+          shutil.copy2(library, bindings / library.name)
+          sys.path.insert(0, str(bindings))
+
+          import elastik_ffi as e
+
+          root = pathlib.Path(tempfile.mkdtemp(prefix="elastik-ffi-ci-"))
+          none = e.FfiPreconditions(if_match=[], if_none_match=[])
+          engine = e.FfiEngine.open(e.FfiEngineConfig(
+              data_root=str(root),
+              hmac_key=b"ffi-ci-key",
+              read_token=None,
+              write_token=None,
+              approve_token=None,
+              max_world_bytes=None,
+              max_memory_bytes=None,
+              max_storage_bytes=None,
+              max_listen_connections=None,
+              listen_replay_max=8,
+              read_cache_max_entries=2,
+          ))
+
+          engine.replace("home/ffi", e.FfiRepresentation(
+              body=b"hello",
+              content_type="text/plain",
+              headers=[],
+          ), none, e.FfiAccessTier.WRITE)
+          read = engine.read("home/ffi", e.FfiAccessTier.READ)
+          assert read is not None
+          assert read.representation.body == b"hello"
+
+          subscription = engine.subscribe("home/*", e.FfiAccessTier.READ, None)
+          engine.append("home/ffi", b" world", none, e.FfiAccessTier.WRITE)
+          event = subscription.next(5_000)
+          assert event.kind == e.FfiSubscriptionNextKind.EVENT, event.kind
+          assert event.event.path == "home/ffi", event.event.path
+
+          engine.shutdown()
+          closed = subscription.next(5_000)
+          assert closed.kind == e.FfiSubscriptionNextKind.CLOSED, closed.kind
+          print("ffi artifact smoke ok", e.ffi_version(), root)
+          PY
+
+      - name: package FFI artifact
+        shell: bash
+        working-directory: ffi
+        env:
+          ELASTIK_FFI_NAME: ${{ matrix.name }}
+          ELASTIK_FFI_LIBRARY: ${{ matrix.library-path }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import os
+          import pathlib
+          import shutil
+          import zipfile
+
+          name = os.environ["ELASTIK_FFI_NAME"]
+          library = pathlib.Path(os.environ["ELASTIK_FFI_LIBRARY"]).resolve()
+          bindings = pathlib.Path("target/bindings/python").resolve()
+          out = pathlib.Path("ffi-artifact").resolve()
+          package = pathlib.Path(f"elastik-ffi-{name}.zip").resolve()
+
+          if out.exists():
+              shutil.rmtree(out)
+          out.joinpath("lib").mkdir(parents=True)
+          out.joinpath("python").mkdir(parents=True)
+
+          native_dst = out / "lib" / library.name
+          shutil.copy2(library, native_dst)
+          shutil.copy2(bindings / "elastik_ffi.py", out / "python" / "elastik_ffi.py")
+          shutil.copy2(library, out / "python" / library.name)
+
+          def sha256(path: pathlib.Path) -> str:
+              h = hashlib.sha256()
+              with path.open("rb") as f:
+                  for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                      h.update(chunk)
+              return h.hexdigest()
+
+          manifest = "\n".join([
+              f"name={name}",
+              f"library={library.name}",
+              f"library_sha256={sha256(native_dst)}",
+              "python_binding=python/elastik_ffi.py",
+              "",
+          ])
+          out.joinpath("MANIFEST.txt").write_text(manifest, encoding="utf-8")
+
+          if package.exists():
+              package.unlink()
+          with zipfile.ZipFile(package, "w", zipfile.ZIP_DEFLATED) as z:
+              for path in sorted(out.rglob("*")):
+                  if path.is_file():
+                      z.write(path, path.relative_to(out).as_posix())
+          print(package)
+          PY
+
+      - name: upload FFI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: elastik-ffi-${{ matrix.name }}
+          path: ffi/elastik-ffi-${{ matrix.name }}.zip
+          if-no-files-found: error

--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
             os: ubuntu-24.04-arm
             library-path: target/release/libelastik_ffi.so
           - name: macos-x64
-            os: macos-13
+            os: macos-15-intel
             library-path: target/release/libelastik_ffi.dylib
           - name: macos-arm64
             os: macos-14

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -6,11 +6,16 @@ This crate is deliberately not an HTTP binding. Its upstream is the Rust
 `Engine` facade from `elastik-core`; HTTP, CoAP, SDK wire clients, and this FFI
 crate are sibling adapters.
 
-## Current Surface (Layer 2: Handle + Type Boundary)
+## Current Surface
 
+- `crate-type = ["lib", "cdylib"]`
+- UniFFI scaffolding compiles
 - `FfiEngine.open(config)` — construct an Engine with an embedded Tokio runtime
 - `engine.config_summary()` — non-secret configuration accepted by the adapter
 - `engine.verify_token(token)` — check caller access tier without side effects
+- `engine.read`, `replace`, `append`, `delete` — Engine verbs bound directly
+- `engine.worlds`, `du`, `df`, `pool`, `audit_verify` — typed introspection
+- `engine.subscribe(pattern, tier, since)` — blocking `FfiSubscription.next(timeout_ms)` receiver
 - `engine.shutdown()` — orderly Engine shutdown (also called automatically on drop)
 - 24-variant `FfiError` with structured payloads (quota numbers, sqlite codes,
   auth gate identity) — errors cross the FFI boundary without information loss
@@ -27,9 +32,9 @@ cargo run --bin uniffi-bindgen -- generate target\debug\elastik_ffi.dll --langua
 
 ## Python-Shaped Usage
 
-Names can vary slightly by generated binding language, but the current FFI
-surface intentionally stays limited to handle construction, token verification,
-configuration summary, shutdown, and typed errors.
+Names can vary slightly by generated binding language. This example sticks to
+the handle-level calls every binding exposes the same way; verb and subscription
+DTOs are generated from the same UniFFI surface.
 
 ```python
 from elastik_ffi import FfiAccessTier, FfiEngine, FfiEngineConfig
@@ -79,11 +84,16 @@ except FfiError.BuildDataRootLockHeld as e:
     print(f"locked: {e.path}")
 ```
 
-## Not Yet Bound
+## Artifact CI
 
-These Engine capabilities have FFI DTOs defined but are not yet wired:
+The artifact CI workflow builds and smokes native libraries plus generated
+Python bindings for:
 
-- `read`, `replace`, `append`, `delete` — Engine verbs
-- `worlds`, `du`, `df`, `pool`, `audit_verify(world)` — typed introspection
-- `subscribe(pattern, tier, since) -> FfiSubscription` — change event receiver
-- CI/release build matrix for `.so`, `.dylib`, `.dll`, and language bindings
+- Linux x64 (`libelastik_ffi.so`)
+- Linux ARM64 (`libelastik_ffi.so`)
+- macOS x64 (`libelastik_ffi.dylib`)
+- macOS ARM64 (`libelastik_ffi.dylib`)
+- Windows x64 (`elastik_ffi.dll`)
+
+Tagged-release attachment and checksum integration belong to the next stack
+layer after the CI artifact shape is validated.

--- a/ffi/STACK.md
+++ b/ffi/STACK.md
@@ -25,20 +25,29 @@ HTTP server, routes, status codes, or `/proc/*` paths.
 
 4. **Subscribe Receiver**
    - Bind `subscribe(pattern, tier, since) -> FfiSubscription`.
-   - Expose `next(timeout_ms) -> Option<ChangeEvent>` and `close`.
+   - Expose `next(timeout_ms) -> FfiSubscriptionNext` with typed `Event`,
+     `Timeout`, `Lagged`, `Closed`, and `Unknown` states.
+   - Let dropping the subscription object release the Engine slot; avoid a
+     callback-first ABI.
    - Avoid callback-first FFI; language wrappers can build iterators or async
      streams on top of `next`.
 
-5. **Build + Distribution Matrix**
-   - Add CI/release jobs for native FFI libraries:
-     - `x86_64-unknown-linux-gnu`
-     - `aarch64-unknown-linux-gnu`
-     - `x86_64-apple-darwin`
-     - `aarch64-apple-darwin`
-     - `x86_64-pc-windows-msvc`
+5. **Artifact CI Matrix**
+   - Build and smoke native FFI libraries plus generated Python UniFFI binding:
+     - Linux x64 (`.so`)
+     - Linux ARM64 (`.so`)
+     - macOS x64 (`.dylib`)
+     - macOS ARM64 (`.dylib`)
+     - Windows x64 (`.dll`)
+   - Upload zipped CI artifacts containing the native library, generated
+     `elastik_ffi.py`, and a manifest with the native library hash.
+
+6. **Release Integration**
+   - Attach FFI artifacts to tagged releases once the CI artifact shape is
+     validated.
+   - Add FFI packages to release checksum manifests.
    - Document OpenWrt/MIPS as a cross-toolchain target, not a guaranteed
      GitHub-hosted runner output.
-   - Generate and package language bindings after the Engine surface is stable.
 
 ## Boundary Rules
 


### PR DESCRIPTION
## Layer

Layer 5 of the UniFFI Engine adapter stack.

Base: `feat/ffi-subscribe-receiver` (#171)

## Scope

Adds a dedicated FFI artifact CI workflow. This PR does not change the FFI API surface and does not attach release assets yet.

The workflow builds, smokes, packages, and uploads zipped artifacts for:

- Linux x64: `libelastik_ffi.so`
- Linux ARM64: `libelastik_ffi.so`
- macOS x64: `libelastik_ffi.dylib`
- macOS ARM64: `libelastik_ffi.dylib`
- Windows x64: `elastik_ffi.dll`

Each artifact includes:

- `lib/<native-library>`
- `python/elastik_ffi.py`
- `python/<native-library>` for immediate Python import smoke/use
- `MANIFEST.txt` with the native library SHA-256

## Boundary

This stays in the distribution lane:

- no Engine API additions
- no HTTP/server adapter leakage
- no tagged release mutation yet
- no crates/npm/PyPI publishing changes

Release attachment and checksum integration are intentionally left for the next stack layer after the artifact shape is validated by CI.

## Validation

Local validation on Windows:

- `cargo build --release --manifest-path ffi\Cargo.toml`
- `cargo run --bin uniffi-bindgen -- generate target\release\elastik_ffi.dll --language python --out-dir target\bindings\python` from `ffi/`
- generated Python binding smoke against the release DLL: Engine open/read/write/subscribe/closed path passed
- local package script produced `elastik-ffi-windows-x64.zip` containing `MANIFEST.txt`, `lib/elastik_ffi.dll`, `python/elastik_ffi.py`, and `python/elastik_ffi.dll`
- `git diff --check`
- Push hook: all Elastik local gates passed, including Rust core tests, Python SDK smoke, header policy scanner, JS syntax, and whitespace check

## Review notes

`uniffi-bindgen` must run from the `ffi/` crate directory because it invokes `cargo metadata`. The workflow does that explicitly for binding generation, smoke, and packaging.