### PR TITLE
[codex] Improve data root writer lock diagnostics

### DIFF
--- a/core/src/data_lock.rs
+++ b/core/src/data_lock.rs
@@ -1,25 +1,114 @@
+//! Process-local ownership guard for one AuditeDB data directory.
+//!
+//! This is a SQLite-backed mutex for one host process at a time. It is not a
+//! distributed lease and should not be treated as reliable fencing on NFS or
+//! other network filesystems with weak locking/cache semantics. Put
+//! `ELASTIK_DATA` on a local filesystem, or use an external coordinator that is
+//! designed for distributed ownership.
+//!
+//! The lock database deliberately uses rollback-journal mode. WAL is useful for
+//! durable world databases because readers and writers coexist there; this
+//! file only needs a single uncommitted `BEGIN IMMEDIATE` transaction to keep a
+//! second writer out.
+
 use std::path::Path;
 use std::time::Duration;
 
-pub(crate) fn acquire_data_root_writer_lock(data: &Path) -> rusqlite::Result<rusqlite::Connection> {
+#[derive(Debug)]
+pub(crate) enum DataRootWriterLockError {
+    Storage(rusqlite::Error),
+    Held {
+        source: rusqlite::Error,
+        holder_pid: Option<String>,
+    },
+}
+
+impl DataRootWriterLockError {
+    pub(crate) fn sqlite_error(&self) -> &rusqlite::Error {
+        match self {
+            Self::Storage(err) | Self::Held { source: err, .. } => err,
+        }
+    }
+
+    pub(crate) fn holder_pid(&self) -> Option<&str> {
+        match self {
+            Self::Held { holder_pid, .. } => holder_pid.as_deref(),
+            Self::Storage(_) => None,
+        }
+    }
+}
+
+impl From<rusqlite::Error> for DataRootWriterLockError {
+    fn from(value: rusqlite::Error) -> Self {
+        Self::Storage(value)
+    }
+}
+
+pub(crate) fn acquire_data_root_writer_lock(
+    data: &Path,
+) -> Result<rusqlite::Connection, DataRootWriterLockError> {
     let c = rusqlite::Connection::open(data.join(".elastik-writer-lock.sqlite3"))?;
     c.busy_timeout(Duration::from_millis(0))?;
     c.execute_batch(
         r#"
-        PRAGMA journal_mode=WAL;
+        PRAGMA journal_mode=DELETE;
         CREATE TABLE IF NOT EXISTS writer_lock(
             id INTEGER PRIMARY KEY CHECK(id=1),
             holder TEXT NOT NULL DEFAULT ''
         );
         INSERT OR IGNORE INTO writer_lock(id, holder) VALUES(1, '');
-        BEGIN IMMEDIATE;
         "#,
-    )?;
-    c.execute(
-        "UPDATE writer_lock SET holder=?1 WHERE id=1",
-        [std::process::id().to_string()],
-    )?;
+    )
+    .map_err(|source| lock_attempt_error(&c, source))?;
+
+    // `holder` is diagnostic, not part of SQLite's locking proof. Commit it
+    // before the never-committed lock transaction so a rejected second process
+    // can report who was most likely already holding the data root. It is a
+    // best-effort diagnostic, not proof of the current holder.
+    let holder = std::process::id().to_string();
+    commit_holder(&c, holder.as_str()).map_err(|source| lock_attempt_error(&c, source))?;
+    c.execute_batch("BEGIN IMMEDIATE;")
+        .map_err(|source| lock_attempt_error(&c, source))?;
     Ok(c)
+}
+
+fn commit_holder(c: &rusqlite::Connection, holder: &str) -> rusqlite::Result<()> {
+    c.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = c
+        .execute("UPDATE writer_lock SET holder=?1 WHERE id=1", [holder])
+        .and_then(|_| c.execute_batch("COMMIT;"));
+    if result.is_err() {
+        let _ = c.execute_batch("ROLLBACK;");
+    }
+    result
+}
+
+fn lock_attempt_error(
+    c: &rusqlite::Connection,
+    source: rusqlite::Error,
+) -> DataRootWriterLockError {
+    DataRootWriterLockError::Held {
+        holder_pid: query_holder(c).ok().flatten(),
+        source,
+    }
+}
+
+#[cfg(test)]
+fn read_data_root_writer_lock_holder(data: &Path) -> rusqlite::Result<Option<String>> {
+    let c = rusqlite::Connection::open(data.join(".elastik-writer-lock.sqlite3"))?;
+    c.busy_timeout(Duration::from_millis(0))?;
+    query_holder(&c)
+}
+
+fn query_holder(c: &rusqlite::Connection) -> rusqlite::Result<Option<String>> {
+    let holder = c.query_row("SELECT holder FROM writer_lock WHERE id=1", [], |row| {
+        row.get::<_, String>(0)
+    })?;
+    if holder.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(holder))
+    }
 }
 
 #[cfg(test)]
