### PR TITLE
Remove public EngineError sqlite_code accessor

### DIFF
--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -414,31 +414,6 @@ impl ShutdownToken {
     }
 }
 
-impl EngineError {
-    /// Returns the underlying SQLite extended result code, when this error
-    /// originated in the storage backend.
-    ///
-    /// Non-storage variants (auth, not-found, append-only, precondition,
-    /// quota, subscription-limit, shutting-down, internal-invariant) always
-    /// return `None`. Adapters can use this for protocol-specific code
-    /// mapping without inspecting the variant.
-    pub fn sqlite_code(&self) -> Option<i32> {
-        match self {
-            Self::TransientStorage | Self::InsufficientStorage | Self::Storage => None,
-            Self::Auth(_)
-            | Self::InvalidWorldName
-            | Self::NotFound
-            | Self::AppendOnly
-            | Self::PayloadTooLarge { .. }
-            | Self::PreconditionFailed { .. }
-            | Self::QuotaExceeded { .. }
-            | Self::SubscriptionLimit
-            | Self::ShuttingDown
-            | Self::InternalInvariant(_) => None,
-        }
-    }
-}
-
 impl fmt::Debug for Engine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Engine").finish_non_exhaustive()

--- a/core/src/engine_trace.rs
+++ b/core/src/engine_trace.rs
@@ -44,8 +44,8 @@ pub trait EngineDeleteTraceHooks {
     fn audit_intent(&self) {}
     /// Diagnostic-only debug rendering when the delete audit intent append fails.
     ///
-    /// Do not parse this string programmatically; use [`EngineError`]
-    /// categories and [`EngineError::sqlite_code`] for stable decisions.
+    /// Do not parse this string programmatically; match [`EngineError`]
+    /// variants for stable decisions.
     fn audit_intent_failed(&self, _err: &str) {}
     /// In-flight reads were drained from the read cache.
     fn read_cache_drained(&self) {}
@@ -57,16 +57,16 @@ pub trait EngineDeleteTraceHooks {
     fn notify_sent(&self) {}
     /// Diagnostic-only debug rendering of the internal blocking storage error.
     ///
-    /// Do not parse this string programmatically; use [`EngineError`]
-    /// categories and [`EngineError::sqlite_code`] for stable decisions.
+    /// Do not parse this string programmatically; match [`EngineError`]
+    /// variants for stable decisions.
     fn audit_commit_failed(&self, _err: &str) {}
     /// `audit_commit_failed` was followed by a successful `delete_commit_failed`
     /// ledger entry — the audit chain reflects the partial state.
     fn audit_commit_failed_event_logged(&self) {}
     /// Diagnostic-only debug rendering of the internal blocking storage error.
     ///
-    /// Do not parse this string programmatically; use [`EngineError`]
-    /// categories and [`EngineError::sqlite_code`] for stable decisions.
+    /// Do not parse this string programmatically; match [`EngineError`]
+    /// variants for stable decisions.
     fn audit_commit_failed_event_failed(&self, _err: &str) {}
     /// The audit-commit ledger row was written successfully.
     fn audit_commit(&self) {}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -976,14 +976,9 @@ mod tests {
         }
 
         let transient: FfiError = EngineError::TransientStorage.into();
-        assert!(matches!(
-            transient,
-            FfiError::TransientStorage {
-                sqlite_code: None
-            }
-        ));
+        assert!(matches!(transient, FfiError::TransientStorage));
         assert!(!transient.to_string().contains("Some("));
-        assert!(transient.to_string().contains("no sqlite code"));
+        assert!(!transient.to_string().contains("sqlite"));
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -293,15 +293,9 @@ pub enum FfiError {
         quota: u64,
         projected: u64,
     },
-    TransientStorage {
-        sqlite_code: Option<i32>,
-    },
-    InsufficientStorage {
-        sqlite_code: Option<i32>,
-    },
-    Storage {
-        sqlite_code: Option<i32>,
-    },
+    TransientStorage,
+    InsufficientStorage,
+    Storage,
     SubscriptionLimit,
     ShuttingDown,
     InternalInvariant {
@@ -621,9 +615,9 @@ impl From<EngineError> for FfiError {
                 quota: quota as u64,
                 projected: projected as u64,
             },
-            EngineError::TransientStorage => Self::TransientStorage { sqlite_code: None },
-            EngineError::InsufficientStorage => Self::InsufficientStorage { sqlite_code: None },
-            EngineError::Storage => Self::Storage { sqlite_code: None },
+            EngineError::TransientStorage => Self::TransientStorage,
+            EngineError::InsufficientStorage => Self::InsufficientStorage,
+            EngineError::Storage => Self::Storage,
             EngineError::SubscriptionLimit => Self::SubscriptionLimit,
             EngineError::ShuttingDown => Self::ShuttingDown,
             EngineError::InternalInvariant(message) => Self::InternalInvariant {
@@ -677,19 +671,9 @@ impl fmt::Display for FfiError {
                 f,
                 "storage quota exceeded (used {used}, quota {quota}, projected {projected})"
             ),
-            Self::TransientStorage { sqlite_code } => {
-                write!(
-                    f,
-                    "storage temporarily unavailable ({})",
-                    code_label(*sqlite_code)
-                )
-            }
-            Self::InsufficientStorage { sqlite_code } => {
-                write!(f, "insufficient storage ({})", code_label(*sqlite_code))
-            }
-            Self::Storage { sqlite_code } => {
-                write!(f, "storage failed ({})", code_label(*sqlite_code))
-            }
+            Self::TransientStorage => f.write_str("storage temporarily unavailable"),
+            Self::InsufficientStorage => f.write_str("insufficient storage"),
+            Self::Storage => f.write_str("storage failed"),
             Self::SubscriptionLimit => f.write_str("subscription limit reached"),
             Self::ShuttingDown => f.write_str("engine is shutting down"),
         }


### PR DESCRIPTION
## Summary

Layer 2/3 for #288. Builds on #318.

This removes the public `EngineError::sqlite_code()` accessor entirely. After layer 1, embedders can still match the semantic `EngineError` variants but can no longer branch on the raw SQLite integer code.

It also updates the public trace documentation to describe matching `EngineError` categories instead of calling the removed SQLite-code accessor.

## Validation

- `cargo check --manifest-path bin/Cargo.toml`
- `cargo check --manifest-path ffi/Cargo.toml`
- pushed with local pre-push gate passing:
  - Rust format
  - Rust clippy
  - Rust tests: core `93 passed, 2 ignored`; bin `108 passed`
  - version consistency
  - supply-chain quick audit
  - Python SDK smoke
  - header policy scanner
  - whitespace check