### PR TITLE
[codex] prepare v8.2.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - name: version consistency
+        run: python tools/version_consistency_check.py
       - name: format
         working-directory: core
         run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,16 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - name: verify binary version matches tag
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: verify release versions match tag
         if: startsWith(github.ref, 'refs/tags/v')
-        shell: bash
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' bin/Cargo.toml | head -n1)"
-          if [[ "$manifest_version" != "$version" ]]; then
-            echo "::error::tag v${version} does not match bin/Cargo.toml version ${manifest_version}"
-            exit 1
-          fi
+        run: python tools/version_consistency_check.py --tag "${{ github.ref_name }}"
       - name: add rust target
         if: matrix.rust-target != ''
         run: rustup target add ${{ matrix.rust-target }}
@@ -204,16 +200,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: verify ffi version matches tag
+      - name: verify release versions match tag
         if: startsWith(github.ref, 'refs/tags/v')
-        shell: bash
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' ffi/Cargo.toml | head -n1)"
-          if [[ "$manifest_version" != "$version" ]]; then
-            echo "::error::tag v${version} does not match ffi/Cargo.toml version ${manifest_version}"
-            exit 1
-          fi
+        run: python tools/version_consistency_check.py --tag "${{ github.ref_name }}"
 
       - name: build ffi library
         run: cargo build --release --manifest-path ffi/Cargo.toml
@@ -406,6 +395,10 @@ jobs:
       - name: show platform
         run: python -c "import platform, sys; print(sys.platform, platform.machine())"
 
+      - name: verify release versions match tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: python tools/version_consistency_check.py --tag "${{ github.ref_name }}"
+
       - name: download core asset
         uses: actions/download-artifact@v8
         with:
@@ -548,17 +541,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: verify release versions match tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: python tools/version_consistency_check.py --tag "${{ github.ref_name }}"
       - name: publish elastik-core to crates.io
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           version="${GITHUB_REF_NAME#v}"
-          manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' core/Cargo.toml | head -n1)"
-          if [[ "$manifest_version" != "$version" ]]; then
-            echo "::error::tag v${version} does not match core/Cargo.toml version ${manifest_version}"
-            exit 1
-          fi
           api_url="https://crates.io/api/v1/crates/elastik-core/${version}"
           if curl -fsS -H "User-Agent: Elastik release workflow" "$api_url" >/dev/null; then
             echo "elastik-core ${version} already published; skipping cargo publish"

