### PR TITLE
Carry audit errors through world writes

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -133,7 +133,7 @@ fn append_with_conn_verified(
     empty_chain: EmptyChain,
 ) -> rusqlite::Result<String> {
     let tx = conn.transaction()?;
-    let audit_tx = verify_appendable_tx(&tx, key, empty_chain)?;
+    let audit_tx = verify_appendable_tx(&tx, key, empty_chain).map_err(AuditError::into_sqlite)?;
     let h = append_tx(
         &audit_tx,
         event_type,
@@ -241,17 +241,25 @@ pub fn verify_world(data_root: &Path, world_name: &str, key: &[u8]) -> AuditResu
     require_intact(verify_connection(&c, key)?)
 }
 
-pub fn verify_appendable_tx_existing<'tx, 'conn>(
+pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn>(
     tx: &'tx Transaction<'conn>,
     key: &[u8],
-) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
+) -> AuditResult<VerifiedAuditTx<'tx, 'conn>> {
     verify_appendable_tx(tx, key, EmptyChain::Reject)
 }
 
+#[cfg(test)]
 pub fn verify_appendable_tx_genesis<'tx, 'conn>(
     tx: &'tx Transaction<'conn>,
     key: &[u8],
 ) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
+    verify_appendable_tx_genesis_checked(tx, key).map_err(AuditError::into_sqlite)
+}
+
+pub(crate) fn verify_appendable_tx_genesis_checked<'tx, 'conn>(
+    tx: &'tx Transaction<'conn>,
+    key: &[u8],
+) -> AuditResult<VerifiedAuditTx<'tx, 'conn>> {
     verify_appendable_tx(tx, key, EmptyChain::Allow)
 }
 
@@ -259,11 +267,10 @@ fn verify_appendable_tx<'tx, 'conn>(
     tx: &'tx Transaction<'conn>,
     key: &[u8],
     empty_chain: EmptyChain,
-) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
+) -> AuditResult<VerifiedAuditTx<'tx, 'conn>> {
     let mut stmt = tx.prepare(AUDIT_SELECT)?;
     let allow_empty = matches!(empty_chain, EmptyChain::Allow);
-    require_intact(verify_statement(&mut stmt, key, allow_empty)?)
-        .map_err(AuditError::into_sqlite)?;
+    require_intact(verify_statement(&mut stmt, key, allow_empty)?)?;
     Ok(VerifiedAuditTx { tx })
 }
 

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -30,16 +30,6 @@ pub enum AuditError {
     Storage(rusqlite::Error),
 }
 
-impl AuditError {
-    #[cfg(test)]
-    pub(crate) fn into_sqlite(self) -> rusqlite::Error {
-        match self {
-            Self::ChainBroken(break_report) => audit_chain_broken_error(&break_report),
-            Self::Storage(err) => err,
-        }
-    }
-}
-
 impl fmt::Display for AuditError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -249,14 +239,6 @@ pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn>(
     verify_appendable_tx(tx, key, EmptyChain::Reject)
 }
 
