### PR TITLE
Wrap delete ledger keys as secrets

### DIFF
--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use crate::{
     auth, can_delete,
     engine::EngineError,
-    engine_types::{ChangeVerb, Preconditions, ValidatedWorldPath},
+    engine_types::{ChangeVerb, Preconditions, SecretBytes, ValidatedWorldPath},
     etag, is_insufficient_storage_error, is_transient_storage_error, store, world, AuditAppendJob,
     AuthGate, BlockingSqliteError, Core,
 };
@@ -118,7 +118,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
             size: 0,
             content_type: req.content_type.clone(),
             headers: req.headers.clone(),
-            key: core.hmac_key.clone(),
+            key: ledger_hmac_key(core),
         })
         .await
     {
@@ -169,7 +169,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
             size: 0,
             content_type: req.content_type.clone(),
             headers: req.headers.clone(),
-            key: core.hmac_key.clone(),
+            key: ledger_hmac_key(core),
         })
         .await
     {
@@ -189,7 +189,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
                 size: 0,
                 content_type: req.content_type,
                 headers: req.headers,
-                key: core.hmac_key.clone(),
+                key: ledger_hmac_key(core),
             })
             .await
         {
@@ -208,6 +208,10 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     }
     hooks.audit_commit();
     Ok(())
+}
+
+fn ledger_hmac_key(core: &Core) -> SecretBytes {
+    SecretBytes::new(core.hmac_key.clone()).expect("Core hmac_key is validated at construction")
 }
 
 fn check_preconditions(

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -292,6 +292,11 @@ impl SecretBytes {
         Self::new(bytes.to_vec())
     }
 
+    /// Borrows the secret bytes for immediate cryptographic use.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+
     /// Transfers the bytes out of the secret wrapper.
     ///
     /// After this call, wipe-on-drop responsibility belongs to the caller that

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -25,6 +25,7 @@ use std::sync::Mutex as StdMutex;
 use rusqlite::Connection;
 
 use crate::audit;
+use crate::engine_types::SecretBytes;
 use crate::world;
 
 /// One audit append's input. Owns its strings/buffers because the
@@ -37,7 +38,7 @@ pub(crate) struct AuditAppendJob {
     pub(crate) size: i64,
     pub(crate) content_type: String,
     pub(crate) headers: Vec<(String, String)>,
-    pub(crate) key: Vec<u8>,
+    pub(crate) key: SecretBytes,
 }
 
 /// Result of an audit append run inside `spawn_blocking`. Shared
@@ -111,7 +112,7 @@ impl LedgerWriter {
             job.size,
             &job.content_type,
             &job.headers,
-            &job.key,
+            job.key.as_slice(),
         )
         .map_err(BlockingSqliteError::Sqlite)
     }


### PR DESCRIPTION
## What

Layer 1 for #285.

- Adds crate-internal `SecretBytes::as_slice()` for immediate HMAC use.
- Changes `AuditAppendJob.key` from bare `Vec<u8>` to `SecretBytes`.
- Wraps delete-ledger blocking-job key copies in `SecretBytes`, so those temporary copies wipe on drop too.

## Why

This prepares the core HMAC-key migration without changing `Core` yet. It also removes one existing naked long-enough key copy from the delete ledger path.

## Validation

- `cargo fmt --manifest-path core\Cargo.toml --check`
- `cargo test --manifest-path core\Cargo.toml --quiet`
- `cargo clippy --manifest-path core\Cargo.toml --all-targets -- -D warnings`
- pre-push fast gates passed when pushing the stack

Part of #285.