--- a/RELEASE-NOTES-v8.2.0.md
+++ b/RELEASE-NOTES-v8.2.0.md
@@ -1,0 +1,73 @@
+# Elastik v8.2.0 - supply-chain refresh
+
+v8.2.0 is a minor release for the v8 Engine line.
+
+This release republishes the v8 packages after the dependency supply-chain
+refresh that landed after v8.1.0. The goal is boring but important: new
+installs should resolve to manifests and lockfiles that already contain the
+audited dependency updates, rather than asking users to install an older crate
+and rediscover the same upgrade path locally.
+
+## Highlights
+
+- **Rust dependency floor refreshed.** The core, binary, and FFI Cargo surfaces
+  now ship with the post-v8.1.0 supply-chain lock state.
+- **SQLite path updated.** `rusqlite` is now on the 0.40 line across the Rust
+  packages, with the bundled SQLite blind spot documented and checked by the
+  supply-chain workflow.
+- **HMAC/SHA stack updated.** `hmac` moved to 0.13 and `sha2` moved to 0.11.
+  The HMAC code imports `KeyInit` explicitly and keeps the RFC 4231 known-vector
+  test as a sentinel.
+- **HTTP adapter stack updated.** The binary adapter now uses axum 0.8 route
+  syntax. The wildcard route migration keeps world-path canonicalization
+  unchanged.
+- **Release versions are aligned.** Rust, Python, JavaScript, npm companion
+  packages, docs examples, and lockfiles all move from 8.1.0 to 8.2.0 together.
+
+## Compatibility notes
+
+- The Rust library package remains `elastik-core`.
+- The server binary package remains `elastik-bin`, and still produces the
+  `elastik-core` executable.
+- The public Rust `Engine` API remains behind `unstable-engine`.
+- HTTP, CoAP, SSE, MQTT, Python SDK, and JavaScript SDK protocol shapes are not
+  intentionally changed by this release.
+- Existing `elastik-core = { version = "8", ... }` Cargo manifests will be able
+  to resolve to 8.2.0 after the crate is published.
+
+## Operational notes
+
+- `cargo add elastik-core` will report 8.2.0 after crates.io publication.
+- CI and tag release jobs run `tools/version_consistency_check.py`, which fails
+  if Rust manifests, Cargo locks, Python metadata, JavaScript package metadata,
+  npm companion metadata, active docs, release notes, or the tag version drift.
+- The supply-chain workflow continues to run RustSec, cargo-deny, duplicate
+  dependency warnings, and the repository supply-chain scanner.
+
+## Packages
+
+These are the planned v8.2.0 release artifacts. The release workflow validates
+the version surface against the tag before publishing.
+
+- Rust library crate: `elastik-core` `8.2.0`
+- Repository Rust server binary package: `elastik-bin` `8.2.0`,
+  producing the `elastik-core` executable
+- Repository FFI Cargo package and GitHub Release assets: `elastik-ffi` `8.2.0`
+- Python SDK: `elastik` `8.2.0`
+- JavaScript SDK: `@elastikjs/client` `8.2.0`
+- npm binary companions:
+  - `@elastikjs/core-linux-x64` `8.2.0`
+  - `@elastikjs/core-linux-arm64` `8.2.0`
+  - `@elastikjs/core-darwin-arm64` `8.2.0`
+  - `@elastikjs/core-win32-x64` `8.2.0`
+- GitHub Release core assets:
+  - `elastik-core-linux-x64.zip`
+  - `elastik-core-linux-arm64.zip`
+  - `elastik-core-darwin-arm64.zip`
+  - `elastik-core-win32-x64.zip`
+- GitHub Release FFI assets:
+  - `elastik-ffi-linux-x64.zip`
+  - `elastik-ffi-linux-arm64.zip`
+  - `elastik-ffi-darwin-x64.zip`
+  - `elastik-ffi-darwin-arm64.zip`
+  - `elastik-ffi-win32-x64.zip`

--- a/bin/Cargo.lock
+++ b/bin/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-bin"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "bytes",
  "dashmap",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastik-bin"
-version = "8.1.0"
+version = "8.2.0"
 edition = "2021"
 description = "Elastik server binary adapters for the elastik-core storage engine."
 license = "MIT"

--- a/bin/src/server/http/README.md
+++ b/bin/src/server/http/README.md
@@ -13,7 +13,7 @@ file documents the binary wire surface: startup, HTTP worlds, `/proc/*`,
 export ELASTIK_KEY=secret
 export ELASTIK_WRITE_TOKEN=secret
 cargo run --manifest-path bin/Cargo.toml --bin elastik-core
-# elastik-core v8.1.0 on http://127.0.0.1:3105/
+# elastik-core v8.2.0 on http://127.0.0.1:3105/
 
 curl                  http://127.0.0.1:3105/proc/version
 curl -X PUT -H "Authorization: Bearer $ELASTIK_WRITE_TOKEN" \
@@ -80,7 +80,7 @@ always policy-free capability discovery.
 
 | Endpoint | Methods | Auth | Purpose |
 |----------|---------|------|---------|