-#[cfg(test)]
-pub fn verify_appendable_tx_genesis<'tx, 'conn>(
-    tx: &'tx Transaction<'conn>,
-    key: &[u8],
-) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
-    verify_appendable_tx_genesis_checked(tx, key).map_err(AuditError::into_sqlite)
-}
-
 pub(crate) fn verify_appendable_tx_genesis_checked<'tx, 'conn>(
     tx: &'tx Transaction<'conn>,
     key: &[u8],
@@ -395,31 +377,6 @@ fn require_intact(report: VerifyReport) -> AuditResult<()> {
         VerifyReport::Valid(_) => Ok(()),
         VerifyReport::Broken(break_report) => Err(AuditError::ChainBroken(break_report)),
     }
-}
-
-#[cfg(test)]
-fn audit_chain_broken_error(break_report: &VerifyBreak) -> rusqlite::Error {
-    rusqlite::Error::SqliteFailure(
-        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CORRUPT),
-        Some(format!(
-            "{AUDIT_CHAIN_BROKEN_PREFIX}{}: expected {}, actual {}",
-            break_report.break_at, break_report.expected, break_report.actual
-        )),
-    )
-}
-
-#[cfg(test)]
-fn is_audit_chain_broken_error(err: &rusqlite::Error) -> bool {
-    matches!(
-        err,
-        rusqlite::Error::SqliteFailure(
-            rusqlite::ffi::Error {
-                code: rusqlite::ErrorCode::DatabaseCorrupt,
-                ..
-            },
-            Some(message),
-        ) if message.starts_with(AUDIT_CHAIN_BROKEN_PREFIX)
-    )
 }
 
 fn verify_event(
@@ -578,7 +535,7 @@ mod tests {
     fn hmac_for(event_type: &str, target: &str) -> String {
         let c = test_connection();
         let tx = c.unchecked_transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         append_tx(
             &audit_tx,
             event_type,
@@ -654,7 +611,7 @@ mod tests {
     fn verify_connection_accepts_intact_chain() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         let h1 = append_tx(
             &audit_tx,
             "put",
@@ -721,12 +678,15 @@ mod tests {
         .unwrap();
 
         let tx = c.transaction().unwrap();
-        let err = match verify_appendable_tx_genesis(&tx, b"key") {
+        let err = match verify_appendable_tx_genesis_checked(&tx, b"key") {
             Ok(_) => panic!("corrupt latest hmac must not be treated as an empty chain"),
             Err(e) => e,
         };
 
-        assert!(matches!(err, rusqlite::Error::InvalidColumnType(..)));
+        assert!(matches!(
+            err,
+            AuditError::Storage(rusqlite::Error::InvalidColumnType(..))
+        ));
         let count: i64 = tx
             .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
             .unwrap();
@@ -734,29 +694,48 @@ mod tests {
     }
 
     #[test]
-    fn audit_chain_broken_predicate_tracks_rusqlite_error_shape() {
-        let err = audit_chain_broken_error(&VerifyBreak {
-            break_at: 7,
-            expected: "hmac-good".to_string(),
-            actual: "hmac-bad".to_string(),
-        });
+    fn verify_appendable_existing_reports_chain_broken_error() {
+        let mut c = test_connection();
+        {
+            let tx = c.transaction().unwrap();
+            let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
+            append_tx(
+                &audit_tx,
+                "put",
+                "home/a",
+                "abc",
+                3,
+                "text/plain",
+                &[],
+                b"key",
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
+            .unwrap();
 
-        assert_eq!(
-            err.sqlite_error_code(),
-            Some(rusqlite::ffi::ErrorCode::DatabaseCorrupt),
-            "audit-chain breakage must remain a SQLite corrupt-class error"
-        );
-        assert!(
-            is_audit_chain_broken_error(&err),
-            "rusqlite Error::SqliteFailure shape changed without updating the audit predicate"
-        );
+        let tx = c.transaction().unwrap();
+        let err = match verify_appendable_tx_existing_checked(&tx, b"key") {
+            Ok(_) => panic!("tampered audit chain must not be appendable"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            AuditError::ChainBroken(VerifyBreak {
+                break_at: 0,
+                actual,
+                ..
+            }) if actual == "hmac-bad"
+        ));
     }
 
     #[test]
     fn verify_connection_rejects_tampered_event_hmac() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         append_tx(
             &audit_tx,
             "put",
@@ -784,17 +763,6 @@ mod tests {
     }
 
     #[test]
-    fn chain_broken_error_predicate_matches_generated_error() {
-        let err = audit_chain_broken_error(&VerifyBreak {
-            break_at: 7,
-            expected: "hmac-expected".to_owned(),
-            actual: "hmac-actual".to_owned(),
-        });
-
-        assert!(is_audit_chain_broken_error(&err));
-    }
-
-    #[test]
     fn startup_verification_rejects_tampered_world() {
         let root =
             std::env::temp_dir().join(format!("elastik-audit-startup-{}", std::process::id()));
@@ -814,7 +782,7 @@ mod tests {
     fn verify_connection_rejects_tampered_event_headers() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         append_tx(
             &audit_tx,
             "put",

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,7 +4,7 @@
 //! the write.
 
 use hmac::{Hmac, KeyInit, Mac};
-use rusqlite::{ffi, Connection, OptionalExtension, Statement, Transaction};
+use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
 use crate::world;
@@ -31,6 +31,7 @@ pub enum AuditError {
 }
 
 impl AuditError {
+    #[cfg(test)]
     pub(crate) fn into_sqlite(self) -> rusqlite::Error {
         match self {
             Self::ChainBroken(break_report) => audit_chain_broken_error(&break_report),
@@ -82,7 +83,7 @@ pub fn append_with_conn_existing(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<String> {
+) -> AuditResult<String> {
     append_with_conn_verified(
         conn,
         event_type,
@@ -106,7 +107,7 @@ pub fn append_with_conn_genesis(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<String> {
+) -> AuditResult<String> {
     append_with_conn_verified(
         conn,
         event_type,
@@ -131,9 +132,9 @@ fn append_with_conn_verified(
     headers: &[(String, String)],
     key: &[u8],
     empty_chain: EmptyChain,
-) -> rusqlite::Result<String> {
+) -> AuditResult<String> {
     let tx = conn.transaction()?;
-    let audit_tx = verify_appendable_tx(&tx, key, empty_chain).map_err(AuditError::into_sqlite)?;
+    let audit_tx = verify_appendable_tx(&tx, key, empty_chain)?;
     let h = append_tx(
         &audit_tx,
         event_type,
@@ -396,9 +397,10 @@ fn require_intact(report: VerifyReport) -> AuditResult<()> {
     }
 }
 
+#[cfg(test)]
 fn audit_chain_broken_error(break_report: &VerifyBreak) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
-        ffi::Error::new(ffi::SQLITE_CORRUPT),
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CORRUPT),
         Some(format!(
             "{AUDIT_CHAIN_BROKEN_PREFIX}{}: expected {}, actual {}",
             break_report.break_at, break_report.expected, break_report.actual
@@ -411,7 +413,7 @@ fn is_audit_chain_broken_error(err: &rusqlite::Error) -> bool {
     matches!(
         err,
         rusqlite::Error::SqliteFailure(
-            ffi::Error {
+            rusqlite::ffi::Error {
                 code: rusqlite::ErrorCode::DatabaseCorrupt,
                 ..
             },

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -264,6 +264,22 @@ fn blocking_error_to_engine(
         Some(world.as_str()),
     );
     match err {
+        BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(_)) => {
+            EngineError::Storage { sqlite_code: None }
+        }
+        BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
+            match crate::classify_storage_failure(&err) {
+                StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage {
+                    sqlite_code: crate::engine::sqlite_code(&err),
+                },
+                StorageFailureClass::Transient => EngineError::TransientStorage {
+                    sqlite_code: crate::engine::sqlite_code(&err),
+                },
+                StorageFailureClass::Other => EngineError::Storage {
+                    sqlite_code: crate::engine::sqlite_code(&err),
+                },
+            }
+        }
         BlockingSqliteError::Sqlite(err) => match crate::classify_storage_failure(&err) {
             StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage {
                 sqlite_code: crate::engine::sqlite_code(&err),

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -547,6 +547,12 @@ pub(crate) fn log_blocking_storage_error(
     world: Option<&str>,
 ) {
     match err {
+        BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(break_report)) => {
+            log_audit_chain_error(scope, break_report, operation, world)
+        }
+        BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
+            log_storage_error(scope, err, operation, world)
+        }
         BlockingSqliteError::Sqlite(err) => log_storage_error(scope, err, operation, world),
         BlockingSqliteError::Worker => {
             #[cfg(feature = "unstable-engine")]

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -474,6 +474,13 @@ fn write_error_to_engine(value: world_ops::WriteError, world: Option<&str>) -> E
                 sqlite_code: engine::sqlite_code(&err),
             }
         }
+        world_ops::WriteError::AuditChainBroken {
+            scope,
+            break_report,
+        } => {
+            log_audit_chain_error(scope, &break_report, "write_audit", world);
+            EngineError::Storage { sqlite_code: None }
+        }
         world_ops::WriteError::Internal(message) => EngineError::InternalInvariant(message),
     }
 }
@@ -500,6 +507,36 @@ pub(crate) fn log_storage_error(
             eprintln!("elastik-core internal {scope} ({operation}) world={world}: {err}");
         }
         None => eprintln!("elastik-core internal {scope} ({operation}): {err}"),
+    }
+}
+
+pub(crate) fn log_audit_chain_error(
+    scope: &'static str,
+    break_report: &crate::audit::VerifyBreak,
+    operation: &'static str,
+    world: Option<&str>,
+) {
+    #[cfg(feature = "unstable-engine")]
+    tracing::error!(
+        scope,
+        operation,
+        world = world.unwrap_or(""),
+        break_at = break_report.break_at,
+        expected = %break_report.expected,
+        actual = %break_report.actual,
+        "engine audit chain broken"
+    );
+
+    #[cfg(not(feature = "unstable-engine"))]
+    match world {
+        Some(world) => eprintln!(
+            "elastik-core internal {scope} ({operation}) world={world}: audit chain broken at event {}: expected {}, actual {}",
+            break_report.break_at, break_report.expected, break_report.actual
+        ),
+        None => eprintln!(
+            "elastik-core internal {scope} ({operation}): audit chain broken at event {}: expected {}, actual {}",
+            break_report.break_at, break_report.expected, break_report.actual
+        ),
     }
 }
 

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -46,6 +46,7 @@ pub(crate) struct AuditAppendJob {
 /// (`handler::execute_delete`).
 #[derive(Debug)]
 pub(crate) enum BlockingSqliteError {
+    Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
     Worker,
 }
@@ -114,6 +115,6 @@ impl LedgerWriter {
             &job.headers,
             job.key.as_slice(),
         )
-        .map_err(BlockingSqliteError::Sqlite)
+        .map_err(BlockingSqliteError::Audit)
     }
 }

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -237,7 +237,7 @@ impl Core {
         body: &[u8],
         content_type: &str,
         headers: &[(String, String)],
-    ) -> rusqlite::Result<()> {
+    ) -> Result<(), world::WriteAuditError> {
         if store::is_memory_world(world) {
             self.mem.write(world, body, content_type, headers);
             Ok(())

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -207,6 +207,7 @@ pub struct WriteAuditResult {
     pub existed: bool,
 }
 
+#[derive(Debug)]
 pub enum WriteAuditError {
     Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
@@ -371,14 +372,9 @@ pub fn write_with_audit(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<String> {
+) -> Result<String, WriteAuditError> {
     write_with_audit_checked(data_root, world, body, content_type, headers, key, None)
         .map(|result| result.hmac)
-        .map_err(|err| match err {
-            WriteAuditError::Audit(e) => e.into_sqlite(),
-            WriteAuditError::Sqlite(e) => e,
-            WriteAuditError::Quota { .. } => unreachable!("quota is disabled"),
-        })
 }
 
 pub fn write_with_audit_checked(

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -208,6 +208,7 @@ pub struct WriteAuditResult {
 }
 
 pub enum WriteAuditError {
+    Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
     /// Returned only if the caller passes a `quota` argument to
     /// `write_with_audit_checked`. The active path passes `None` and
@@ -225,6 +226,12 @@ pub enum WriteAuditError {
 impl From<rusqlite::Error> for WriteAuditError {
     fn from(value: rusqlite::Error) -> Self {
         Self::Sqlite(value)
+    }
+}
+
+impl From<audit::AuditError> for WriteAuditError {
+    fn from(value: audit::AuditError) -> Self {
+        Self::Audit(value)
     }
 }
 
@@ -368,6 +375,7 @@ pub fn write_with_audit(
     write_with_audit_checked(data_root, world, body, content_type, headers, key, None)
         .map(|result| result.hmac)
         .map_err(|err| match err {
+            WriteAuditError::Audit(e) => e.into_sqlite(),
             WriteAuditError::Sqlite(e) => e,
             WriteAuditError::Quota { .. } => unreachable!("quota is disabled"),
         })
@@ -487,7 +495,7 @@ pub fn append_with_audit(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<Option<(AppendResult, String)>> {
+) -> Result<Option<(AppendResult, String)>, WriteAuditError> {
     let path = world_db(data_root, world);
     if !path.exists() {
         return Ok(None);
@@ -531,11 +539,11 @@ fn verify_appendable_world_tx<'tx, 'conn>(
     tx: &'tx Transaction<'conn>,
     key: &[u8],
     existed_before_open: bool,
-) -> rusqlite::Result<audit::VerifiedAuditTx<'tx, 'conn>> {
+) -> Result<audit::VerifiedAuditTx<'tx, 'conn>, WriteAuditError> {
     if !existed_before_open || is_empty_bootstrap_tx(tx)? {
-        audit::verify_appendable_tx_genesis(tx, key)
+        Ok(audit::verify_appendable_tx_genesis_checked(tx, key)?)
     } else {
-        audit::verify_appendable_tx_existing(tx, key)
+        Ok(audit::verify_appendable_tx_existing_checked(tx, key)?)
     }
 }
 

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::Ordering;
 use bytes::Bytes;
 
 use crate::{
-    auth, can_read, can_write,
+    audit, auth, can_read, can_write,
     engine_types::{ChangeVerb, ValidatedWorldPath},
     etag, needs_write_approve, store, world, AuthGate, Core, StorageFailureClass,
 };
@@ -121,6 +121,11 @@ pub(crate) enum WriteError {
         #[allow(dead_code)]
         scope: &'static str,
         err: rusqlite::Error,
+    },
+    AuditChainBroken {
+        #[allow(dead_code)]
+        scope: &'static str,
+        break_report: audit::VerifyBreak,
     },
     Internal(&'static str),
 }
@@ -244,6 +249,10 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
                 core.rollback_storage_reservation(prev_len, req.body.len());
                 return Err(WriteError::Internal("unexpected quota error"));
             }
+            Err(world::WriteAuditError::Audit(err)) => {
+                core.rollback_storage_reservation(prev_len, req.body.len());
+                return Err(classify_write_audit_error("storage/audit", err));
+            }
             Err(world::WriteAuditError::Sqlite(err)) => {
                 core.rollback_storage_reservation(prev_len, req.body.len());
                 return Err(classify_write_storage_error(
@@ -337,13 +346,21 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
                 core.rollback_storage_reservation(0, req.body.len());
                 return Err(WriteError::NotFound);
             }
-            Err(err) => {
+            Err(world::WriteAuditError::Audit(err)) => {
+                core.rollback_storage_reservation(0, req.body.len());
+                return Err(classify_write_audit_error("storage/audit", err));
+            }
+            Err(world::WriteAuditError::Sqlite(err)) => {
                 core.rollback_storage_reservation(0, req.body.len());
                 return Err(classify_write_storage_error(
                     "storage/audit",
                     err,
                     StorageOp::WriteAudit,
                 ));
+            }
+            Err(world::WriteAuditError::Quota { .. }) => {
+                core.rollback_storage_reservation(0, req.body.len());
+                return Err(WriteError::Internal("unexpected quota error"));
             }
         }
     } else {
@@ -401,6 +418,18 @@ fn classify_read_error(scope: &'static str, err: rusqlite::Error) -> ReadError {
         StorageFailureClass::InsufficientStorage => ReadError::InsufficientStorage { scope, err },
         StorageFailureClass::Transient => ReadError::TransientStorage { scope, err },
         StorageFailureClass::Other => ReadError::StorageRead { scope, err },
+    }
+}
+
+fn classify_write_audit_error(scope: &'static str, err: audit::AuditError) -> WriteError {
+    match err {
+        audit::AuditError::ChainBroken(break_report) => WriteError::AuditChainBroken {
+            scope,
+            break_report,
+        },
+        audit::AuditError::Storage(err) => {
+            classify_write_storage_error(scope, err, StorageOp::WriteAudit)
+        }
     }
 }
 


### PR DESCRIPTION
Stack layer 3/5 for #276. Base: #313.

This layer migrates durable replace/append write paths to carry typed audit errors:
- adds checked appendable transaction helpers
- threads `AuditError` through `WriteAuditError`
- maps chain breakage separately at the engine boundary
- preserves storage failure classification for real SQLite/storage errors

Validation:
- pre-push fast gate passed on this branch
- includes Rust fmt, clippy, tests, version consistency, cargo audit, SDK smoke, header policy scanner, JS syntax, whitespace

Part of #276.