### PR TITLE
Carry audit errors through delete ledger appends

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -30,16 +30,6 @@ pub enum AuditError {
     Storage(rusqlite::Error),
 }
 
-impl AuditError {
-    #[cfg(test)]
-    pub(crate) fn into_sqlite(self) -> rusqlite::Error {
-        match self {
-            Self::ChainBroken(break_report) => audit_chain_broken_error(&break_report),
-            Self::Storage(err) => err,
-        }
-    }
-}
-
 impl fmt::Display for AuditError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -249,14 +239,6 @@ pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn>(
     verify_appendable_tx(tx, key, EmptyChain::Reject)
 }
 
-#[cfg(test)]
-pub fn verify_appendable_tx_genesis<'tx, 'conn>(
-    tx: &'tx Transaction<'conn>,
-    key: &[u8],
-) -> rusqlite::Result<VerifiedAuditTx<'tx, 'conn>> {
-    verify_appendable_tx_genesis_checked(tx, key).map_err(AuditError::into_sqlite)
-}
-
 pub(crate) fn verify_appendable_tx_genesis_checked<'tx, 'conn>(
     tx: &'tx Transaction<'conn>,
     key: &[u8],
@@ -395,31 +377,6 @@ fn require_intact(report: VerifyReport) -> AuditResult<()> {
         VerifyReport::Valid(_) => Ok(()),
         VerifyReport::Broken(break_report) => Err(AuditError::ChainBroken(break_report)),
     }
-}
-
-#[cfg(test)]
-fn audit_chain_broken_error(break_report: &VerifyBreak) -> rusqlite::Error {
-    rusqlite::Error::SqliteFailure(
-        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CORRUPT),
-        Some(format!(
-            "{AUDIT_CHAIN_BROKEN_PREFIX}{}: expected {}, actual {}",
-            break_report.break_at, break_report.expected, break_report.actual
-        )),
-    )
-}
-
-#[cfg(test)]
-fn is_audit_chain_broken_error(err: &rusqlite::Error) -> bool {
-    matches!(
-        err,
-        rusqlite::Error::SqliteFailure(
-            rusqlite::ffi::Error {
-                code: rusqlite::ErrorCode::DatabaseCorrupt,
-                ..
-            },
-            Some(message),
-        ) if message.starts_with(AUDIT_CHAIN_BROKEN_PREFIX)
-    )
 }
 
 fn verify_event(
@@ -578,7 +535,7 @@ mod tests {
     fn hmac_for(event_type: &str, target: &str) -> String {
         let c = test_connection();
         let tx = c.unchecked_transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         append_tx(
             &audit_tx,
             event_type,
@@ -654,7 +611,7 @@ mod tests {
     fn verify_connection_accepts_intact_chain() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         let h1 = append_tx(
             &audit_tx,
             "put",
@@ -721,12 +678,15 @@ mod tests {
         .unwrap();
 
         let tx = c.transaction().unwrap();
-        let err = match verify_appendable_tx_genesis(&tx, b"key") {
+        let err = match verify_appendable_tx_genesis_checked(&tx, b"key") {
             Ok(_) => panic!("corrupt latest hmac must not be treated as an empty chain"),
             Err(e) => e,
         };
 
-        assert!(matches!(err, rusqlite::Error::InvalidColumnType(..)));
+        assert!(matches!(
+            err,
+            AuditError::Storage(rusqlite::Error::InvalidColumnType(..))
+        ));
         let count: i64 = tx
             .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
             .unwrap();
@@ -734,29 +694,48 @@ mod tests {
     }
 
     #[test]
-    fn audit_chain_broken_predicate_tracks_rusqlite_error_shape() {
-        let err = audit_chain_broken_error(&VerifyBreak {
-            break_at: 7,
-            expected: "hmac-good".to_string(),
-            actual: "hmac-bad".to_string(),
-        });
+    fn verify_appendable_existing_reports_chain_broken_error() {
+        let mut c = test_connection();
+        {
+            let tx = c.transaction().unwrap();
+            let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
+            append_tx(
+                &audit_tx,
+                "put",
+                "home/a",
+                "abc",
+                3,
+                "text/plain",
+                &[],
+                b"key",
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+        c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
+            .unwrap();
 
-        assert_eq!(
-            err.sqlite_error_code(),
-            Some(rusqlite::ffi::ErrorCode::DatabaseCorrupt),
-            "audit-chain breakage must remain a SQLite corrupt-class error"
-        );
-        assert!(
-            is_audit_chain_broken_error(&err),
-            "rusqlite Error::SqliteFailure shape changed without updating the audit predicate"
-        );
+        let tx = c.transaction().unwrap();
+        let err = match verify_appendable_tx_existing_checked(&tx, b"key") {
+            Ok(_) => panic!("tampered audit chain must not be appendable"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            AuditError::ChainBroken(VerifyBreak {
+                break_at: 0,
+                actual,
+                ..
+            }) if actual == "hmac-bad"
+        ));
     }
 
     #[test]
     fn verify_connection_rejects_tampered_event_hmac() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         append_tx(
             &audit_tx,
             "put",
@@ -784,17 +763,6 @@ mod tests {
     }
 
     #[test]
-    fn chain_broken_error_predicate_matches_generated_error() {
-        let err = audit_chain_broken_error(&VerifyBreak {
-            break_at: 7,
-            expected: "hmac-expected".to_owned(),
-            actual: "hmac-actual".to_owned(),
-        });
-
-        assert!(is_audit_chain_broken_error(&err));
-    }
-
-    #[test]
     fn startup_verification_rejects_tampered_world() {
         let root =
             std::env::temp_dir().join(format!("elastik-audit-startup-{}", std::process::id()));
@@ -814,7 +782,7 @@ mod tests {
     fn verify_connection_rejects_tampered_event_headers() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis(&tx, b"key").unwrap();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
         append_tx(
             &audit_tx,
             "put",

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,7 +4,7 @@
 //! the write.
 
 use hmac::{Hmac, KeyInit, Mac};
-use rusqlite::{ffi, Connection, OptionalExtension, Statement, Transaction};
+use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
 use crate::world;
@@ -31,6 +31,7 @@ pub enum AuditError {
 }
 
 impl AuditError {
+    #[cfg(test)]
     pub(crate) fn into_sqlite(self) -> rusqlite::Error {
         match self {
             Self::ChainBroken(break_report) => audit_chain_broken_error(&break_report),
@@ -82,7 +83,7 @@ pub fn append_with_conn_existing(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<String> {
+) -> AuditResult<String> {
     append_with_conn_verified(
         conn,
         event_type,
@@ -106,7 +107,7 @@ pub fn append_with_conn_genesis(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<String> {
+) -> AuditResult<String> {
     append_with_conn_verified(
         conn,
         event_type,
@@ -131,9 +132,9 @@ fn append_with_conn_verified(
     headers: &[(String, String)],
     key: &[u8],
     empty_chain: EmptyChain,
-) -> rusqlite::Result<String> {
+) -> AuditResult<String> {
     let tx = conn.transaction()?;
-    let audit_tx = verify_appendable_tx(&tx, key, empty_chain).map_err(AuditError::into_sqlite)?;
+    let audit_tx = verify_appendable_tx(&tx, key, empty_chain)?;
     let h = append_tx(
         &audit_tx,
         event_type,
@@ -396,9 +397,10 @@ fn require_intact(report: VerifyReport) -> AuditResult<()> {
     }
 }
 
+#[cfg(test)]
 fn audit_chain_broken_error(break_report: &VerifyBreak) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
-        ffi::Error::new(ffi::SQLITE_CORRUPT),
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CORRUPT),
         Some(format!(
             "{AUDIT_CHAIN_BROKEN_PREFIX}{}: expected {}, actual {}",
             break_report.break_at, break_report.expected, break_report.actual
@@ -411,7 +413,7 @@ fn is_audit_chain_broken_error(err: &rusqlite::Error) -> bool {
     matches!(
         err,
         rusqlite::Error::SqliteFailure(
-            ffi::Error {
+            rusqlite::ffi::Error {
                 code: rusqlite::ErrorCode::DatabaseCorrupt,
                 ..
             },

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -264,6 +264,22 @@ fn blocking_error_to_engine(
         Some(world.as_str()),
     );
     match err {
+        BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(_)) => {
+            EngineError::Storage { sqlite_code: None }
+        }
+        BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
+            match crate::classify_storage_failure(&err) {
+                StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage {
+                    sqlite_code: crate::engine::sqlite_code(&err),
+                },
+                StorageFailureClass::Transient => EngineError::TransientStorage {
+                    sqlite_code: crate::engine::sqlite_code(&err),
+                },
+                StorageFailureClass::Other => EngineError::Storage {
+                    sqlite_code: crate::engine::sqlite_code(&err),
+                },
+            }
+        }
         BlockingSqliteError::Sqlite(err) => match crate::classify_storage_failure(&err) {
             StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage {
                 sqlite_code: crate::engine::sqlite_code(&err),

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -547,6 +547,12 @@ pub(crate) fn log_blocking_storage_error(
     world: Option<&str>,
 ) {
     match err {
+        BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(break_report)) => {
+            log_audit_chain_error(scope, break_report, operation, world)
+        }
+        BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
+            log_storage_error(scope, err, operation, world)
+        }
         BlockingSqliteError::Sqlite(err) => log_storage_error(scope, err, operation, world),
         BlockingSqliteError::Worker => {
             #[cfg(feature = "unstable-engine")]

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -46,6 +46,7 @@ pub(crate) struct AuditAppendJob {
 /// (`handler::execute_delete`).
 #[derive(Debug)]
 pub(crate) enum BlockingSqliteError {
+    Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
     Worker,
 }
@@ -114,6 +115,6 @@ impl LedgerWriter {
             &job.headers,
             job.key.as_slice(),
         )
-        .map_err(BlockingSqliteError::Sqlite)
+        .map_err(BlockingSqliteError::Audit)
     }
 }

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -237,7 +237,7 @@ impl Core {
         body: &[u8],
         content_type: &str,
         headers: &[(String, String)],
-    ) -> rusqlite::Result<()> {
+    ) -> Result<(), world::WriteAuditError> {
         if store::is_memory_world(world) {
             self.mem.write(world, body, content_type, headers);
             Ok(())

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -207,6 +207,7 @@ pub struct WriteAuditResult {
     pub existed: bool,
 }
 
+#[derive(Debug)]
 pub enum WriteAuditError {
     Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
@@ -371,14 +372,9 @@ pub fn write_with_audit(
     content_type: &str,
     headers: &[(String, String)],
     key: &[u8],
-) -> rusqlite::Result<String> {
+) -> Result<String, WriteAuditError> {
     write_with_audit_checked(data_root, world, body, content_type, headers, key, None)
         .map(|result| result.hmac)
-        .map_err(|err| match err {
-            WriteAuditError::Audit(e) => e.into_sqlite(),
-            WriteAuditError::Sqlite(e) => e,
-            WriteAuditError::Quota { .. } => unreachable!("quota is disabled"),
-        })
 }
 
 pub fn write_with_audit_checked(


### PR DESCRIPTION
Stack layer 4/5 for #276. Base: #314.

This layer migrates the cached delete ledger append path:
- `append_with_conn_existing` / `append_with_conn_genesis` return `AuditResult`
- `BlockingSqliteError` can carry `AuditError`
- delete intent/commit logging distinguishes chain breakage from SQLite storage failures

Validation:
- pre-push fast gate passed on this branch
- includes Rust fmt, clippy, tests, version consistency, cargo audit, SDK smoke, header policy scanner, JS syntax, whitespace

Part of #276.