### PR TITLE
Remove sqlite codes from EngineError variants

### DIFF
--- a/bin/src/server/coap_errors.rs
+++ b/bin/src/server/coap_errors.rs
@@ -5,11 +5,11 @@ use crate::engine::EngineError;
 pub(crate) fn read_error_to_coap(err: &EngineError) -> u8 {
     match err {
         EngineError::Auth(_) => 129,
-        EngineError::InsufficientStorage { .. } => 167,
-        EngineError::TransientStorage { .. }
+        EngineError::InsufficientStorage => 167,
+        EngineError::TransientStorage
         | EngineError::ShuttingDown
         | EngineError::SubscriptionLimit => 163,
-        EngineError::Storage { .. } | EngineError::InternalInvariant(_) => 160,
+        EngineError::Storage | EngineError::InternalInvariant(_) => 160,
         EngineError::InvalidWorldName
         | EngineError::NotFound
         | EngineError::AppendOnly
@@ -23,8 +23,8 @@ pub(crate) fn read_error_to_coap(err: &EngineError) -> u8 {
 pub(crate) fn read_error_body(err: &EngineError) -> &'static [u8] {
     match err {
         EngineError::Auth(_) => b"unauthorized\n",
-        EngineError::InsufficientStorage { .. } => b"insufficient storage\n",
-        EngineError::TransientStorage { .. }
+        EngineError::InsufficientStorage => b"insufficient storage\n",
+        EngineError::TransientStorage
         | EngineError::ShuttingDown
         | EngineError::SubscriptionLimit => b"storage busy\n",
         _ => b"storage error\n",
@@ -37,11 +37,11 @@ pub(crate) fn write_error_to_coap(err: &EngineError) -> u8 {
         EngineError::PayloadTooLarge { .. } => 141,
         EngineError::PreconditionFailed { .. } => 140,
         EngineError::NotFound => 132,
-        EngineError::QuotaExceeded { .. } | EngineError::InsufficientStorage { .. } => 167,
-        EngineError::TransientStorage { .. }
+        EngineError::QuotaExceeded { .. } | EngineError::InsufficientStorage => 167,
+        EngineError::TransientStorage
         | EngineError::ShuttingDown
         | EngineError::SubscriptionLimit => 163,
-        EngineError::Storage { .. }
+        EngineError::Storage
         | EngineError::InternalInvariant(_)
         | EngineError::InvalidWorldName
         | EngineError::AppendOnly => 160,

--- a/bin/src/server/handler.rs
+++ b/bin/src/server/handler.rs
@@ -315,15 +315,15 @@ fn read_error_phase(err: EngineError) -> Phase {
             resp: unauthorized("read requires read token"),
             reason: ErrorReason::Auth(gate),
         },
-        EngineError::TransientStorage { .. } => Phase::Error {
+        EngineError::TransientStorage => Phase::Error {
             resp: storage_temporarily_unavailable(),
             reason: ErrorReason::StorageRead,
         },
-        EngineError::InsufficientStorage { .. } => Phase::Error {
+        EngineError::InsufficientStorage => Phase::Error {
             resp: insufficient_storage(),
             reason: ErrorReason::InsufficientStorage,
         },
-        EngineError::Storage { .. } | EngineError::InternalInvariant(_) => Phase::Error {
+        EngineError::Storage | EngineError::InternalInvariant(_) => Phase::Error {
             resp: server_error("storage failure".to_string()),
             reason: ErrorReason::StorageRead,
         },
@@ -377,15 +377,15 @@ pub(crate) fn write_error_phase(err: EngineError) -> Phase {
             resp: storage_quota_exceeded(used, quota, projected),
             reason: ErrorReason::QuotaExceeded,
         },
-        EngineError::TransientStorage { .. } => Phase::Error {
+        EngineError::TransientStorage => Phase::Error {
             resp: storage_temporarily_unavailable(),
             reason: ErrorReason::StorageWriteAudit,
         },
-        EngineError::InsufficientStorage { .. } => Phase::Error {
+        EngineError::InsufficientStorage => Phase::Error {
             resp: insufficient_storage(),
             reason: ErrorReason::InsufficientStorage,
         },
-        EngineError::Storage { .. } => Phase::Error {
+        EngineError::Storage => Phase::Error {
             resp: server_error("storage failure".to_string()),
             reason: ErrorReason::StorageRead,
         },

--- a/bin/src/server/handler/delete.rs
+++ b/bin/src/server/handler/delete.rs
@@ -213,11 +213,11 @@ fn delete_error_phase(err: EngineError, last_step: DeleteStep) -> Phase {
             resp: not_found(),
             reason: ErrorReason::NotFound,
         },
-        EngineError::TransientStorage { .. } | EngineError::ShuttingDown => {
+        EngineError::TransientStorage | EngineError::ShuttingDown => {
             transient_delete_error_phase(last_step)
         }
-        EngineError::InsufficientStorage { .. } => insufficient_delete_error_phase(last_step),
-        EngineError::Storage { .. } => storage_delete_error_phase(last_step),
+        EngineError::InsufficientStorage => insufficient_delete_error_phase(last_step),
+        EngineError::Storage => storage_delete_error_phase(last_step),
         EngineError::InternalInvariant(message) => invariant_delete_error_phase(message, last_step),
         EngineError::InvalidWorldName
         | EngineError::PayloadTooLarge { .. }
@@ -380,11 +380,8 @@ mod tests {
 
     #[tokio::test]
     async fn delete_error_phase_preserves_intent_succeeded_failure_body() {
-        let (status, reason, body) = error_parts(delete_error_phase(
-            EngineError::Storage { sqlite_code: None },
-            DeleteStep::Intent,
-        ))
-        .await;
+        let (status, reason, body) =
+            error_parts(delete_error_phase(EngineError::Storage, DeleteStep::Intent)).await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert!(matches!(reason, ErrorReason::StorageWriteAudit));

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -54,7 +54,7 @@ pub(crate) async fn handler(
             )
                 .into_response();
         }
-        Err(EngineError::ShuttingDown) | Err(EngineError::TransientStorage { .. }) => {
+        Err(EngineError::ShuttingDown) | Err(EngineError::TransientStorage) => {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
                 [

--- a/bin/src/server/mqtt/retained.rs
+++ b/bin/src/server/mqtt/retained.rs
@@ -291,7 +291,7 @@ mod tests {
             &metrics,
             RetainedReplayError::List {
                 prefix: "home/sensor/".to_owned(),
-                err: EngineError::Storage { sqlite_code: None },
+                err: EngineError::Storage,
             },
         );
 

--- a/bin/src/server/proc.rs
+++ b/bin/src/server/proc.rs
@@ -329,11 +329,11 @@ fn proc_engine_error(scope: &'static str, err: EngineError) -> Response {
     match err {
         EngineError::Auth(_) => unauthorized("read requires read token"),
         EngineError::NotFound => not_found(),
-        EngineError::TransientStorage { .. } | EngineError::ShuttingDown => {
+        EngineError::TransientStorage | EngineError::ShuttingDown => {
             storage_temporarily_unavailable()
         }
-        EngineError::InsufficientStorage { .. } => insufficient_storage(),
-        EngineError::Storage { .. } => server_error(format!("{scope} storage failure")),
+        EngineError::InsufficientStorage => insufficient_storage(),
+        EngineError::Storage => server_error(format!("{scope} storage failure")),
         EngineError::InvalidWorldName => bad_request("invalid world path"),
         EngineError::InternalInvariant(message) => {
             server_error(format!("{scope} internal invariant: {message}"))

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -265,31 +265,19 @@ fn blocking_error_to_engine(
     );
     match err {
         BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(_)) => {
-            EngineError::Storage { sqlite_code: None }
+            EngineError::Storage
         }
         BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
             match crate::classify_storage_failure(&err) {
-                StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage {
-                    sqlite_code: crate::engine::sqlite_code(&err),
-                },
-                StorageFailureClass::Transient => EngineError::TransientStorage {
-                    sqlite_code: crate::engine::sqlite_code(&err),
-                },
-                StorageFailureClass::Other => EngineError::Storage {
-                    sqlite_code: crate::engine::sqlite_code(&err),
-                },
+                StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage,
+                StorageFailureClass::Transient => EngineError::TransientStorage,
+                StorageFailureClass::Other => EngineError::Storage,
             }
         }
         BlockingSqliteError::Sqlite(err) => match crate::classify_storage_failure(&err) {
-            StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage {
-                sqlite_code: crate::engine::sqlite_code(&err),
-            },
-            StorageFailureClass::Transient => EngineError::TransientStorage {
-                sqlite_code: crate::engine::sqlite_code(&err),
-            },
-            StorageFailureClass::Other => EngineError::Storage {
-                sqlite_code: crate::engine::sqlite_code(&err),
-            },
+            StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage,
+            StorageFailureClass::Transient => EngineError::TransientStorage,
+            StorageFailureClass::Other => EngineError::Storage,
         },
         BlockingSqliteError::Worker => EngineError::InternalInvariant("sqlite worker failed"),
     }
@@ -304,26 +292,18 @@ impl From<DeleteError> for EngineError {
             DeleteError::NotFound => Self::NotFound,
             DeleteError::TransientStorage { scope, world, err } => {
                 crate::engine_ops::log_storage_error(scope, &err, "delete", Some(world.as_str()));
-                Self::TransientStorage {
-                    sqlite_code: crate::engine::sqlite_code(&err),
-                }
+                Self::TransientStorage
             }
             DeleteError::InsufficientStorage { scope, world, err } => {
                 crate::engine_ops::log_storage_error(scope, &err, "delete", Some(world.as_str()));
-                Self::InsufficientStorage {
-                    sqlite_code: crate::engine::sqlite_code(&err),
-                }
+                Self::InsufficientStorage
             }
             DeleteError::StorageRead { scope, world, err } => {
                 crate::engine_ops::log_storage_error(scope, &err, "delete", Some(world.as_str()));
-                Self::Storage {
-                    sqlite_code: crate::engine::sqlite_code(&err),
-                }
+                Self::Storage
             }
             DeleteError::AuditIntent { world, err } => blocking_error_to_engine(&world, err),
-            DeleteError::DeleteFailedAfterIntent | DeleteError::AuditCommitFailed => {
-                Self::Storage { sqlite_code: None }
-            }
+            DeleteError::DeleteFailedAfterIntent | DeleteError::AuditCommitFailed => Self::Storage,
         }
     }
 }

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -414,31 +414,6 @@ impl ShutdownToken {
     }
 }
 
-impl EngineError {
-    /// Returns the underlying SQLite extended result code, when this error
-    /// originated in the storage backend.
-    ///
-    /// Non-storage variants (auth, not-found, append-only, precondition,
-    /// quota, subscription-limit, shutting-down, internal-invariant) always
-    /// return `None`. Adapters can use this for protocol-specific code
-    /// mapping without inspecting the variant.
-    pub fn sqlite_code(&self) -> Option<i32> {
-        match self {
-            Self::TransientStorage | Self::InsufficientStorage | Self::Storage => None,
-            Self::Auth(_)
-            | Self::InvalidWorldName
-            | Self::NotFound
-            | Self::AppendOnly
-            | Self::PayloadTooLarge { .. }
-            | Self::PreconditionFailed { .. }
-            | Self::QuotaExceeded { .. }
-            | Self::SubscriptionLimit
-            | Self::ShuttingDown
-            | Self::InternalInvariant(_) => None,
-        }
-    }
-}
-
 impl fmt::Debug for Engine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Engine").finish_non_exhaustive()

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -145,21 +145,12 @@ pub enum EngineError {
     },
     /// Storage is temporarily unavailable (e.g. SQLite `BUSY`/`LOCKED`).
     /// Callers should retry with backoff.
-    TransientStorage {
-        /// Underlying SQLite extended result code, when available.
-        sqlite_code: Option<i32>,
-    },
+    TransientStorage,
     /// Storage backing exhausted (full disk, IO failure that maps to
     /// "no space left"). Callers must surface this as 5xx-class to operators.
-    InsufficientStorage {
-        /// Underlying SQLite extended result code, when available.
-        sqlite_code: Option<i32>,
-    },
+    InsufficientStorage,
     /// Generic storage failure that is neither transient nor insufficient.
-    Storage {
-        /// Underlying SQLite extended result code, when available.
-        sqlite_code: Option<i32>,
-    },
+    Storage,
     /// Subscription slot semaphore is exhausted.
     SubscriptionLimit,
     /// [`Engine::shutdown`] has been called; do not start new operations.
@@ -433,9 +424,7 @@ impl EngineError {
     /// mapping without inspecting the variant.
     pub fn sqlite_code(&self) -> Option<i32> {
         match self {
-            Self::TransientStorage { sqlite_code }
-            | Self::InsufficientStorage { sqlite_code }
-            | Self::Storage { sqlite_code } => *sqlite_code,
+            Self::TransientStorage | Self::InsufficientStorage | Self::Storage => None,
             Self::Auth(_)
             | Self::InvalidWorldName
             | Self::NotFound

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -9,7 +9,7 @@ use std::{fmt, sync::atomic::Ordering};
 
 use crate::{
     auth,
-    engine::{self, Engine, EngineError},
+    engine::{Engine, EngineError},
     engine_ops::{log_storage_error, EngineOps},
     engine_types::{AccessTier, ValidatedWorldPath},
     store, world, AuthGate, StorageFailureClass,
@@ -565,21 +565,15 @@ fn storage_error_to_engine(
     match crate::classify_storage_failure(&err) {
         StorageFailureClass::InsufficientStorage => {
             log_storage_error(scope, &err, operation, world);
-            EngineError::InsufficientStorage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::InsufficientStorage
         }
         StorageFailureClass::Transient => {
             log_storage_error(scope, &err, operation, world);
-            EngineError::TransientStorage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::TransientStorage
         }
         StorageFailureClass::Other => {
             log_storage_error(scope, &err, operation, world);
-            EngineError::Storage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::Storage
         }
     }
 }

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -411,21 +411,15 @@ fn read_error_to_engine(value: world_ops::ReadError, world: Option<&str>) -> Eng
         world_ops::ReadError::Auth(gate) => EngineError::Auth(gate),
         world_ops::ReadError::TransientStorage { scope, err } => {
             log_storage_error(scope, &err, "read", world);
-            EngineError::TransientStorage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::TransientStorage
         }
         world_ops::ReadError::InsufficientStorage { scope, err } => {
             log_storage_error(scope, &err, "read", world);
-            EngineError::InsufficientStorage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::InsufficientStorage
         }
         world_ops::ReadError::StorageRead { scope, err } => {
             log_storage_error(scope, &err, "read", world);
-            EngineError::Storage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::Storage
         }
         world_ops::ReadError::PermitWorldMismatch => {
             EngineError::InternalInvariant("read permit world mismatch")
@@ -452,34 +446,26 @@ fn write_error_to_engine(value: world_ops::WriteError, world: Option<&str>) -> E
         },
         world_ops::WriteError::TransientStorage { scope, err, op } => {
             log_storage_error(scope, &err, storage_op_label(op), world);
-            EngineError::TransientStorage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::TransientStorage
         }
         world_ops::WriteError::InsufficientStorage { scope, err, op } => {
             log_storage_error(scope, &err, storage_op_label(op), world);
-            EngineError::InsufficientStorage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::InsufficientStorage
         }
         world_ops::WriteError::StorageRead { scope, err } => {
             log_storage_error(scope, &err, "read", world);
-            EngineError::Storage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::Storage
         }
         world_ops::WriteError::StorageWriteAudit { scope, err } => {
             log_storage_error(scope, &err, "write_audit", world);
-            EngineError::Storage {
-                sqlite_code: engine::sqlite_code(&err),
-            }
+            EngineError::Storage
         }
         world_ops::WriteError::AuditChainBroken {
             scope,
             break_report,
         } => {
             log_audit_chain_error(scope, &break_report, "write_audit", world);
-            EngineError::Storage { sqlite_code: None }
+            EngineError::Storage
         }
         world_ops::WriteError::Internal(message) => EngineError::InternalInvariant(message),
     }

--- a/core/src/engine_trace.rs
+++ b/core/src/engine_trace.rs
@@ -44,8 +44,8 @@ pub trait EngineDeleteTraceHooks {
     fn audit_intent(&self) {}
     /// Diagnostic-only debug rendering when the delete audit intent append fails.
     ///
-    /// Do not parse this string programmatically; use [`EngineError`]
-    /// categories and [`EngineError::sqlite_code`] for stable decisions.
+    /// Do not parse this string programmatically; match [`EngineError`]
+    /// variants for stable decisions.
     fn audit_intent_failed(&self, _err: &str) {}
     /// In-flight reads were drained from the read cache.
     fn read_cache_drained(&self) {}
@@ -57,16 +57,16 @@ pub trait EngineDeleteTraceHooks {
     fn notify_sent(&self) {}
     /// Diagnostic-only debug rendering of the internal blocking storage error.
     ///
-    /// Do not parse this string programmatically; use [`EngineError`]
-    /// categories and [`EngineError::sqlite_code`] for stable decisions.
+    /// Do not parse this string programmatically; match [`EngineError`]
+    /// variants for stable decisions.
     fn audit_commit_failed(&self, _err: &str) {}
     /// `audit_commit_failed` was followed by a successful `delete_commit_failed`
     /// ledger entry — the audit chain reflects the partial state.
     fn audit_commit_failed_event_logged(&self) {}
     /// Diagnostic-only debug rendering of the internal blocking storage error.
     ///
-    /// Do not parse this string programmatically; use [`EngineError`]
-    /// categories and [`EngineError::sqlite_code`] for stable decisions.
+    /// Do not parse this string programmatically; match [`EngineError`]
+    /// variants for stable decisions.
     fn audit_commit_failed_event_failed(&self, _err: &str) {}
     /// The audit-commit ledger row was written successfully.
     fn audit_commit(&self) {}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -975,18 +975,15 @@ mod tests {
             other => panic!("expected structured quota error, got {other:?}"),
         }
 
-        let transient: FfiError = EngineError::TransientStorage {
-            sqlite_code: Some(5),
-        }
-        .into();
+        let transient: FfiError = EngineError::TransientStorage.into();
         assert!(matches!(
             transient,
             FfiError::TransientStorage {
-                sqlite_code: Some(5)
+                sqlite_code: None
             }
         ));
-        assert!(!transient.to_string().contains("Some(5)"));
-        assert!(transient.to_string().contains("code 5"));
+        assert!(!transient.to_string().contains("Some("));
+        assert!(transient.to_string().contains("no sqlite code"));
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -976,14 +976,9 @@ mod tests {
         }
 
         let transient: FfiError = EngineError::TransientStorage.into();
-        assert!(matches!(
-            transient,
-            FfiError::TransientStorage {
-                sqlite_code: None
-            }
-        ));
+        assert!(matches!(transient, FfiError::TransientStorage));
         assert!(!transient.to_string().contains("Some("));
-        assert!(transient.to_string().contains("no sqlite code"));
+        assert!(!transient.to_string().contains("sqlite"));
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -621,11 +621,9 @@ impl From<EngineError> for FfiError {
                 quota: quota as u64,
                 projected: projected as u64,
             },
-            EngineError::TransientStorage { sqlite_code } => Self::TransientStorage { sqlite_code },
-            EngineError::InsufficientStorage { sqlite_code } => {
-                Self::InsufficientStorage { sqlite_code }
-            }
-            EngineError::Storage { sqlite_code } => Self::Storage { sqlite_code },
+            EngineError::TransientStorage => Self::TransientStorage { sqlite_code: None },
+            EngineError::InsufficientStorage => Self::InsufficientStorage { sqlite_code: None },
+            EngineError::Storage => Self::Storage { sqlite_code: None },
             EngineError::SubscriptionLimit => Self::SubscriptionLimit,
             EngineError::ShuttingDown => Self::ShuttingDown,
             EngineError::InternalInvariant(message) => Self::InternalInvariant {

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -293,15 +293,9 @@ pub enum FfiError {
         quota: u64,
         projected: u64,
     },
-    TransientStorage {
-        sqlite_code: Option<i32>,
-    },
-    InsufficientStorage {
-        sqlite_code: Option<i32>,
-    },
-    Storage {
-        sqlite_code: Option<i32>,
-    },
+    TransientStorage,
+    InsufficientStorage,
+    Storage,
     SubscriptionLimit,
     ShuttingDown,
     InternalInvariant {
@@ -621,9 +615,9 @@ impl From<EngineError> for FfiError {
                 quota: quota as u64,
                 projected: projected as u64,
             },
-            EngineError::TransientStorage => Self::TransientStorage { sqlite_code: None },
-            EngineError::InsufficientStorage => Self::InsufficientStorage { sqlite_code: None },
-            EngineError::Storage => Self::Storage { sqlite_code: None },
+            EngineError::TransientStorage => Self::TransientStorage,
+            EngineError::InsufficientStorage => Self::InsufficientStorage,
+            EngineError::Storage => Self::Storage,
             EngineError::SubscriptionLimit => Self::SubscriptionLimit,
             EngineError::ShuttingDown => Self::ShuttingDown,
             EngineError::InternalInvariant(message) => Self::InternalInvariant {
@@ -677,19 +671,9 @@ impl fmt::Display for FfiError {
                 f,
                 "storage quota exceeded (used {used}, quota {quota}, projected {projected})"
             ),
-            Self::TransientStorage { sqlite_code } => {
-                write!(
-                    f,
-                    "storage temporarily unavailable ({})",
-                    code_label(*sqlite_code)
-                )
-            }
-            Self::InsufficientStorage { sqlite_code } => {
-                write!(f, "insufficient storage ({})", code_label(*sqlite_code))
-            }
-            Self::Storage { sqlite_code } => {
-                write!(f, "storage failed ({})", code_label(*sqlite_code))
-            }
+            Self::TransientStorage => f.write_str("storage temporarily unavailable"),
+            Self::InsufficientStorage => f.write_str("insufficient storage"),
+            Self::Storage => f.write_str("storage failed"),
             Self::SubscriptionLimit => f.write_str("subscription limit reached"),
             Self::ShuttingDown => f.write_str("engine is shutting down"),
         }


### PR DESCRIPTION
## Summary

Layer 1/3 for #288.

This removes the public `sqlite_code: Option<i32>` payloads from the core storage error variants:

- `EngineError::TransientStorage`
- `EngineError::InsufficientStorage`
- `EngineError::Storage`

The variants now expose only the semantic category embedders should match on. Internal conversion boundaries still classify rusqlite failures before constructing `EngineError`.

For stack compatibility, this layer keeps `EngineError::sqlite_code()` as a temporary shim that now returns `None` for these storage categories. The next layer removes the accessor.

## Validation

- `cargo check --manifest-path bin/Cargo.toml`
- `cargo check --manifest-path ffi/Cargo.toml`
- pushed with local pre-push gate passing:
  - Rust format
  - Rust clippy
  - Rust tests: core `93 passed, 2 ignored`; bin `108 passed`
  - version consistency
  - supply-chain quick audit
  - Python SDK smoke
  - header policy scanner
  - whitespace check