-| `/proc/version` | `GET`, `HEAD`, `OPTIONS` | public | Binary version string, e.g. `elastik-core 8.1.0 (rust)`. |
+| `/proc/version` | `GET`, `HEAD`, `OPTIONS` | public | Binary version string, e.g. `elastik-core 8.2.0 (rust)`. |
 | `/proc/worlds` | `GET`, `HEAD`, `OPTIONS` | read-gated | Canonical world list, one `home/foo`-style key per line. |
 | `/proc/du` | `GET`, `HEAD`, `OPTIONS` | read-gated | Per-world byte usage. This is an unpaginated management view. |
 | `/proc/df` | `GET`, `HEAD`, `OPTIONS` | read-gated | Storage and memory quota snapshot plus world count. |

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "bytes",
  "dashmap",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastik-core"
-version = "8.1.0"
+version = "8.2.0"
 edition = "2021"
 description = "Elastik — Audi-ted L5 storage engine. SQLite for files."
 license = "MIT"

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-ffi"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "elastik-core",
  "rusqlite",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastik-ffi"
-version = "8.1.0"
+version = "8.2.0"
 edition = "2021"
 description = "UniFFI adapter for Elastik's protocol-neutral Engine."
 license = "MIT"

--- a/scripts/pre-push.ps1
+++ b/scripts/pre-push.ps1
@@ -129,6 +129,10 @@ Step "Rust tests" {
     Run cargo test --manifest-path bin/Cargo.toml
 }
 
