### PR TITLE
ci: test Windows VS2026 runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          - windows-2025-vs2026
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             npm-platform: darwin
             npm-arch: arm64
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             rust-target: ""
             asset-name: elastik-core-win32-x64.zip
             npm-platform: win32
@@ -180,7 +180,7 @@ jobs:
             wheel-platform-tag: "macosx_11_0_arm64"
             wheel-platform-regex: "macosx_.*_arm64"
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             wheel-platform-tag: ""
             wheel-platform-regex: "win_amd64"
     steps:

--- a/.github/workflows/wheel-ci.yml
+++ b/.github/workflows/wheel-ci.yml
@@ -27,7 +27,7 @@ jobs:
             wheel-platform-tag: "macosx_11_0_arm64"
             wheel-platform-regex: "macosx_.*_arm64"
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             wheel-platform-tag: ""
             wheel-platform-regex: "win_amd64"
     steps:


### PR DESCRIPTION
## Purpose

Compatibility probe for GitHub's June 2026 Windows runner migration.

This changes the Windows jobs from `windows-latest` to `windows-2025-vs2026` so CI exercises the Visual Studio 2026 image before GitHub flips the default labels.

## Scope

- `ci.yml` SDK blackbox Windows job
- `wheel-ci.yml` Windows wheel dry-run
- `release.yml` Windows core asset and wheel matrix entries

## Notes

This is intentionally a test PR. If it passes, we know the current Rust/Python packaging path is compatible with the VS2026 runner image. If we do not want early migration after the test, close or revert this PR rather than merging it.