### PR TITLE
Deny unsafe code in elastik-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo clippy --bin elastik-core --no-default-features --features bundled-sqlite,unstable-engine -- -D clippy::unwrap_used -D clippy::print_stdout
       - name: clippy
         working-directory: core
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks
       - name: binary clippy
         working-directory: bin
         run: cargo clippy -- -D warnings

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -85,6 +85,7 @@ impl fmt::Debug for NonEmptyBytes {
     }
 }
 
+#[allow(unsafe_code)]
 fn wipe_vec_allocation(bytes: &mut Vec<u8>) {
     // These bytes are credentials. Wipe the full allocation, not only len(),
     // because callers can hand us a Vec whose spare capacity still contains
@@ -92,6 +93,10 @@ fn wipe_vec_allocation(bytes: &mut Vec<u8>) {
     // fence make the best-effort wipe physically observable before free.
     let ptr = bytes.as_mut_ptr();
     for index in 0..bytes.capacity() {
+        // SAFETY: `ptr` came from this Vec allocation and `index` is strictly
+        // below `capacity`, so the computed pointer stays within the
+        // allocation. Volatile-writing a `u8` zero is valid for every byte in
+        // the allocation, including spare capacity.
         unsafe {
             ptr::write_volatile(ptr.add(index), 0);
         }
@@ -232,11 +237,16 @@ mod tests {
     }
 
     #[test]
+    #[allow(unsafe_code)]
     fn wipe_vec_allocation_clears_spare_capacity() {
         let mut bytes = Vec::with_capacity(8);
         bytes.extend_from_slice(b"key");
         let ptr = bytes.as_mut_ptr();
         let cap = bytes.capacity();
+        // SAFETY: `ptr` came from this Vec allocation and every index in
+        // `len..capacity` addresses spare capacity within the allocation.
+        // Writing initialized bytes there lets the test prove the wipe covers
+        // spare capacity as well as the current length.
         unsafe {
             for index in bytes.len()..cap {
                 ptr.add(index).write(b'x');
@@ -245,6 +255,10 @@ mod tests {
 
         wipe_vec_allocation(&mut bytes);
 
+        // SAFETY: the test initialized the spare capacity above, and
+        // `wipe_vec_allocation` wrote zeros across the full allocation, so
+        // exposing `capacity` bytes for inspection does not read uninitialized
+        // memory.
         unsafe {
             bytes.set_len(cap);
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(unsafe_code)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
 //! # AuditeDB — powered by the Elastik L5 Engine
 //!
 //! `elastik-core` is a protocol-neutral storage engine: canonical paths, opaque


### PR DESCRIPTION
## What

- Add `#![deny(unsafe_code)]` at the `elastik-core` crate root.
- Add `#![deny(clippy::undocumented_unsafe_blocks)]` so allowed unsafe blocks must carry a `SAFETY:` explanation.
- Change the core CI clippy step to run `cargo clippy --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks`, so test-only unsafe blocks are checked in CI too.
- Add explicit `#[allow(unsafe_code)]` only around the existing volatile wipe implementation and its test.
- Document the safety invariants for the production wipe path and the spare-capacity wipe test.

## Why

`elastik-core` currently has one intentional unsafe boundary: zeroizing secret bytes with `ptr::write_volatile`. New unsafe code elsewhere should fail compilation unless the diff adds an explicit `#[allow(unsafe_code)]`, making the exception reviewable.

The Clippy lint covers the other half: any allowed unsafe block must explain why it is sound. The CI command now checks all core targets, including tests, so this is not just a local convention.

Closes #302.

## Validation

- `cargo clippy --manifest-path core\Cargo.toml --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks`
- `cargo test --manifest-path core\Cargo.toml --quiet`
- `cargo clippy --manifest-path bin\Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path bin\Cargo.toml --quiet`
- `git diff --check`
- pre-push fast gates passed