@@ -34,11 +123,59 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
 
         let first = acquire_data_root_writer_lock(&dir).unwrap();
-        assert!(acquire_data_root_writer_lock(&dir).is_err());
+        assert!(matches!(
+            acquire_data_root_writer_lock(&dir),
+            Err(DataRootWriterLockError::Held { .. })
+        ));
         drop(first);
         let second = acquire_data_root_writer_lock(&dir).unwrap();
         drop(second);
 
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn data_root_writer_lock_uses_rollback_journal() {
+        let dir = temp_dir("journal-mode");
+
+        let lock = acquire_data_root_writer_lock(&dir).unwrap();
+        let mode: String = lock
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+
+        assert_eq!(mode.to_ascii_lowercase(), "delete");
+
+        drop(lock);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn data_root_writer_lock_holder_is_visible_while_lock_is_held() {
+        let dir = temp_dir("holder");
+
+        let first = acquire_data_root_writer_lock(&dir).unwrap();
+        let expected_pid = std::process::id().to_string();
+        assert_eq!(
+            read_data_root_writer_lock_holder(&dir).unwrap().as_deref(),
+            Some(expected_pid.as_str())
+        );
+
+        let err = acquire_data_root_writer_lock(&dir).unwrap_err();
+        assert_eq!(err.holder_pid(), Some(expected_pid.as_str()));
+        assert_eq!(
+            read_data_root_writer_lock_holder(&dir).unwrap().as_deref(),
+            Some(expected_pid.as_str())
+        );
+
+        drop(first);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("elastik-data-lock-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
     }
 }

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -90,6 +90,9 @@ pub enum EngineBuildError {
     DataRootLockHeld {
         /// The data root that failed to acquire the writer lock.
         path: PathBuf,
+        /// Best-effort PID last written by the process that attempted to hold
+        /// the lock. This is diagnostic only, not a fencing proof.
+        holder_pid: Option<String>,
     },
     /// [`EngineBuilder::key`] was never called.
     HmacKeyMissing,
@@ -299,6 +302,7 @@ impl EngineBuilder {
                 storage_class::StorageFailureClass::Transient => {
                     EngineBuildError::DataRootLockHeld {
                         path: self.data_root.clone(),
+                        holder_pid: None,
                     }
                 }
                 storage_class::StorageFailureClass::InsufficientStorage
@@ -441,15 +445,20 @@ pub(crate) fn sqlite_code(err: &rusqlite::Error) -> Option<i32> {
     err.sqlite_error_code().map(|code| code as i32)
 }
 
-fn map_writer_lock_error(data_root: &std::path::Path, err: rusqlite::Error) -> EngineBuildError {
-    match storage_class::classify_storage_failure(&err) {
+fn map_writer_lock_error(
+    data_root: &std::path::Path,
+    err: crate::data_lock::DataRootWriterLockError,
+) -> EngineBuildError {
+    let sqlite_err = err.sqlite_error();
+    match storage_class::classify_storage_failure(sqlite_err) {
         storage_class::StorageFailureClass::Transient => EngineBuildError::DataRootLockHeld {
             path: data_root.to_path_buf(),
+            holder_pid: err.holder_pid().map(str::to_owned),
         },
         storage_class::StorageFailureClass::InsufficientStorage
         | storage_class::StorageFailureClass::Other => EngineBuildError::Storage {
-            sqlite_code: sqlite_code(&err),
-            detail: format!("writer lock open failed: {err}"),
+            sqlite_code: sqlite_code(sqlite_err),
+            detail: format!("writer lock open failed: {sqlite_err}"),
         },
     }
 }
@@ -475,6 +484,7 @@ fn verify_all_worlds_with_names(
                 storage_class::StorageFailureClass::Transient => {
                     EngineBuildError::DataRootLockHeld {
                         path: data_root.to_path_buf(),
+                        holder_pid: None,
                     }
                 }
                 storage_class::StorageFailureClass::InsufficientStorage => {
@@ -635,10 +645,13 @@ mod tests {
             .key(SecretBytes::try_from_slice(b"key").unwrap())
             .build();
 
-        assert!(matches!(
-            second,
-            Err(EngineBuildError::DataRootLockHeld { .. })
-        ));
+        match second {
+            Err(EngineBuildError::DataRootLockHeld { holder_pid, .. }) => {
+                let expected_pid = std::process::id().to_string();
+                assert_eq!(holder_pid.as_deref(), Some(expected_pid.as_str()));
+            }
+            other => panic!("expected data root writer lock error, got {other:?}"),
+        }
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -163,7 +163,8 @@ try:
 except FfiError.InvalidSecret as e:
     print(e.message)
 except FfiError.BuildDataRootLockHeld as e:
-    print(f"locked: {e.path}")
+    holder = f" by PID {e.holder_pid}" if e.holder_pid else ""
+    print(f"locked{holder}: {e.path}")
 ```
 
 ## Artifact CI

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -163,7 +163,7 @@ try:
 except FfiError.InvalidSecret as e:
     print(e.message)
 except FfiError.BuildDataRootLockHeld as e:
-    holder = f" by PID {e.holder_pid}" if e.holder_pid else ""
+    holder = f" (last writer: PID {e.holder_pid})" if e.holder_pid else ""
     print(f"locked{holder}: {e.path}")
 ```
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1018,7 +1018,7 @@ mod tests {
         ));
         assert_eq!(
             err.to_string(),
-            "data root writer lock is held by PID 12345: data"
+            "data root writer lock is held (last writer: PID 12345): data"
         );
     }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1003,6 +1003,23 @@ mod tests {
         let err: FfiError = EngineBuildError::HmacKeyMissing.into();
         assert!(matches!(err, FfiError::BuildHmacKeyMissing));
         assert_eq!(err.to_string(), "hmac key missing");
+
+        let err: FfiError = EngineBuildError::DataRootLockHeld {
+            path: std::path::PathBuf::from("data"),
+            holder_pid: Some("12345".to_owned()),
+        }
+        .into();
+        assert!(matches!(
+            err,
+            FfiError::BuildDataRootLockHeld {
+                ref holder_pid,
+                ..
+            } if holder_pid.as_deref() == Some("12345")
+        ));
+        assert_eq!(
+            err.to_string(),
+            "data root writer lock is held by PID 12345: data"
+        );
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -258,6 +258,7 @@ pub enum FfiError {
     },
     BuildDataRootLockHeld {
         path: String,
+        holder_pid: Option<String>,
     },
     BuildHmacKeyMissing,
     BuildAuditChainCorrupted {
@@ -574,9 +575,12 @@ impl From<EngineBuildError> for FfiError {
             EngineBuildError::DataRootIo(err) => Self::BuildDataRootIo {
                 message: err.to_string(),
             },
-            EngineBuildError::DataRootLockHeld { path } => Self::BuildDataRootLockHeld {
-                path: path.to_string_lossy().into_owned(),
-            },
+            EngineBuildError::DataRootLockHeld { path, holder_pid } => {
+                Self::BuildDataRootLockHeld {
+                    path: path.to_string_lossy().into_owned(),
+                    holder_pid,
+                }
+            }
             EngineBuildError::HmacKeyMissing => Self::BuildHmacKeyMissing,
             EngineBuildError::AuditChainCorrupted { world, detail } => {
                 Self::BuildAuditChainCorrupted { world, detail }
@@ -643,9 +647,10 @@ impl fmt::Display for FfiError {
             Self::UnknownBuildError { detail } | Self::UnknownEngineError { detail } => {
                 f.write_str(detail)
             }
-            Self::BuildDataRootLockHeld { path } => {
-                write!(f, "data root writer lock is held: {path}")
-            }
+            Self::BuildDataRootLockHeld { path, holder_pid } => match holder_pid {
+                Some(pid) => write!(f, "data root writer lock is held by PID {pid}: {path}"),
+                None => write!(f, "data root writer lock is held: {path}"),
+            },
             Self::BuildHmacKeyMissing => f.write_str("hmac key missing"),
             Self::BuildAuditChainCorrupted { world, detail } => {
                 write!(f, "audit chain corrupted for {world}: {detail}")

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -648,7 +648,10 @@ impl fmt::Display for FfiError {
                 f.write_str(detail)
             }
             Self::BuildDataRootLockHeld { path, holder_pid } => match holder_pid {
-                Some(pid) => write!(f, "data root writer lock is held by PID {pid}: {path}"),
+                Some(pid) => write!(
+                    f,
+                    "data root writer lock is held (last writer: PID {pid}): {path}"
+                ),
                 None => write!(f, "data root writer lock is held: {path}"),
             },
             Self::BuildHmacKeyMissing => f.write_str("hmac key missing"),

--- a/skills/elastik.skill/references/deployment.md
+++ b/skills/elastik.skill/references/deployment.md
@@ -145,7 +145,15 @@ are intentional.
 AuditeDB holds a SQLite-backed writer lock on
 `ELASTIK_DATA/.elastik-writer-lock.sqlite3` for the lifetime of the process. A
 second AuditeDB process pointed at the same data directory fails to start with a
-lock error instead of silently corrupting state.
+lock error instead of silently corrupting state. The error includes a
+best-effort holder PID when the previous owner committed one before taking the
+lock.
+
+This assumes a local filesystem. SQLite file locks are not a distributed
+coordination protocol, and NFS or other network filesystems with weak locking
+or caching semantics can break that assumption. Put `ELASTIK_DATA` on local
+storage, or use an external coordinator that is designed for distributed
+ownership.
 
 To serve a different universe, change `ELASTIK_DATA`.
 


### PR DESCRIPTION
## Summary
- switch the data-root writer-lock database back to rollback-journal mode instead of WAL
- commit a best-effort holder PID before taking the never-committed writer lock, then surface that PID in `EngineBuildError` and FFI errors when a second process is rejected
- document the local-filesystem assumption and NFS/network-filesystem boundary for the SQLite-backed writer lock

## Why
The previous `holder` update happened inside the never-committed lock transaction, so a rejected second process could not use it as a diagnostic. The lock DB also does not benefit from WAL because it is only a single-host ownership guard, not a read/write world database.

## Validation
- `cargo test --manifest-path core/Cargo.toml --features bundled-sqlite,unstable-engine`
- `cargo test --manifest-path ffi/Cargo.toml`
- `cargo clippy --manifest-path core/Cargo.toml --features bundled-sqlite,unstable-engine -- -D warnings`
- `cargo clippy --manifest-path ffi/Cargo.toml -- -D warnings`
- `git diff --check`
- pre-push hook: Rust format, Rust clippy, Rust tests, version consistency, supply-chain quick audit, Python SDK smoke, header policy scanner, JS syntax, whitespace