### PR TITLE
Store Core HMAC key as secret bytes

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -571,7 +571,7 @@ mod tests {
             b"hello",
             "text/plain; charset=utf-8",
             &headers,
-            &core.hmac_key,
+            core.hmac_key.as_slice(),
         )
         .unwrap();
 

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -61,10 +61,6 @@ impl NonEmptyBytes {
     pub(crate) fn as_slice(&self) -> &[u8] {
         &self.0
     }
-
-    pub(crate) fn into_vec(mut self) -> Vec<u8> {
-        std::mem::take(&mut self.0)
-    }
 }
 
 /// Returns true when raw token bytes can represent a configured or candidate

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -211,7 +211,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
 }
 
 fn ledger_hmac_key(core: &Core) -> SecretBytes {
-    SecretBytes::new(core.hmac_key.clone()).expect("Core hmac_key is validated at construction")
+    core.hmac_key.clone_secret()
 }
 
 fn check_preconditions(

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -290,9 +290,9 @@ impl EngineBuilder {
         std::fs::create_dir_all(&self.data_root).map_err(EngineBuildError::DataRootIo)?;
         let data_lock = crate::acquire_data_root_writer_lock(&self.data_root)
             .map_err(|err| map_writer_lock_error(&self.data_root, err))?;
-        let hmac_key = self.key.ok_or(EngineBuildError::HmacKeyMissing)?.into_vec();
+        let hmac_key = self.key.ok_or(EngineBuildError::HmacKeyMissing)?;
 
-        verify_all_worlds_with_names(&self.data_root, &hmac_key)?;
+        verify_all_worlds_with_names(&self.data_root, hmac_key.as_slice())?;
         let durable_sizes = world::sizes(&self.data_root).map_err(|err| {
             if storage_class::is_transient_storage_error(&err) {
                 EngineBuildError::DataRootLockHeld {

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -297,12 +297,11 @@ impl SecretBytes {
         self.bytes.as_slice()
     }
 
-    /// Transfers the bytes out of the secret wrapper.
-    ///
-    /// After this call, wipe-on-drop responsibility belongs to the caller that
-    /// owns the returned `Vec<u8>`. Today that caller is `Core::hmac_key`.
-    pub(crate) fn into_vec(self) -> Vec<u8> {
-        self.bytes.into_vec()
+    /// Creates an owned secret copy for `'static` blocking jobs.
+    pub(crate) fn clone_secret(&self) -> Self {
+        Self {
+            bytes: self.bytes.clone(),
+        }
     }
 }
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::AtomicU64;
 use dashmap::DashMap;
 use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 
-use crate::engine_types::ValidatedWorldPath;
+use crate::engine_types::{SecretBytes, ValidatedWorldPath};
 use crate::ledger::LedgerWriter;
 pub(crate) use crate::ledger::{AuditAppendJob, BlockingSqliteError};
 use crate::read_cache::ReadCache;
@@ -73,11 +73,10 @@ pub(crate) struct StorageReservationError {
     pub(crate) projected: usize,
 }
 
-#[derive(Clone)]
 pub(crate) struct Core {
     pub(crate) data: PathBuf,
     pub(crate) tokens: auth::Tokens,
-    pub(crate) hmac_key: Vec<u8>,
+    pub(crate) hmac_key: SecretBytes,
     pub(crate) mem: Arc<store::MemoryStore>,
     pub(crate) max_world_bytes: usize,
     pub(crate) max_memory_bytes: usize,
@@ -222,7 +221,7 @@ impl Core {
             "cached_verify_chain only applies to durable worlds"
         );
         self.read_cache
-            .cached_verify_chain(&self.data, world, &self.hmac_key)
+            .cached_verify_chain(&self.data, world, self.hmac_key.as_slice())
     }
 
     /// Test-only fixture: seed a world directly without going through
@@ -250,7 +249,7 @@ impl Core {
                 body,
                 content_type,
                 headers,
-                &self.hmac_key,
+                self.hmac_key.as_slice(),
             )?;
             let prev = current_len.unwrap_or(0);
             let _ = self.storage_body_bytes.fetch_update(
@@ -383,5 +382,21 @@ impl Core {
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
                     Some(used.saturating_sub(new_len).saturating_add(prev_len))
                 });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::engine_types::SecretBytes;
+
+    #[test]
+    fn core_hmac_key_is_stored_as_secret_bytes() {
+        let (core, dir) = crate::test_support::test_core("core-secret-key-type");
+
+        fn assert_secret_bytes(_: &SecretBytes) {}
+        assert_secret_bytes(&core.hmac_key);
+
+        drop(core);
+        std::fs::remove_dir_all(dir).ok();
     }
 }

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -345,7 +345,7 @@ mod tests {
             b"final",
             "text/plain; charset=utf-8",
             &[],
-            &core.hmac_key,
+            core.hmac_key.as_slice(),
         )
         .unwrap();
 

--- a/core/src/test_support.rs
+++ b/core/src/test_support.rs
@@ -12,6 +12,7 @@ use crate::{
         DEFAULT_LISTEN_REPLAY_MAX, DEFAULT_MAX_LISTEN_CONNECTIONS, DEFAULT_MAX_MEMORY_BYTES,
         DEFAULT_MAX_WORLD_BYTES,
     },
+    engine_types::SecretBytes,
     store, Core,
 };
 
@@ -43,7 +44,7 @@ pub(crate) fn test_core_with_read_cache_max(
                     write: None,
                     approve: None,
                 },
-                hmac_key: b"test-key".to_vec(),
+                hmac_key: SecretBytes::try_from_slice(b"test-key").unwrap(),
                 mem: Arc::new(store::MemoryStore::new()),
                 max_world_bytes: DEFAULT_MAX_WORLD_BYTES,
                 max_memory_bytes: DEFAULT_MAX_MEMORY_BYTES,

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -232,7 +232,7 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
             &req.body,
             &req.content_type,
             &req.headers,
-            &core.hmac_key,
+            core.hmac_key.as_slice(),
             None,
         ) {
             Ok(result) => {
@@ -331,7 +331,7 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
             &req.body,
             &content_type,
             &stored_headers,
-            &core.hmac_key,
+            core.hmac_key.as_slice(),
         ) {
             Ok(Some((_result, h))) => etag::hmac_etag(&h),
             Ok(None) => {


### PR DESCRIPTION
## What

Layer 2 for #285, stacked on #300.

- Stores `Core::hmac_key` as `SecretBytes` instead of `Vec<u8>`.
- Removes the crate-internal `SecretBytes::into_vec()` / `NonEmptyBytes::into_vec()` escape hatch.
- Changes all HMAC call sites to borrow the key via `as_slice()`.
- Adds a compile-time type-shape test pinning `Core::hmac_key` to `SecretBytes`.

## Why

The audit HMAC key should remain inside a zeroizing wrapper for the lifetime of the engine. This keeps the wipe-on-drop contract in the type instead of relying on a manual `Core::Drop` implementation.

## Validation

- `cargo fmt --manifest-path core\Cargo.toml --check`
- `cargo test --manifest-path core\Cargo.toml --quiet`
- `cargo clippy --manifest-path core\Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path bin\Cargo.toml --quiet`
- `cargo clippy --manifest-path bin\Cargo.toml --all-targets -- -D warnings`
- `python tools\version_consistency_check.py --tag v8.2.1`
- pre-push fast gates passed when pushing the stack

Closes #285.