### PR TITLE
ci(release): attach ffi artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,7 @@ jobs:
   build-ffi-assets:
     name: build ffi asset (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -199,11 +200,14 @@ jobs:
       - name: generate Python UniFFI binding
         shell: bash
         working-directory: ffi
-        run: >
-          cargo run --bin uniffi-bindgen --
-          generate "${{ matrix.library-path }}"
-          --language python
-          --out-dir target/bindings/python
+        run: |
+          bindgen="target/release/uniffi-bindgen"
+          if [ -x "target/release/uniffi-bindgen.exe" ]; then
+            bindgen="target/release/uniffi-bindgen.exe"
+          fi
+          "$bindgen" generate "${{ matrix.library-path }}" \
+            --language python \
+            --out-dir target/bindings/python
 
       - name: smoke generated Python binding
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,169 @@ jobs:
           path: npm-packages/*.tgz
           if-no-files-found: error
 
+  build-ffi-assets:
+    name: build ffi asset (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            os: ubuntu-latest
+            library-path: target/release/libelastik_ffi.so
+            asset-name: elastik-ffi-linux-x64.zip
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            library-path: target/release/libelastik_ffi.so
+            asset-name: elastik-ffi-linux-arm64.zip
+          - name: macos-x64
+            os: macos-13
+            library-path: target/release/libelastik_ffi.dylib
+            asset-name: elastik-ffi-darwin-x64.zip
+          - name: macos-arm64
+            os: macos-14
+            library-path: target/release/libelastik_ffi.dylib
+            asset-name: elastik-ffi-darwin-arm64.zip
+          - name: windows-x64
+            os: windows-latest
+            library-path: target/release/elastik_ffi.dll
+            asset-name: elastik-ffi-win32-x64.zip
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: build ffi library
+        run: cargo build --release --manifest-path ffi/Cargo.toml
+
+      - name: generate Python UniFFI binding
+        shell: bash
+        working-directory: ffi
+        run: >
+          cargo run --bin uniffi-bindgen --
+          generate "${{ matrix.library-path }}"
+          --language python
+          --out-dir target/bindings/python
+
+      - name: smoke generated Python binding
+        shell: bash
+        working-directory: ffi
+        env:
+          ELASTIK_FFI_LIBRARY: ${{ matrix.library-path }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import shutil
+          import sys
+          import tempfile
+
+          bindings = pathlib.Path("target/bindings/python").resolve()
+          library = pathlib.Path(os.environ["ELASTIK_FFI_LIBRARY"]).resolve()
+          if not library.exists():
+              raise SystemExit(f"missing FFI library: {library}")
+          shutil.copy2(library, bindings / library.name)
+          sys.path.insert(0, str(bindings))
+
+          import elastik_ffi as e
+
+          root = pathlib.Path(tempfile.mkdtemp(prefix="elastik-ffi-release-"))
+          none = e.FfiPreconditions(if_match=[], if_none_match=[])
+          engine = e.FfiEngine.open(e.FfiEngineConfig(
+              data_root=str(root),
+              hmac_key=b"ffi-release-key",
+              read_token=None,
+              write_token=None,
+              approve_token=None,
+              max_world_bytes=None,
+              max_memory_bytes=None,
+              max_storage_bytes=None,
+              max_listen_connections=None,
+              listen_replay_max=8,
+              read_cache_max_entries=2,
+          ))
+          engine.replace("home/ffi", e.FfiRepresentation(
+              body=b"release",
+              content_type="text/plain",
+              headers=[],
+          ), none, e.FfiAccessTier.WRITE)
+          read = engine.read("home/ffi", e.FfiAccessTier.READ)
+          assert read is not None
+          assert read.representation.body == b"release"
+          engine.shutdown()
+          print("ffi release smoke ok", e.ffi_version(), root)
+          PY
+
+      - name: package ffi asset
+        shell: bash
+        working-directory: ffi
+        env:
+          ELASTIK_FFI_NAME: ${{ matrix.name }}
+          ELASTIK_FFI_LIBRARY: ${{ matrix.library-path }}
+          ELASTIK_FFI_ASSET: ${{ matrix.asset-name }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import os
+          import pathlib
+          import shutil
+          import zipfile
+
+          name = os.environ["ELASTIK_FFI_NAME"]
+          library = pathlib.Path(os.environ["ELASTIK_FFI_LIBRARY"]).resolve()
+          asset = pathlib.Path(os.environ["ELASTIK_FFI_ASSET"]).resolve()
+          bindings = pathlib.Path("target/bindings/python").resolve()
+          out = pathlib.Path("ffi-release-asset").resolve()
+
+          if out.exists():
+              shutil.rmtree(out)
+          out.joinpath("lib").mkdir(parents=True)
+          out.joinpath("python").mkdir(parents=True)
+
+          native_dst = out / "lib" / library.name
+          shutil.copy2(library, native_dst)
+          shutil.copy2(bindings / "elastik_ffi.py", out / "python" / "elastik_ffi.py")
+          shutil.copy2(library, out / "python" / library.name)
+
+          def sha256(path: pathlib.Path) -> str:
+              h = hashlib.sha256()
+              with path.open("rb") as f:
+                  for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                      h.update(chunk)
+              return h.hexdigest()
+
+          out.joinpath("MANIFEST.txt").write_text("\n".join([
+              f"name={name}",
+              f"library={library.name}",
+              f"library_sha256={sha256(native_dst)}",
+              "python_binding=python/elastik_ffi.py",
+              "",
+          ]), encoding="utf-8")
+
+          if asset.exists():
+              asset.unlink()
+          with zipfile.ZipFile(asset, "w", zipfile.ZIP_DEFLATED) as z:
+              for path in sorted(out.rglob("*")):
+                  if path.is_file():
+                      z.write(path, path.relative_to(out).as_posix())
+          print(asset)
+          PY
+
+      - name: upload ffi release asset
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ffi/${{ matrix.asset-name }}
+
+      - name: upload ffi asset artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffi-asset-${{ matrix.name }}
+          path: ffi/${{ matrix.asset-name }}
+          if-no-files-found: error
+
   build-wheels:
     name: build wheel (${{ matrix.name }})
     needs: build-core-assets
@@ -426,6 +589,7 @@ jobs:
   release-checksums:
     name: publish release checksums
     needs:
+      - build-ffi-assets
       - publish-pypi
       - publish-crates
       - publish-npm-client
@@ -496,7 +660,13 @@ jobs:
               if path.suffix in {".zip", ".whl"}:
                   with zipfile.ZipFile(path) as z:
                       for name in sorted(z.namelist()):
-                          if pathlib.PurePosixPath(name).name in {"elastik-core", "elastik-core.exe"}:
+                          if pathlib.PurePosixPath(name).name in {
+                              "elastik-core",
+                              "elastik-core.exe",
+                              "elastik_ffi.dll",
+                              "libelastik_ffi.dylib",
+                              "libelastik_ffi.so",
+                          }:
                               record_binary(name, z.read(name))
               elif path.suffix == ".tgz":
                   with tarfile.open(path, "r:gz") as t:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,12 @@ jobs:
           read = engine.read("home/ffi", e.FfiAccessTier.READ)
           assert read is not None
           assert read.representation.body == b"release"
+          subscription = engine.subscribe("home/*", e.FfiAccessTier.READ, None)
+          engine.append("home/ffi", b" asset", none, e.FfiAccessTier.WRITE)
+          event = subscription.next(5_000)
+          assert event.kind == e.FfiSubscriptionNextKind.EVENT, event.kind
+          assert event.event.verb == e.FfiChangeVerb.APPEND, event.event.verb
+          assert event.event.path == "home/ffi", event.event.path
           engine.shutdown()
           print("ffi release smoke ok", e.ffi_version(), root)
           PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
             library-path: target/release/libelastik_ffi.so
             asset-name: elastik-ffi-linux-arm64.zip
           - name: macos-x64
-            os: macos-13
+            os: macos-15-intel
             library-path: target/release/libelastik_ffi.dylib
             asset-name: elastik-ffi-darwin-x64.zip
           - name: macos-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,13 +184,13 @@ jobs:
             library-path: target/release/libelastik_ffi.dylib
             asset-name: elastik-ffi-darwin-arm64.zip
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             library-path: target/release/elastik_ffi.dll
             asset-name: elastik-ffi-win32-x64.zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -320,7 +320,7 @@ jobs:
           files: ffi/${{ matrix.asset-name }}
 
       - name: upload ffi asset artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ffi-asset-${{ matrix.name }}
           path: ffi/${{ matrix.asset-name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing
 
-Elastik is a small HTTP byte engine. The contribution model is intentionally
-small too: one coherent change, one pull request.
+Elastik is an Audi-ted L5 storage engine with HTTP, CoAP, MQTT, SDK, and FFI
+adapters. The contribution model is intentionally small too: one coherent
+change, one pull request.
 
 ## Before You Start
 

--- a/prompts/elastik-agent-tool.prompt.yml
+++ b/prompts/elastik-agent-tool.prompt.yml
@@ -1,12 +1,12 @@
 name: Elastik Agent Tool
-description: Teaches agents to drive Elastik's HTTP byte-store API without hallucinating verbs, paths, auth, or header persistence semantics.
+description: Teaches agents to drive Elastik's HTTP adapter without hallucinating verbs, paths, auth, or header persistence semantics.
 model: openai/gpt-4o-mini
 modelParameters:
   temperature: 0.0
 messages:
   - role: system
     content: |
-      You help agents drive Elastik, an HTTP byte store. Prefer runnable commands over prose. Default to curl unless the conversation clearly asks for Python or already contains Python SDK context.
+      You help agents drive Elastik, an Audi-ted L5 storage engine, through its HTTP adapter. Prefer runnable commands over prose. Default to curl unless the conversation clearly asks for Python or already contains Python SDK context.
 
       Core verbs:
       - PUT replaces bytes at a path. Use --data-binary for files and exact bytes. PUT normally returns 201 on create or 200 on replace.


### PR DESCRIPTION
## Layer

Layer 6 of the UniFFI Engine adapter stack.

Base: `feat/ffi-artifact-ci` (#172)

## Scope

Adds tagged-release integration for FFI artifacts. This PR does not change the FFI API surface.

Release workflow additions:

- build FFI native libraries for:
  - Linux x64: `elastik-ffi-linux-x64.zip`
  - Linux ARM64: `elastik-ffi-linux-arm64.zip`
  - macOS x64: `elastik-ffi-darwin-x64.zip`
  - macOS ARM64: `elastik-ffi-darwin-arm64.zip`
  - Windows x64: `elastik-ffi-win32-x64.zip`
- generate Python UniFFI binding from the built native library
- smoke the generated Python binding before packaging
- upload FFI zips to GitHub Releases on tags
- upload FFI zips as workflow artifacts so `release-checksums` includes them in `SHA256SUMS.txt`
- include FFI native library entries in `BINARY-SHA256SUMS.txt`

## Boundary

This stays in release/distribution plumbing:

- no Engine/FFI API additions
- no HTTP/server adapter leakage
- no crates/npm/PyPI publishing changes
- no OpenWrt/MIPS promise yet; that remains a documented cross-toolchain target, not a GitHub-hosted release artifact

## Validation

Local validation on Windows:

- release-style FFI zip script produced `elastik-ffi-win32-x64.zip`
- zip contained `MANIFEST.txt`, `lib/elastik_ffi.dll`, `python/elastik_ffi.py`, and `python/elastik_ffi.dll`
- checksum extraction logic recognises FFI native DLL entries in the zip
- `git diff --check`
- Push hook: all Elastik local gates passed, including Rust core tests, Python SDK smoke, header policy scanner, JS syntax, and whitespace check

## Review notes

The `release` workflow only runs on `workflow_dispatch` and tag pushes. Normal PR CI will not execute the new release job. The preceding stack layer (#172) is the PR-executed proof for the same artifact build/smoke/package shape across the five hosted platforms.