### PR TITLE
Hide sqlite codes from FFI operation errors

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -976,14 +976,9 @@ mod tests {
         }
 
         let transient: FfiError = EngineError::TransientStorage.into();
-        assert!(matches!(
-            transient,
-            FfiError::TransientStorage {
-                sqlite_code: None
-            }
-        ));
+        assert!(matches!(transient, FfiError::TransientStorage));
         assert!(!transient.to_string().contains("Some("));
-        assert!(transient.to_string().contains("no sqlite code"));
+        assert!(!transient.to_string().contains("sqlite"));
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -293,15 +293,9 @@ pub enum FfiError {
         quota: u64,
         projected: u64,
     },
-    TransientStorage {
-        sqlite_code: Option<i32>,
-    },
-    InsufficientStorage {
-        sqlite_code: Option<i32>,
-    },
-    Storage {
-        sqlite_code: Option<i32>,
-    },
+    TransientStorage,
+    InsufficientStorage,
+    Storage,
     SubscriptionLimit,
     ShuttingDown,
     InternalInvariant {
@@ -621,9 +615,9 @@ impl From<EngineError> for FfiError {
                 quota: quota as u64,
                 projected: projected as u64,
             },
-            EngineError::TransientStorage => Self::TransientStorage { sqlite_code: None },
-            EngineError::InsufficientStorage => Self::InsufficientStorage { sqlite_code: None },
-            EngineError::Storage => Self::Storage { sqlite_code: None },
+            EngineError::TransientStorage => Self::TransientStorage,
+            EngineError::InsufficientStorage => Self::InsufficientStorage,
+            EngineError::Storage => Self::Storage,
             EngineError::SubscriptionLimit => Self::SubscriptionLimit,
             EngineError::ShuttingDown => Self::ShuttingDown,
             EngineError::InternalInvariant(message) => Self::InternalInvariant {
@@ -677,19 +671,9 @@ impl fmt::Display for FfiError {
                 f,
                 "storage quota exceeded (used {used}, quota {quota}, projected {projected})"
             ),
-            Self::TransientStorage { sqlite_code } => {
-                write!(
-                    f,
-                    "storage temporarily unavailable ({})",
-                    code_label(*sqlite_code)
-                )
-            }
-            Self::InsufficientStorage { sqlite_code } => {
-                write!(f, "insufficient storage ({})", code_label(*sqlite_code))
-            }
-            Self::Storage { sqlite_code } => {
-                write!(f, "storage failed ({})", code_label(*sqlite_code))
-            }
+            Self::TransientStorage => f.write_str("storage temporarily unavailable"),
+            Self::InsufficientStorage => f.write_str("insufficient storage"),
+            Self::Storage => f.write_str("storage failed"),
             Self::SubscriptionLimit => f.write_str("subscription limit reached"),
             Self::ShuttingDown => f.write_str("engine is shutting down"),
         }


### PR DESCRIPTION
## Summary

Layer 3/3 for #288. Builds on #319.

This mirrors the core API cleanup across FFI operation errors:

- `FfiError::TransientStorage`
- `FfiError::InsufficientStorage`
- `FfiError::Storage`

Those operation errors are now semantic unit variants, so FFI consumers do not receive or learn to match raw SQLite integer codes.

`BuildStorage { sqlite_code, detail }` is intentionally left unchanged in this layer because it is a startup/build diagnostic path, not an operation-level `EngineError` surface. Keeping it avoids expanding #288 beyond the embedder-facing operation error leak.

Closes #288.

## Validation

- `cargo fmt --manifest-path core/Cargo.toml --check`
- `cargo fmt --manifest-path bin/Cargo.toml --check`
- `cargo fmt --manifest-path ffi/Cargo.toml --check`
- `cargo clippy --manifest-path core/Cargo.toml --features unstable-engine -- -D warnings`
- `cargo test --manifest-path core/Cargo.toml --features unstable-engine --lib` (`93 passed, 2 ignored`)
- `cargo check --manifest-path bin/Cargo.toml`
- `cargo check --manifest-path ffi/Cargo.toml`
- `cargo test --manifest-path ffi/Cargo.toml engine_errors_cross_ffi_with_structured_details`
- leak scan: no matches for `EngineError::sqlite_code`, `pub fn sqlite_code(&self)`, or public storage variants carrying `sqlite_code`
- pushed with local pre-push gate passing:
  - Rust format
  - Rust clippy
  - Rust tests: core `93 passed, 2 ignored`; bin `108 passed`
  - version consistency
  - supply-chain quick audit
  - Python SDK smoke
  - header policy scanner
  - whitespace check