+Step "Version consistency" {
+    Run python tools/version_consistency_check.py
+}
+
 if (-not $strict) {
     Step "Rust supply-chain quick audit" {
         Run python tools/supply_chain_check.py prepush

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -106,7 +106,7 @@ the same process tree.
 | `win32-x64`     | `@elastikjs/core-win32-x64`    |
 
 The npm matrix matches the Rust core's release matrix
-([Elastik v8.1.0](https://github.com/rangersui/Elastik/releases/tag/v8.1.0)).
+([Elastik v8.2.0](https://github.com/rangersui/Elastik/releases/tag/v8.2.0)).
 Linux binaries are statically linked against musl libc for distro
 compatibility. `darwin-x64` is intentionally not in the matrix (Apple
 Silicon only on the Mac side).
@@ -641,7 +641,7 @@ If you need the bytes, follow up with `e.get(ev.path)`.
 
 ```js
 await e.exists("home/note");   // → false only on 404; auth/network errors throw
-await e.version();             // → "elastik-core 8.1.0 (rust)"
+await e.version();             // → "elastik-core 8.2.0 (rust)"
 await e.worlds();              // → "home/note\nhome/log\n..."
 ```
 

--- a/sdk-js/core-darwin-arm64/package.json
+++ b/sdk-js/core-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-darwin-arm64",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Elastik L5 — bundled Rust core binary for macOS Apple Silicon. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-linux-arm64/package.json
+++ b/sdk-js/core-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-linux-arm64",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Elastik L5 — bundled Rust core binary for Linux ARM64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-linux-x64/package.json
+++ b/sdk-js/core-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-linux-x64",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Elastik L5 — bundled Rust core binary for Linux x64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-win32-x64/package.json
+++ b/sdk-js/core-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-win32-x64",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Elastik L5 — bundled Rust core binary for Windows x64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core.exe"

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/client",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "JavaScript SDK for Elastik L5. Audi-ted storage over HTTP; one import, zero dependencies.",
   "type": "module",
   "main": "./index.mjs",
@@ -53,10 +53,10 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "@elastikjs/core-linux-x64": "8.1.0",
-    "@elastikjs/core-linux-arm64": "8.1.0",
-    "@elastikjs/core-darwin-arm64": "8.1.0",
-    "@elastikjs/core-win32-x64": "8.1.0"
+    "@elastikjs/core-linux-x64": "8.2.0",
+    "@elastikjs/core-linux-arm64": "8.2.0",
+    "@elastikjs/core-darwin-arm64": "8.2.0",
+    "@elastikjs/core-win32-x64": "8.2.0"
   },
   "engines": {
     "node": ">=18"

--- a/sdk-js/scripts/pack-platform.mjs
+++ b/sdk-js/scripts/pack-platform.mjs
@@ -14,7 +14,7 @@
 // Usage:
 //   node scripts/pack-platform.mjs <plat> <arch> <binary-path> [--version <version>] [--pack]
 // Example:
-//   node scripts/pack-platform.mjs linux x64 /tmp/elastik-core --version 8.1.0 --pack
+//   node scripts/pack-platform.mjs linux x64 /tmp/elastik-core --version 8.2.0 --pack
 //
 // On the win32 runner the binary is elastik-core.exe; everywhere else it's
 // elastik-core. The script auto-detects from the source filename.

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elastik"
-version = "8.1.0"
+version = "8.2.0"
 description = "Elastik L5: Audi-ted storage engine over HTTP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -164,7 +164,7 @@ __all__ = [
     "list_worlds", "list_paths", "list_keys", "request",
 ]
 
-__version__ = "8.1.0"
+__version__ = "8.2.0"
 
 
 # ── module-level singleton client ──────────────────────────────────

--- a/tools/version_consistency_check.py
+++ b/tools/version_consistency_check.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Fail if Elastik release version surfaces drift apart."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CORE_PLATFORMS = {
+    "@elastikjs/core-linux-x64": ROOT / "sdk-js" / "core-linux-x64" / "package.json",
+    "@elastikjs/core-linux-arm64": ROOT / "sdk-js" / "core-linux-arm64" / "package.json",
+    "@elastikjs/core-darwin-arm64": ROOT / "sdk-js" / "core-darwin-arm64" / "package.json",
+    "@elastikjs/core-win32-x64": ROOT / "sdk-js" / "core-win32-x64" / "package.json",
+}
+
+ACTIVE_TEXT_SURFACES = [
+    ROOT / "README.md",
+    ROOT / "bin" / "src" / "server" / "http" / "README.md",
+    ROOT / "bin" / "src" / "server" / "mqtt" / "README.md",
+    ROOT / "bin" / "src" / "server" / "coap" / "README.md",
+    ROOT / "ffi" / "README.md",
+    ROOT / "sdk" / "README.md",
+    ROOT / "sdk-js" / "README.md",
+    ROOT / "sdk-js" / "scripts" / "pack-platform.mjs",
+]
+
+ACTIVE_TEXT_VERSION_PATTERNS = [
+    ("Elastik release label", re.compile(r"\bElastik\s+v(\d+\.\d+\.\d+)\b")),
+    ("GitHub release tag", re.compile(r"/releases/tag/v(\d+\.\d+\.\d+)\b")),
+    ("elastik-core version", re.compile(r"\belastik-core\s+v?(\d+\.\d+\.\d+)\b")),
+    ("pack-platform --version", re.compile(r"--version\s+(\d+\.\d+\.\d+)\b")),
+]
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def load_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def package_version(path: Path) -> str:
+    return load_toml(path)["package"]["version"]
+
+
+def pyproject_version(path: Path) -> str:
+    return load_toml(path)["project"]["version"]
+
+
+def lock_package_versions(path: Path, package: str) -> list[str]:
+    return [
+        entry["version"]
+        for entry in load_toml(path).get("package", [])
+        if entry.get("name") == package
+    ]
+
+
+def normalize_tag(raw: str) -> str:
+    tag = raw.strip()
+    if tag.startswith("refs/tags/"):
+        tag = tag.removeprefix("refs/tags/")
+    if tag.startswith("v"):
+        tag = tag[1:]
+    return tag
+
+
+def infer_tag_arg(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    ref = os.environ.get("GITHUB_REF", "")
+    name = os.environ.get("GITHUB_REF_NAME", "")
+    if ref.startswith("refs/tags/v") and name:
+        return name
+    return None
+
+
+def check_equal(errors: list[str], label: str, found: str | None, expected: str) -> None:
+    if found != expected:
+        errors.append(f"{label}: {found!r} != {expected!r}")
+
+
+def check_lock(errors: list[str], path: Path, package: str, expected: str) -> None:
+    versions = lock_package_versions(path, package)
+    if versions != [expected]:
+        errors.append(f"{rel(path)} package {package}: {versions!r} != [{expected!r}]")
+
+
+def check_active_text_versions(errors: list[str], expected: str) -> None:
+    for path in ACTIVE_TEXT_SURFACES:
+        if not path.exists():
+            errors.append(f"{rel(path)}: missing active text surface")
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for label, pattern in ACTIVE_TEXT_VERSION_PATTERNS:
+                for match in pattern.finditer(line):
+                    found = match.group(1)
+                    if found != expected:
+                        errors.append(
+                            f"{rel(path)}:{lineno}: {label} {found!r} != {expected!r}"
+                        )
+
+
+def check_release_note(errors: list[str], expected: str) -> None:
+    path = ROOT / f"RELEASE-NOTES-v{expected}.md"
+    if not path.exists():
+        errors.append(f"{rel(path)}: missing release notes for {expected}")
+        return
+    text = path.read_text(encoding="utf-8")
+    required = [
+        f"# Elastik v{expected} -",
+        f"v{expected} is a minor release",
+        f"`elastik-core` `{expected}`",
+        f"to resolve to {expected} after",
+        f"`cargo add elastik-core` will report {expected}",
+        f"`elastik-bin` `{expected}`",
+        f"`elastik-ffi` `{expected}`",
+        f"`elastik` `{expected}`",
+        f"`@elastikjs/client` `{expected}`",
+        f"`@elastikjs/core-linux-x64` `{expected}`",
+        f"`@elastikjs/core-linux-arm64` `{expected}`",
+        f"`@elastikjs/core-darwin-arm64` `{expected}`",
+        f"`@elastikjs/core-win32-x64` `{expected}`",
+    ]
+    for snippet in required:
+        if snippet not in text:
+            errors.append(f"{rel(path)}: missing {snippet!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", help="Release tag or ref, for example v8.2.0 or refs/tags/v8.2.0")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    expected = package_version(ROOT / "core" / "Cargo.toml")
+    if not re.fullmatch(r"\d+\.\d+\.\d+", expected):
+        errors.append(f"core/Cargo.toml version is not semver X.Y.Z: {expected!r}")
+
+    tag = infer_tag_arg(args.tag)
+    if tag:
+        check_equal(errors, "release tag", normalize_tag(tag), expected)
+
+    check_equal(errors, "bin/Cargo.toml", package_version(ROOT / "bin" / "Cargo.toml"), expected)
+    check_equal(errors, "ffi/Cargo.toml", package_version(ROOT / "ffi" / "Cargo.toml"), expected)
+
+    check_lock(errors, ROOT / "core" / "Cargo.lock", "elastik-core", expected)
+    check_lock(errors, ROOT / "bin" / "Cargo.lock", "elastik-core", expected)
+    check_lock(errors, ROOT / "bin" / "Cargo.lock", "elastik-bin", expected)
+    check_lock(errors, ROOT / "ffi" / "Cargo.lock", "elastik-core", expected)
+    check_lock(errors, ROOT / "ffi" / "Cargo.lock", "elastik-ffi", expected)
+
+    check_equal(errors, "sdk/pyproject.toml", pyproject_version(ROOT / "sdk" / "pyproject.toml"), expected)
+    init_text = (ROOT / "sdk" / "src" / "elastik" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'^__version__ = "([^"]+)"$', init_text, re.MULTILINE)
+    check_equal(errors, "sdk/src/elastik/__init__.py __version__", match.group(1) if match else None, expected)
+
+    client = load_json(ROOT / "sdk-js" / "package.json")
+    check_equal(errors, "sdk-js/package.json version", client.get("version"), expected)
+    optional = client.get("optionalDependencies", {})
+    if set(optional) != set(CORE_PLATFORMS):
+        errors.append(
+            "sdk-js/package.json optionalDependencies: "
+            f"{sorted(optional)} != {sorted(CORE_PLATFORMS)}"
+        )
+    for package_name in sorted(CORE_PLATFORMS):
+        check_equal(errors, f"sdk-js/package.json optional {package_name}", optional.get(package_name), expected)
+        package_json = load_json(CORE_PLATFORMS[package_name])
+        check_equal(errors, f"{rel(CORE_PLATFORMS[package_name])} name", package_json.get("name"), package_name)
+        check_equal(errors, f"{rel(CORE_PLATFORMS[package_name])} version", package_json.get("version"), expected)
+
+    check_active_text_versions(errors, expected)
+    check_release_note(errors, expected)
+
+    if errors:
+        print("version consistency check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(f"version consistency ok: {expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/version_consistency_check.py
+++ b/tools/version_consistency_check.py
@@ -119,12 +119,8 @@ def check_release_note(errors: list[str], expected: str) -> None:
         errors.append(f"{rel(path)}: missing release notes for {expected}")
         return
     text = path.read_text(encoding="utf-8")
-    required = [
-        f"# Elastik v{expected} -",
-        f"v{expected} is a",
+    artifact_snippets = [
         f"`elastik-core` `{expected}`",
-        f"to resolve to {expected} after",
-        f"`cargo add elastik-core` will report {expected}",
         f"`elastik-bin` `{expected}`",
         f"`elastik-ffi` `{expected}`",
         f"`elastik` `{expected}`",
@@ -134,9 +130,9 @@ def check_release_note(errors: list[str], expected: str) -> None:
         f"`@elastikjs/core-darwin-arm64` `{expected}`",
         f"`@elastikjs/core-win32-x64` `{expected}`",
     ]
-    for snippet in required:
+    for snippet in artifact_snippets:
         if snippet not in text:
-            errors.append(f"{rel(path)}: missing {snippet!r}")
+            errors.append(f"{rel(path)}: missing artifact version {snippet!r}")
 
 
 def main() -> int:

--- a/tools/version_consistency_check.py
+++ b/tools/version_consistency_check.py
@@ -121,7 +121,7 @@ def check_release_note(errors: list[str], expected: str) -> None:
     text = path.read_text(encoding="utf-8")
     required = [
         f"# Elastik v{expected} -",
-        f"v{expected} is a minor release",
+        f"v{expected} is a",
         f"`elastik-core` `{expected}`",
         f"to resolve to {expected} after",
         f"`cargo add elastik-core` will report {expected}",


### PR DESCRIPTION
## What changed

- Bumped Elastik release surfaces from 8.1.0 to 8.2.0 across Rust Cargo packages/locks, Python SDK, JS SDK, platform npm packages, HTTP docs, and JS docs.
- Added `RELEASE-NOTES-v8.2.0.md` for the supply-chain refresh release.
- Added `tools/version_consistency_check.py` and wired it into CI, release tag jobs, and `scripts/pre-push.ps1`.
- Release jobs now fail if the pushed tag does not match the checked-in package/doc/lock versions.

## Why

The old release path depended on hand-checking version surfaces. This makes version drift fail loud in CI: Cargo manifests, lockfiles, Python metadata, JS package metadata, platform optional deps, active docs examples, release notes, and release tags must agree.

## Local validation

- `python tools/version_consistency_check.py`
- `python tools/version_consistency_check.py --tag v8.2.0`
- `python tools/version_consistency_check.py --tag v8.1.0` fails as expected
- `python tools/supply_chain_check.py ci`
- `git diff --check`
- Push pre-push hook passed: Rust format, clippy, core/bin tests, version consistency, quick supply-chain audit, Python SDK smoke, header policy scanner, JS syntax, whitespace check

## Review notes

- Huygens follow-up review found the untracked script/release-note staging risk and one P3 gap in release-note prose coverage; both are addressed in this commit.
- The SDK release link points to `v8.2.0`; it becomes live after the release tag is created.