### PR TITLE
Route engine storage errors through classifier

### DIFF
--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -294,15 +294,17 @@ impl EngineBuilder {
 
         verify_all_worlds_with_names(&self.data_root, hmac_key.as_slice())?;
         let durable_sizes = world::sizes(&self.data_root).map_err(|err| {
-            if storage_class::is_transient_storage_error(&err) {
-                EngineBuildError::DataRootLockHeld {
-                    path: self.data_root.clone(),
+            match storage_class::classify_storage_failure(&err) {
+                storage_class::StorageFailureClass::Transient => {
+                    EngineBuildError::DataRootLockHeld {
+                        path: self.data_root.clone(),
+                    }
                 }
-            } else {
-                EngineBuildError::Storage {
+                storage_class::StorageFailureClass::InsufficientStorage
+                | storage_class::StorageFailureClass::Other => EngineBuildError::Storage {
                     sqlite_code: sqlite_code(&err),
                     detail: err.to_string(),
-                }
+                },
             }
         })?;
         let storage_body_bytes = durable_sizes.iter().map(|(_, size)| *size).sum();
@@ -466,14 +468,15 @@ pub(crate) fn sqlite_code(err: &rusqlite::Error) -> Option<i32> {
 }
 
 fn map_writer_lock_error(data_root: &std::path::Path, err: rusqlite::Error) -> EngineBuildError {
-    if storage_class::is_transient_storage_error(&err) {
-        return EngineBuildError::DataRootLockHeld {
+    match storage_class::classify_storage_failure(&err) {
+        storage_class::StorageFailureClass::Transient => EngineBuildError::DataRootLockHeld {
             path: data_root.to_path_buf(),
-        };
-    }
-    EngineBuildError::Storage {
-        sqlite_code: sqlite_code(&err),
-        detail: format!("writer lock open failed: {err}"),
+        },
+        storage_class::StorageFailureClass::InsufficientStorage
+        | storage_class::StorageFailureClass::Other => EngineBuildError::Storage {
+            sqlite_code: sqlite_code(&err),
+            detail: format!("writer lock open failed: {err}"),
+        },
     }
 }
 
@@ -487,28 +490,33 @@ fn verify_all_worlds_with_names(
     })?;
     for world_name in worlds {
         audit::verify_world(data_root, &world_name, key).map_err(|err| {
-            if storage_class::is_transient_storage_error(&err) {
-                EngineBuildError::DataRootLockHeld {
-                    path: data_root.to_path_buf(),
+            match storage_class::classify_storage_failure(&err) {
+                storage_class::StorageFailureClass::Transient => {
+                    EngineBuildError::DataRootLockHeld {
+                        path: data_root.to_path_buf(),
+                    }
                 }
-            } else if storage_class::is_insufficient_storage_error(&err) {
-                EngineBuildError::Storage {
-                    sqlite_code: sqlite_code(&err),
-                    detail: format!(
-                        "audit verification for {world_name} failed with sqlite code {:?}: {err}",
-                        sqlite_code(&err)
-                    ),
+                storage_class::StorageFailureClass::InsufficientStorage => {
+                    EngineBuildError::Storage {
+                        sqlite_code: sqlite_code(&err),
+                        detail: format!(
+                            "audit verification for {world_name} failed with sqlite code {:?}: {err}",
+                            sqlite_code(&err)
+                        ),
+                    }
                 }
-            } else if audit::is_audit_chain_broken_error(&err) {
-                EngineBuildError::AuditChainCorrupted {
-                    world: world_name.clone(),
-                    detail: err.to_string(),
+                storage_class::StorageFailureClass::Other
+                    if audit::is_audit_chain_broken_error(&err) =>
+                {
+                    EngineBuildError::AuditChainCorrupted {
+                        world: world_name.clone(),
+                        detail: err.to_string(),
+                    }
                 }
-            } else {
-                EngineBuildError::Storage {
+                storage_class::StorageFailureClass::Other => EngineBuildError::Storage {
                     sqlite_code: sqlite_code(&err),
                     detail: format!("audit verification for {world_name} failed: {err}"),
-                }
+                },
             }
         })?;
     }

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -12,7 +12,7 @@ use crate::{
     engine::{self, Engine, EngineError},
     engine_ops::{log_storage_error, EngineOps},
     engine_types::{AccessTier, ValidatedWorldPath},
-    store, world, AuthGate,
+    store, world, AuthGate, StorageFailureClass,
 };
 
 /// Validated `/proc/*` introspection endpoint.
@@ -562,20 +562,24 @@ fn storage_error_to_engine(
     operation: &'static str,
     world: Option<&str>,
 ) -> EngineError {
-    if crate::is_insufficient_storage_error(&err) {
-        log_storage_error(scope, &err, operation, world);
-        EngineError::InsufficientStorage {
-            sqlite_code: engine::sqlite_code(&err),
+    match crate::classify_storage_failure(&err) {
+        StorageFailureClass::InsufficientStorage => {
+            log_storage_error(scope, &err, operation, world);
+            EngineError::InsufficientStorage {
+                sqlite_code: engine::sqlite_code(&err),
+            }
         }
-    } else if crate::is_transient_storage_error(&err) {
-        log_storage_error(scope, &err, operation, world);
-        EngineError::TransientStorage {
-            sqlite_code: engine::sqlite_code(&err),
+        StorageFailureClass::Transient => {
+            log_storage_error(scope, &err, operation, world);
+            EngineError::TransientStorage {
+                sqlite_code: engine::sqlite_code(&err),
+            }
         }
-    } else {
-        log_storage_error(scope, &err, operation, world);
-        EngineError::Storage {
-            sqlite_code: engine::sqlite_code(&err),
+        StorageFailureClass::Other => {
+            log_storage_error(scope, &err, operation, world);
+            EngineError::Storage {
+                sqlite_code: engine::sqlite_code(&err),
+            }
         }
     }
 }

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -1474,8 +1474,8 @@ mod tests {
     // `path.try_exists()` returning `Ok(false)` -> 404 (file is
     // genuinely gone). Other variants (`Ok(true)` for unreadable
     // file, `Err(_)` for metadata failure) -> propagate the SQLite
-    // error so the verb maps to 500/507 via
-    // `is_insufficient_storage_error`. v6 collapsed all CANTOPEN
+    // error so the verb maps to 500/507 via the storage failure
+    // classifier. v6 collapsed all CANTOPEN
     // into 404; v7 introduced the recheck; v9 (Bug 49) tightened
     // `path.exists()` -> `path.try_exists()` so metadata errors stop
     // collapsing into a spurious 404.

--- a/core/src/storage_class.rs
+++ b/core/src/storage_class.rs
@@ -21,14 +21,6 @@ pub(crate) fn classify_storage_failure(err: &rusqlite::Error) -> StorageFailureC
     }
 }
 
-pub(crate) fn is_transient_storage_error(err: &rusqlite::Error) -> bool {
-    classify_storage_failure(err) == StorageFailureClass::Transient
-}
-
-pub(crate) fn is_insufficient_storage_error(err: &rusqlite::Error) -> bool {
-    classify_storage_failure(err) == StorageFailureClass::InsufficientStorage
-}
-
 fn is_transient_storage_error_impl(err: &rusqlite::Error) -> bool {
     if matches!(
         err.sqlite_error_code(),
@@ -68,8 +60,6 @@ mod tests {
             classify_storage_failure(&err),
             StorageFailureClass::InsufficientStorage
         );
-        assert!(is_insufficient_storage_error(&err));
-        assert!(!is_transient_storage_error(&err));
     }
 
     #[test]
@@ -80,8 +70,6 @@ mod tests {
                 classify_storage_failure(&err),
                 StorageFailureClass::Transient
             );
-            assert!(is_transient_storage_error(&err));
-            assert!(!is_insufficient_storage_error(&err));
         }
     }
 
@@ -92,7 +80,5 @@ mod tests {
             None,
         );
         assert_eq!(classify_storage_failure(&err), StorageFailureClass::Other);
-        assert!(!is_insufficient_storage_error(&err));
-        assert!(!is_transient_storage_error(&err));
     }
 }


### PR DESCRIPTION
## Summary
- route Engine build and proc introspection storage error mapping through `classify_storage_failure`
- keep audit-chain-broken detection in its existing branch for #276
- remove the old `is_transient_storage_error` / `is_insufficient_storage_error` wrappers after all production callers move to the classifier

Closes #279.

## Validation
- `cargo fmt --manifest-path core/Cargo.toml --check`
- `cargo clippy --manifest-path core/Cargo.toml --features unstable-engine --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks`
- `cargo test --manifest-path core/Cargo.toml --features unstable-engine --lib`
- pre-push fast mode passed on this branch