### PR TITLE
[codex] Seal audit HMAC keys behind length checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,7 @@ ELASTIK_READ_CACHE_MAX_ENTRIES=5000
 # Audit-chain HMAC key. Required by the Rust core. The SDK no longer
 # substitutes a constant default. Generate one with:
 #   python -c "import secrets; print(secrets.token_hex(32))"
-ELASTIK_KEY=change-me-local-dev-key
+ELASTIK_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
 # Tokens. Empty means that tier is disabled.
 # If ELASTIK_READ_TOKEN is empty, reads stay public.

--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -26,9 +26,6 @@ jobs:
           - name: linux-arm64
             os: ubuntu-24.04-arm
             library-path: target/release/libelastik_ffi.so
-          - name: macos-x64
-            os: macos-15-intel
-            library-path: target/release/libelastik_ffi.dylib
           - name: macos-arm64
             os: macos-14
             library-path: target/release/libelastik_ffi.dylib
@@ -87,7 +84,7 @@ jobs:
           none = e.FfiPreconditions(if_match=[], if_none_match=[])
           engine = e.FfiEngine.open(e.FfiEngineConfig(
               data_root=str(root),
-              hmac_key=b"ffi-ci-key",
+              hmac_key=b"0123456789abcdef0123456789abcdef",
               read_token=None,
               write_token=None,
               approve_token=None,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,10 +181,6 @@ jobs:
             os: ubuntu-24.04-arm
             library-path: target/release/libelastik_ffi.so
             asset-name: elastik-ffi-linux-arm64.zip
-          - name: macos-x64
-            os: macos-15-intel
-            library-path: target/release/libelastik_ffi.dylib
-            asset-name: elastik-ffi-darwin-x64.zip
           - name: macos-arm64
             os: macos-14
             library-path: target/release/libelastik_ffi.dylib
@@ -246,7 +242,7 @@ jobs:
           none = e.FfiPreconditions(if_match=[], if_none_match=[])
           engine = e.FfiEngine.open(e.FfiEngineConfig(
               data_root=str(root),
-              hmac_key=b"ffi-release-key",
+              hmac_key=b"0123456789abcdef0123456789abcdef",
               read_token=None,
               write_token=None,
               approve_token=None,

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 # is missing, the next step refuses with a clear error, not magic.
 #
 # CI is the canonical source of release wheels — see
-# .github/workflows/build.yml. Local cross-compile (`make cross`) is a
+# .github/workflows/wheel-ci.yml and .github/workflows/release.yml.
+# Local cross-compile (`make cross`) is a
 # convenience for testing one target at a time.
 
 .PHONY: dev test build wheel cross install clean help info
@@ -23,6 +24,8 @@ RUST_TGT   = bin/target/release/$(BIN_NAME)
 SDK_BIN    = sdk/src/elastik/_bin/$(BIN_NAME)
 
 # Cross-compile target list. zigbuild handles all of these without Docker.
+# This is a local convenience surface, not the current release artifact matrix.
+# FFI release assets intentionally omit macOS x64.
 # Windows ARM64 needs MSVC ARM64 cross tools; CI handles that one.
 CROSS_TARGETS = \
     x86_64-unknown-linux-gnu \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Library embedders call typed Engine methods instead of HTTP `/proc/*` paths:
 
 ```rust
 use elastik_core::{
-    AccessTier, Engine, Preconditions, Representation, SecretBytes, ValidatedWorldPath,
+    AccessTier, AuditHmacKey, Engine, Preconditions, Representation, ValidatedWorldPath,
 };
 use bytes::Bytes;
 
@@ -70,7 +70,7 @@ use bytes::Bytes;
 async fn main() {
     let engine = Engine::builder()
         .data_root("./data")
-        .key(SecretBytes::new(b"shared-secret".to_vec()).unwrap())
+        .key(AuditHmacKey::new(b"0123456789abcdef0123456789abcdef".to_vec()).unwrap())
         .build()
         .unwrap();
 
@@ -90,13 +90,14 @@ async fn main() {
 
 ```toml
 [dependencies]
-elastik-core = { version = "8", default-features = false,
+elastik-core = { version = "=8.3.0", default-features = false,
                  features = ["bundled-sqlite", "unstable-engine"] }
 tokio = { version = "1", features = ["macros", "rt"] }
 ```
 
 The `unstable-engine` gate explicitly marks the public Engine API unstable.
-API shapes may change between minor versions until that gate is removed.
+API shapes may change between minor versions until that gate is removed. Pin an
+exact `elastik-core` version when embedding the unstable Engine API.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,10 +30,10 @@ signs durable writes into an HMAC audit chain, and replays safe persisted
 response metadata. That is the engine's security boundary.
 
 Documentation tokens such as `read-token`, `write-token`, `approve-token`,
-`admin-token`, `dev-hmac-key`, and `change-me` are examples only. The engine
-does not ship with built-in defaults. If those copied strings protect a shared
-deployment, that is a deployment configuration problem, not a hidden default
-credential.
+`admin-token`, and `change-me` are examples only. Audit-chain HMAC keys must be
+at least 32 bytes and must not be empty or all whitespace. The engine does not
+ship with built-in defaults. If copied strings protect a shared deployment, that
+is a deployment configuration problem, not a hidden default credential.
 
 Good security reports usually involve one of these:
 

--- a/bin/Cargo.lock
+++ b/bin/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-bin"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "bytes",
  "dashmap",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastik-bin"
-version = "8.2.1"
+version = "8.3.0"
 edition = "2021"
 description = "AuditeDB server — HTTP, CoAP, MQTT, SSE adapters for the Elastik L5 Engine."
 license = "MIT"

--- a/bin/src/core_bridge.rs
+++ b/bin/src/core_bridge.rs
@@ -39,9 +39,9 @@ pub(crate) mod engine_types {
     #[cfg(test)]
     pub(crate) use elastik_core::WriteResult;
     pub(crate) use elastik_core::{
-        parse_etag_matchers, AccessTier, ChangeEvent, ChangeVerb, EtagMatcher, Preconditions,
-        Representation, SecretBytes, SubscribePattern, SubscriptionRecvError, ValidatedWorldPath,
-        WriteKind,
+        parse_etag_matchers, AccessTier, AuditHmacKey, ChangeEvent, ChangeVerb, EtagMatcher,
+        InvalidHmacKey, Preconditions, Representation, SubscribePattern, SubscriptionRecvError,
+        ValidatedWorldPath, WriteKind,
     };
 }
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -10,7 +10,10 @@ pub(crate) use core_bridge::*;
 #[cfg_attr(not(feature = "multi-thread"), tokio::main(flavor = "current_thread"))]
 #[cfg(not(test))]
 async fn main() {
-    server::run_from_env().await;
+    if let Err(err) = server::run_from_env().await {
+        eprintln!("elastik-core: {err}");
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]

--- a/bin/src/server/config.rs
+++ b/bin/src/server/config.rs
@@ -8,6 +8,8 @@
 
 use std::net::{IpAddr, SocketAddr};
 
+use crate::engine_types::{AuditHmacKey, InvalidHmacKey};
+
 #[cfg(feature = "coap")]
 pub(crate) const DEFAULT_COAP_MAX_IN_FLIGHT: usize = 1024;
 #[cfg(not(test))]
@@ -31,18 +33,22 @@ pub(crate) fn env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
-pub(crate) fn env_optional_usize(name: &str) -> Option<usize> {
-    let Ok(raw) = std::env::var(name) else {
-        return None;
+pub(crate) fn env_optional_usize(name: &str) -> Result<Option<usize>, String> {
+    let raw = match std::env::var(name) {
+        Ok(raw) => raw,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(format!("{name} must be valid Unicode"));
+        }
     };
     let value = raw.trim();
     if value.is_empty() {
-        return None;
+        return Ok(None);
     }
     let parsed = value
         .parse::<usize>()
-        .unwrap_or_else(|_| panic!("{name} must be a non-negative integer byte count"));
-    (parsed > 0).then_some(parsed)
+        .map_err(|_| format!("{name} must be a non-negative integer byte count"))?;
+    Ok((parsed > 0).then_some(parsed))
 }
 
 pub(crate) fn env_nonzero_usize(name: &str, default: usize) -> usize {
@@ -104,10 +110,10 @@ pub(crate) fn listen_addr(host: &str, port: u16) -> String {
         .unwrap_or_else(|_| format!("{host}:{port}"))
 }
 
-pub(crate) fn hmac_key_from_env_value(value: Option<String>) -> Option<Vec<u8>> {
-    value
-        .filter(|s| !s.trim().is_empty())
-        .map(String::into_bytes)
+pub(crate) fn hmac_key_from_env_value(
+    value: Option<String>,
+) -> Result<Option<AuditHmacKey>, InvalidHmacKey> {
+    value.map(|s| AuditHmacKey::new(s.into_bytes())).transpose()
 }
 #[cfg(test)]
 mod tests {
@@ -181,13 +187,23 @@ mod tests {
 
     #[test]
     fn hmac_key_requires_nonempty_semantic_content() {
-        assert!(hmac_key_from_env_value(None).is_none());
-        assert!(hmac_key_from_env_value(Some(String::new())).is_none());
-        assert!(hmac_key_from_env_value(Some(" \t\n".to_string())).is_none());
-        assert_eq!(
-            hmac_key_from_env_value(Some(" secret ".to_string())).unwrap(),
-            b" secret ".to_vec()
-        );
+        assert!(matches!(hmac_key_from_env_value(None), Ok(None)));
+        assert!(matches!(
+            hmac_key_from_env_value(Some(String::new())),
+            Err(InvalidHmacKey::Empty(_))
+        ));
+        assert!(matches!(
+            hmac_key_from_env_value(Some(" \t\n".to_string())),
+            Err(InvalidHmacKey::Empty(_))
+        ));
+        assert!(matches!(
+            hmac_key_from_env_value(Some("short".to_string())),
+            Err(InvalidHmacKey::TooShort { actual: 5, .. })
+        ));
+        assert!(matches!(
+            hmac_key_from_env_value(Some("0123456789abcdef0123456789abcdef".to_string())),
+            Ok(Some(_))
+        ));
     }
 
     #[test]
@@ -206,17 +222,20 @@ mod tests {
         let _guard = env_lock().lock().unwrap();
         let key = format!("ELASTIK_TEST_STORAGE_CAP_{}", std::process::id());
         std::env::remove_var(&key);
-        assert_eq!(env_optional_usize(&key), None);
+        assert_eq!(env_optional_usize(&key), Ok(None));
         std::env::set_var(&key, "");
-        assert_eq!(env_optional_usize(&key), None);
+        assert_eq!(env_optional_usize(&key), Ok(None));
         std::env::set_var(&key, " \t ");
-        assert_eq!(env_optional_usize(&key), None);
+        assert_eq!(env_optional_usize(&key), Ok(None));
         std::env::set_var(&key, "0");
-        assert_eq!(env_optional_usize(&key), None);
+        assert_eq!(env_optional_usize(&key), Ok(None));
         std::env::set_var(&key, "11");
-        assert_eq!(env_optional_usize(&key), Some(11));
+        assert_eq!(env_optional_usize(&key), Ok(Some(11)));
         std::env::set_var(&key, "10GB");
-        assert!(std::panic::catch_unwind(|| env_optional_usize(&key)).is_err());
+        assert_eq!(
+            env_optional_usize(&key),
+            Err(format!("{key} must be a non-negative integer byte count"))
+        );
         std::env::remove_var(&key);
     }
 

--- a/bin/src/server/http/README.md
+++ b/bin/src/server/http/README.md
@@ -10,10 +10,10 @@ file documents the binary wire surface: startup, HTTP worlds, `/proc/*`,
 ## Quick Start
 
 ```bash
-export ELASTIK_KEY=secret
+export ELASTIK_KEY=0123456789abcdef0123456789abcdef
 export ELASTIK_WRITE_TOKEN=secret
 cargo run --manifest-path bin/Cargo.toml --bin elastik-core
-# elastik-core v8.2.1 on http://127.0.0.1:3105/
+# elastik-core v8.3.0 on http://127.0.0.1:3105/
 
 curl                  http://127.0.0.1:3105/proc/version
 curl -X PUT -H "Authorization: Bearer $ELASTIK_WRITE_TOKEN" \
@@ -32,7 +32,7 @@ Common binary environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `ELASTIK_KEY` | required | HMAC audit-chain key; startup refuses empty or missing keys. |
+| `ELASTIK_KEY` | required | HMAC audit-chain key; startup refuses missing, empty, all-whitespace, or shorter-than-32-byte keys. |
 | `ELASTIK_READ_TOKEN` | unset | Gates reads, `/proc/*`, and `/listen/*`; unset means public reads. |
 | `ELASTIK_WRITE_TOKEN` | unset | Enables ordinary PUT/POST writes in user namespaces such as `home/`. |
 | `ELASTIK_APPROVE_TOKEN` | unset | Enables DELETE and writes in protected namespaces such as `etc/` and `var/log/`. |
@@ -80,7 +80,7 @@ always policy-free capability discovery.
 
 | Endpoint | Methods | Auth | Purpose |
 |----------|---------|------|---------|
-| `/proc/version` | `GET`, `HEAD`, `OPTIONS` | public | Binary version string, e.g. `elastik-core 8.2.1 (rust)`. |
+| `/proc/version` | `GET`, `HEAD`, `OPTIONS` | public | Binary version string, e.g. `elastik-core 8.3.0 (rust)`. |
 | `/proc/worlds` | `GET`, `HEAD`, `OPTIONS` | read-gated | Canonical world list, one `home/foo`-style key per line. |
 | `/proc/du` | `GET`, `HEAD`, `OPTIONS` | read-gated | Per-world byte usage. This is an unpaginated management view. |
 | `/proc/df` | `GET`, `HEAD`, `OPTIONS` | read-gated | Storage and memory quota snapshot plus world count. |

--- a/bin/src/server/mod.rs
+++ b/bin/src/server/mod.rs
@@ -45,7 +45,7 @@ use std::time::Duration;
 #[cfg(not(test))]
 use crate::{
     engine::{Engine, EngineBuilder},
-    engine_types::SecretBytes,
+    engine_types::AuditHmacKey,
 };
 #[cfg(all(not(test), feature = "coap"))]
 use config::{coap_bind_from_env, DEFAULT_COAP_MAX_IN_FLIGHT};
@@ -65,14 +65,19 @@ use config::{
 use http::semantics::{header_allowlist_from_env, header_user_deny_from_env};
 
 #[cfg(not(test))]
-pub(crate) async fn run_from_env() {
+pub(crate) async fn run_from_env() -> Result<(), String> {
     pipeline::init_trace_from_env();
 
     let host = std::env::var("ELASTIK_HOST").unwrap_or_else(|_| "127.0.0.1".into());
-    let port: u16 = std::env::var("ELASTIK_PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(3105);
+    let port: u16 = match std::env::var("ELASTIK_PORT") {
+        Ok(raw) => raw
+            .parse()
+            .map_err(|_| format!("ELASTIK_PORT must be a TCP port number; got {raw:?}"))?,
+        Err(std::env::VarError::NotPresent) => 3105,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err("ELASTIK_PORT must be valid Unicode".into());
+        }
+    };
     #[cfg(feature = "coap")]
     let coap_bind = coap_bind_from_env();
     #[cfg(feature = "mqtt")]
@@ -82,7 +87,7 @@ pub(crate) async fn run_from_env() {
     let data = PathBuf::from(std::env::var("ELASTIK_DATA").unwrap_or_else(|_| "./data".into()));
     let max_world_bytes = env_usize("ELASTIK_MAX_WORLD_BYTES", DEFAULT_MAX_WORLD_BYTES);
     let max_memory_bytes = env_usize("ELASTIK_MAX_MEMORY_BYTES", DEFAULT_MAX_MEMORY_BYTES);
-    let max_storage_bytes = env_optional_usize("ELASTIK_MAX_STORAGE_BYTES");
+    let max_storage_bytes = env_optional_usize("ELASTIK_MAX_STORAGE_BYTES")?;
     let max_listen_connections = env_nonzero_usize(
         "ELASTIK_MAX_LISTEN_CONNECTIONS",
         DEFAULT_MAX_LISTEN_CONNECTIONS,
@@ -119,9 +124,22 @@ pub(crate) async fn run_from_env() {
         "ELASTIK_READ_CACHE_MAX_ENTRIES",
         DEFAULT_READ_CACHE_MAX_ENTRIES,
     );
-    let hmac_key = hmac_key_from_env_value(std::env::var("ELASTIK_KEY").ok()).expect(
-        "ELASTIK_KEY must be a non-empty string; the audit chain has no meaning without it",
-    );
+    let raw_hmac_key = match std::env::var("ELASTIK_KEY") {
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err("ELASTIK_KEY is invalid: value is not valid Unicode".into());
+        }
+    };
+    let hmac_key = match hmac_key_from_env_value(raw_hmac_key) {
+        Ok(Some(key)) => key,
+        Ok(None) => {
+            return Err(
+                "ELASTIK_KEY is required; the audit chain has no meaning without it".into(),
+            );
+        }
+        Err(err) => return Err(format!("ELASTIK_KEY is invalid: {err}")),
+    };
     let tokens = ServerTokens::from_env();
     let persist_header_allowlist = header_allowlist_from_env();
     let persist_header_user_deny = header_user_deny_from_env();
@@ -137,7 +155,7 @@ pub(crate) async fn run_from_env() {
             listen_replay_max,
             read_cache_max_entries,
         },
-    );
+    )?;
     let state = ServerState::new(
         engine.clone(),
         max_world_bytes,
@@ -152,7 +170,9 @@ pub(crate) async fn run_from_env() {
     };
 
     let addr = listen_addr(&host, port);
-    let listener = tokio::net::TcpListener::bind(&addr).await.expect("bind");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|err| format!("bind {addr} failed: {err}"))?;
     let bind_ip = listener
         .local_addr()
         .map(|addr| addr.ip())
@@ -206,8 +226,9 @@ pub(crate) async fn run_from_env() {
     let serve_result = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(engine.clone()))
         .await;
-    serve_result.expect("axum server failed");
+    serve_result.map_err(|err| format!("axum server failed: {err}"))?;
     drop(engine);
+    Ok(())
 }
 
 #[cfg(not(test))]
@@ -245,14 +266,13 @@ impl ServerTokens {
 #[cfg(not(test))]
 fn build_engine_from_env(
     data: PathBuf,
-    hmac_key: Vec<u8>,
+    hmac_key: AuditHmacKey,
     tokens: &ServerTokens,
     limits: EngineLimits,
-) -> Engine {
-    let key = SecretBytes::new(hmac_key).expect("ELASTIK_KEY validated before Engine build");
+) -> Result<Engine, String> {
     let builder = Engine::builder()
         .data_root(data)
-        .key(key)
+        .key(hmac_key)
         .max_world_bytes(limits.max_world_bytes)
         .max_memory_bytes(limits.max_memory_bytes)
         .max_storage_bytes(limits.max_storage_bytes)
@@ -261,7 +281,7 @@ fn build_engine_from_env(
         .read_cache_max_entries(limits.read_cache_max_entries);
     configure_tokens(builder, tokens)
         .build()
-        .unwrap_or_else(|err| panic!("build Engine failed: {err:?}"))
+        .map_err(|err| format!("build Engine failed: {err}"))
 }
 
 #[cfg(not(test))]

--- a/bin/src/server/mqtt/mod.rs
+++ b/bin/src/server/mqtt/mod.rs
@@ -2043,7 +2043,12 @@ mod tests {
         ));
         let mut builder = Engine::builder()
             .data_root(&dir)
-            .key(crate::engine_types::SecretBytes::new(b"test-hmac-key".to_vec()).unwrap())
+            .key(
+                crate::engine_types::AuditHmacKey::try_from_slice(
+                    b"0123456789abcdef0123456789abcdef",
+                )
+                .unwrap(),
+            )
             .write_token(b"write-token".to_vec());
         if read_token {
             builder = builder.read_token(b"read-token".to_vec());

--- a/bin/src/server/mqtt/retained.rs
+++ b/bin/src/server/mqtt/retained.rs
@@ -281,7 +281,7 @@ fn log_replay_error(metrics: &MqttMetrics, err: RetainedReplayError) {
 mod tests {
     use super::super::topic::mqtt_filter_to_route;
     use super::*;
-    use crate::engine_types::{Preconditions, Representation, SecretBytes};
+    use crate::engine_types::{AuditHmacKey, Preconditions, Representation};
 
     #[test]
     fn retained_replay_list_errors_are_counted() {
@@ -454,7 +454,7 @@ mod tests {
         ));
         let engine = Engine::builder()
             .data_root(&dir)
-            .key(SecretBytes::new(b"test-hmac-key".to_vec()).unwrap())
+            .key(AuditHmacKey::try_from_slice(b"0123456789abcdef0123456789abcdef").unwrap())
             .read_token(b"read-token".to_vec())
             .write_token(b"write-token".to_vec())
             .build()

--- a/bin/src/server/test_support.rs
+++ b/bin/src/server/test_support.rs
@@ -6,7 +6,7 @@ use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use crate::{
     defaults::{DEFAULT_MAX_LISTEN_CONNECTIONS, DEFAULT_MAX_WORLD_BYTES},
     engine::Engine,
-    engine_types::{AccessTier, Preconditions, Representation, SecretBytes, ValidatedWorldPath},
+    engine_types::{AccessTier, AuditHmacKey, Preconditions, Representation, ValidatedWorldPath},
     server::{http::semantics::HeaderAllowlist, ServerState},
 };
 
@@ -51,7 +51,7 @@ pub(crate) fn test_engine_for_server_with_read_token(
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .read_token(token)
         .build()
         .expect("test engine should build");
@@ -62,7 +62,7 @@ pub(crate) fn test_engine_for_server_with_auth_tokens(label: &str) -> (Engine, s
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .read_token(b"reader".to_vec())
         .write_token(b"writer".to_vec())
         .approve_token(b"approve".to_vec())
@@ -78,7 +78,7 @@ pub(crate) fn test_engine_for_server_with_storage_quota(
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .max_storage_bytes(Some(max_storage_bytes))
         .build()
         .expect("test engine should build");
@@ -92,7 +92,7 @@ pub(crate) fn test_engine_for_server_with_memory_cap(
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .max_memory_bytes(max_memory_bytes)
         .build()
         .expect("test engine should build");
@@ -106,7 +106,7 @@ pub(crate) fn test_engine_for_server_with_read_cache_max(
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .read_cache_max_entries(max_entries)
         .build()
         .expect("test engine should build");
@@ -120,7 +120,7 @@ pub(crate) fn test_engine_for_server_with_world_cap(
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .max_world_bytes(max_world_bytes)
         .build()
         .expect("test engine should build");
@@ -134,7 +134,7 @@ pub(crate) fn test_engine_for_server_with_listen_slots(
     let dir = test_data_root(label);
     let engine = Engine::builder()
         .data_root(dir.clone())
-        .key(SecretBytes::try_from_slice(b"test-hmac-key").expect("test hmac key"))
+        .key(test_hmac_key())
         .max_listen_connections(max_listen_connections)
         .build()
         .expect("test engine should build");
@@ -172,4 +172,9 @@ pub(crate) async fn write_text_world_for_tests(engine: &Engine, world: &str, bod
 pub(crate) fn world_db_path_for_server_tests(data_root: impl AsRef<Path>, world: &str) -> PathBuf {
     let disk_name = utf8_percent_encode(world, TEST_DISK_ENCODE).to_string();
     data_root.as_ref().join(disk_name).join("universe.db")
+}
+const TEST_HMAC_KEY: &[u8; 32] = b"0123456789abcdef0123456789abcdef";
+
+fn test_hmac_key() -> AuditHmacKey {
+    AuditHmacKey::try_from_slice(TEST_HMAC_KEY).expect("test hmac key")
 }

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "bytes",
  "dashmap",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastik-core"
-version = "8.2.1"
+version = "8.3.0"
 edition = "2021"
 description = "AuditeDB — the db that listens. Powered by the Elastik L5 Engine."
 license = "MIT"

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -7,7 +7,7 @@ use hmac::{Hmac, KeyInit, Mac};
 use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
-use crate::world;
+use crate::{engine_types::AuditHmacKey, world};
 use std::{fmt, path::Path};
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
@@ -18,8 +18,9 @@ const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256
            ORDER BY e.id ASC, h.name ASC, h.value ASC"#;
 pub(crate) const AUDIT_CHAIN_BROKEN_PREFIX: &str = "audit chain broken at event ";
 
-pub struct VerifiedAuditTx<'tx, 'conn> {
+pub struct VerifiedAuditTx<'tx, 'conn, 'key> {
     tx: &'tx Transaction<'conn>,
+    key: &'key AuditHmacKey,
 }
 
 pub type AuditResult<T> = Result<T, AuditError>;
@@ -72,7 +73,7 @@ pub fn append_with_conn_existing(
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
 ) -> AuditResult<String> {
     append_with_conn_verified(
         conn,
@@ -96,7 +97,7 @@ pub fn append_with_conn_genesis(
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
 ) -> AuditResult<String> {
     append_with_conn_verified(
         conn,
@@ -120,7 +121,7 @@ fn append_with_conn_verified(
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
     empty_chain: EmptyChain,
 ) -> AuditResult<String> {
     let tx = conn.transaction()?;
@@ -133,7 +134,6 @@ fn append_with_conn_verified(
         size,
         content_type,
         headers,
-        key,
     )?;
     tx.commit()?;
     Ok(h)
@@ -141,14 +141,13 @@ fn append_with_conn_verified(
 
 #[allow(clippy::too_many_arguments)]
 pub fn append_tx(
-    audit_tx: &VerifiedAuditTx<'_, '_>,
+    audit_tx: &VerifiedAuditTx<'_, '_, '_>,
     event_type: &str,
     target: &str,
     body_sha256: &str,
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
 ) -> rusqlite::Result<String> {
     let tx = audit_tx.tx;
     let canonical = canonical_headers(headers);
@@ -162,7 +161,7 @@ pub fn append_tx(
         .optional()?
         .unwrap_or_default();
     let h = event_hmac(
-        key,
+        audit_tx.key.as_slice(),
         EventHmacInput {
             prev: &prev,
             event_type,
@@ -218,43 +217,43 @@ pub enum VerifyReport {
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
-pub fn verify_all_worlds(data_root: &Path, key: &[u8]) -> AuditResult<()> {
+pub fn verify_all_worlds(data_root: &Path, key: &AuditHmacKey) -> AuditResult<()> {
     for world_name in world::list(data_root)? {
         verify_world(data_root, &world_name, key)?;
     }
     Ok(())
 }
 
-pub fn verify_world(data_root: &Path, world_name: &str, key: &[u8]) -> AuditResult<()> {
+pub fn verify_world(data_root: &Path, world_name: &str, key: &AuditHmacKey) -> AuditResult<()> {
     let Some(c) = world::open_existing(data_root, world_name)? else {
         return Ok(());
     };
     require_intact(verify_connection(&c, key)?)
 }
 
-pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn>(
+pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
-    key: &[u8],
-) -> AuditResult<VerifiedAuditTx<'tx, 'conn>> {
+    key: &'key AuditHmacKey,
+) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
     verify_appendable_tx(tx, key, EmptyChain::Reject)
 }
 
-pub(crate) fn verify_appendable_tx_genesis_checked<'tx, 'conn>(
+pub(crate) fn verify_appendable_tx_genesis_checked<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
-    key: &[u8],
-) -> AuditResult<VerifiedAuditTx<'tx, 'conn>> {
+    key: &'key AuditHmacKey,
+) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
     verify_appendable_tx(tx, key, EmptyChain::Allow)
 }
 
-fn verify_appendable_tx<'tx, 'conn>(
+fn verify_appendable_tx<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
-    key: &[u8],
+    key: &'key AuditHmacKey,
     empty_chain: EmptyChain,
-) -> AuditResult<VerifiedAuditTx<'tx, 'conn>> {
+) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
     let mut stmt = tx.prepare(AUDIT_SELECT)?;
     let allow_empty = matches!(empty_chain, EmptyChain::Allow);
-    require_intact(verify_statement(&mut stmt, key, allow_empty)?)?;
-    Ok(VerifiedAuditTx { tx })
+    require_intact(verify_statement(&mut stmt, key.as_slice(), allow_empty)?)?;
+    Ok(VerifiedAuditTx { tx, key })
 }
 
 struct EventRow {
@@ -289,14 +288,14 @@ struct EventHmacInput<'a> {
 /// usual SlotState write guard.
 pub fn verify_chain_via_conn(
     tracked: &mut crate::read_cache::TrackedReadConnection,
-    key: &[u8],
+    key: &AuditHmacKey,
 ) -> rusqlite::Result<VerifyReport> {
     verify_connection(tracked.as_mut_conn(), key)
 }
 
-fn verify_connection(c: &Connection, key: &[u8]) -> rusqlite::Result<VerifyReport> {
+fn verify_connection(c: &Connection, key: &AuditHmacKey) -> rusqlite::Result<VerifyReport> {
     let mut stmt = c.prepare(AUDIT_SELECT)?;
-    verify_statement(&mut stmt, key, false)
+    verify_statement(&mut stmt, key.as_slice(), false)
 }
 
 fn verify_statement(
@@ -532,21 +531,16 @@ mod tests {
         c
     }
 
+    fn test_key() -> AuditHmacKey {
+        AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
     fn hmac_for(event_type: &str, target: &str) -> String {
         let c = test_connection();
         let tx = c.unchecked_transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
-        append_tx(
-            &audit_tx,
-            event_type,
-            target,
-            "abc",
-            3,
-            "text/plain",
-            &[],
-            b"key",
-        )
-        .unwrap()
+        let key = test_key();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        append_tx(&audit_tx, event_type, target, "abc", 3, "text/plain", &[]).unwrap()
     }
 
     #[test]
@@ -577,7 +571,7 @@ mod tests {
             b"hello",
             "text/plain; charset=utf-8",
             &headers,
-            core.hmac_key.as_slice(),
+            &core.hmac_key,
         )
         .unwrap();
 
@@ -611,7 +605,8 @@ mod tests {
     fn verify_connection_accepts_intact_chain() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
+        let key = test_key();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
         let h1 = append_tx(
             &audit_tx,
             "put",
@@ -620,23 +615,12 @@ mod tests {
             3,
             "text/plain",
             &[("x-meta-author".to_owned(), "ranger".to_owned())],
-            b"key",
         )
         .unwrap();
-        let h2 = append_tx(
-            &audit_tx,
-            "append",
-            "home/a",
-            "def",
-            6,
-            "text/plain",
-            &[],
-            b"key",
-        )
-        .unwrap();
+        let h2 = append_tx(&audit_tx, "append", "home/a", "def", 6, "text/plain", &[]).unwrap();
         tx.commit().unwrap();
 
-        let report = verify_connection(&c, b"key").unwrap();
+        let report = verify_connection(&c, &key).unwrap();
         assert_eq!(
             report,
             VerifyReport::Valid(VerifyOk {
@@ -678,7 +662,8 @@ mod tests {
         .unwrap();
 
         let tx = c.transaction().unwrap();
-        let err = match verify_appendable_tx_genesis_checked(&tx, b"key") {
+        let key = test_key();
+        let err = match verify_appendable_tx_genesis_checked(&tx, &key) {
             Ok(_) => panic!("corrupt latest hmac must not be treated as an empty chain"),
             Err(e) => e,
         };
@@ -698,25 +683,17 @@ mod tests {
         let mut c = test_connection();
         {
             let tx = c.transaction().unwrap();
-            let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
-            append_tx(
-                &audit_tx,
-                "put",
-                "home/a",
-                "abc",
-                3,
-                "text/plain",
-                &[],
-                b"key",
-            )
-            .unwrap();
+            let key = test_key();
+            let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+            append_tx(&audit_tx, "put", "home/a", "abc", 3, "text/plain", &[]).unwrap();
             tx.commit().unwrap();
         }
         c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
             .unwrap();
 
         let tx = c.transaction().unwrap();
-        let err = match verify_appendable_tx_existing_checked(&tx, b"key") {
+        let key = test_key();
+        let err = match verify_appendable_tx_existing_checked(&tx, &key) {
             Ok(_) => panic!("tampered audit chain must not be appendable"),
             Err(err) => err,
         };
@@ -735,23 +712,14 @@ mod tests {
     fn verify_connection_rejects_tampered_event_hmac() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
-        append_tx(
-            &audit_tx,
-            "put",
-            "home/a",
-            "abc",
-            3,
-            "text/plain",
-            &[],
-            b"key",
-        )
-        .unwrap();
+        let key = test_key();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        append_tx(&audit_tx, "put", "home/a", "abc", 3, "text/plain", &[]).unwrap();
         tx.commit().unwrap();
         c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
             .unwrap();
 
-        let report = verify_connection(&c, b"key").unwrap();
+        let report = verify_connection(&c, &key).unwrap();
         assert!(matches!(
             report,
             VerifyReport::Broken(VerifyBreak {
@@ -767,14 +735,15 @@ mod tests {
         let root =
             std::env::temp_dir().join(format!("elastik-audit-startup-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
-        world::write_with_audit(&root, "home/a", b"abc", "text/plain", &[], b"key").unwrap();
+        let key = test_key();
+        world::write_with_audit(&root, "home/a", b"abc", "text/plain", &[], &key).unwrap();
         {
             let c = Connection::open(world::world_db(&root, "home/a")).unwrap();
             c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
                 .unwrap();
         }
 
-        assert!(verify_all_worlds(&root, b"key").is_err());
+        assert!(verify_all_worlds(&root, &key).is_err());
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -782,7 +751,8 @@ mod tests {
     fn verify_connection_rejects_tampered_event_headers() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, b"key").unwrap();
+        let key = test_key();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
         append_tx(
             &audit_tx,
             "put",
@@ -791,7 +761,6 @@ mod tests {
             3,
             "text/plain",
             &[("x-meta-author".to_owned(), "ranger".to_owned())],
-            b"key",
         )
         .unwrap();
         tx.commit().unwrap();
@@ -801,7 +770,7 @@ mod tests {
         )
         .unwrap();
 
-        let report = verify_connection(&c, b"key").unwrap();
+        let report = verify_connection(&c, &key).unwrap();
         assert!(matches!(
             report,
             VerifyReport::Broken(VerifyBreak {

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use crate::{
     auth, can_delete,
     engine::EngineError,
-    engine_types::{ChangeVerb, Preconditions, SecretBytes, ValidatedWorldPath},
+    engine_types::{ChangeVerb, Preconditions, ValidatedWorldPath},
     etag, store, world, AuditAppendJob, AuthGate, BlockingSqliteError, Core, StorageFailureClass,
 };
 
@@ -209,7 +209,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     Ok(())
 }
 
-fn ledger_hmac_key(core: &Core) -> SecretBytes {
+fn ledger_hmac_key(core: &Core) -> crate::engine_types::AuditHmacKey {
     core.hmac_key.clone_secret()
 }
 

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -27,7 +27,7 @@ use crate::{
         DEFAULT_LISTEN_REPLAY_MAX, DEFAULT_MAX_LISTEN_CONNECTIONS, DEFAULT_MAX_MEMORY_BYTES,
         DEFAULT_MAX_WORLD_BYTES, DEFAULT_READ_CACHE_MAX_ENTRIES,
     },
-    engine_types::{AccessTier, SecretBytes},
+    engine_types::{AccessTier, AuditHmacKey},
     read_cache::ReadCache,
     state::{new_event_counter, Core},
     storage_class, store, world,
@@ -66,7 +66,7 @@ pub struct ShutdownToken {
 /// defaults without breaking callers.
 pub struct EngineBuilder {
     data_root: PathBuf,
-    key: Option<SecretBytes>,
+    key: Option<AuditHmacKey>,
     tokens: auth::Tokens,
     max_world_bytes: usize,
     max_memory_bytes: usize,
@@ -111,6 +111,35 @@ pub enum EngineBuildError {
         detail: String,
     },
 }
+
+impl fmt::Display for EngineBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DataRootIo(err) => write!(f, "data root IO error: {err}"),
+            Self::DataRootLockHeld { path, holder_pid } => match holder_pid {
+                Some(pid) => write!(
+                    f,
+                    "data root writer lock is held (last writer: PID {pid}): {}",
+                    path.display()
+                ),
+                None => write!(f, "data root writer lock is held: {}", path.display()),
+            },
+            Self::HmacKeyMissing => f.write_str("audit-chain HMAC key is missing"),
+            Self::AuditChainCorrupted { world, detail } => {
+                write!(f, "audit chain verification failed for {world}: {detail}")
+            }
+            Self::Storage {
+                sqlite_code,
+                detail,
+            } => match sqlite_code {
+                Some(code) => write!(f, "startup storage error (SQLite code {code}): {detail}"),
+                None => write!(f, "startup storage error: {detail}"),
+            },
+        }
+    }
+}
+
+impl std::error::Error for EngineBuildError {}
 
 /// Runtime operation errors reported by the Engine facade.
 ///
@@ -197,7 +226,11 @@ impl EngineBuilder {
     }
 
     /// Sets the HMAC key that protects the audit chain. Required.
-    pub fn key(mut self, key: SecretBytes) -> Self {
+    ///
+    /// The key must already be an [`AuditHmacKey`], which proves the input was
+    /// non-empty, not all whitespace, and at least
+    /// [`crate::MIN_HMAC_KEY_BYTES`] long.
+    pub fn key(mut self, key: AuditHmacKey) -> Self {
         self.key = Some(key);
         self
     }
@@ -296,7 +329,7 @@ impl EngineBuilder {
             .map_err(|err| map_writer_lock_error(&self.data_root, err))?;
         let hmac_key = self.key.ok_or(EngineBuildError::HmacKeyMissing)?;
 
-        verify_all_worlds_with_names(&self.data_root, hmac_key.as_slice())?;
+        verify_all_worlds_with_names(&self.data_root, &hmac_key)?;
         let durable_sizes = world::sizes(&self.data_root).map_err(|err| {
             match storage_class::classify_storage_failure(&err) {
                 storage_class::StorageFailureClass::Transient => {
@@ -465,7 +498,7 @@ fn map_writer_lock_error(
 
 fn verify_all_worlds_with_names(
     data_root: &std::path::Path,
-    key: &[u8],
+    key: &AuditHmacKey,
 ) -> Result<(), EngineBuildError> {
     let worlds = world::list(data_root).map_err(|err| EngineBuildError::Storage {
         sqlite_code: sqlite_code(&err),
@@ -509,6 +542,7 @@ fn verify_all_worlds_with_names(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine_types::SecretBytes;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_root(name: &str) -> PathBuf {
@@ -539,7 +573,7 @@ mod tests {
         let root = temp_root("verify-token");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .read_token(b"reader".to_vec())
             .write_token(b"writer".to_vec())
             .approve_token(b"approve".to_vec())
@@ -561,7 +595,7 @@ mod tests {
         let root = temp_root("token-whitespace");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .read_token(b" \t\n".to_vec())
             .write_token(Vec::new())
             .approve_token("\u{2003}\n".as_bytes().to_vec())
@@ -583,7 +617,7 @@ mod tests {
         let root = temp_root("zero-limits");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .max_storage_bytes(Some(0))
             .max_listen_connections(0)
             .listen_replay_max(0)
@@ -614,7 +648,7 @@ mod tests {
         let root = temp_root("shutdown-idempotent");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .build()
             .unwrap();
         let mut shutdown = engine.inner.core.shutdown.clone();
@@ -636,13 +670,13 @@ mod tests {
         let root = temp_root("writer-lock");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .build()
             .unwrap();
 
         let second = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .build();
 
         match second {
@@ -660,7 +694,7 @@ mod tests {
     #[test]
     fn build_verifies_audit_chains_before_returning_engine() {
         let root = temp_root("audit-verify");
-        let key = b"key".to_vec();
+        let key = AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap();
         let write_result = world::write_with_audit_checked(
             &root,
             "home/audit",
@@ -680,10 +714,7 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let result = Engine::builder()
-            .data_root(root.clone())
-            .key(SecretBytes::new(key).unwrap())
-            .build();
+        let result = Engine::builder().data_root(root.clone()).key(key).build();
 
         assert!(matches!(
             result,
@@ -696,7 +727,7 @@ mod tests {
     #[test]
     fn build_classifies_non_chain_verify_failures_as_storage_errors() {
         let root = temp_root("audit-storage-error");
-        let key = b"key".to_vec();
+        let key = AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap();
         let write_result = world::write_with_audit_checked(
             &root,
             "home/schema",
@@ -712,10 +743,7 @@ mod tests {
         conn.execute("DROP TABLE events", []).unwrap();
         drop(conn);
 
-        let result = Engine::builder()
-            .data_root(root.clone())
-            .key(SecretBytes::new(key).unwrap())
-            .build();
+        let result = Engine::builder().data_root(root.clone()).key(key).build();
 
         match result {
             Err(EngineBuildError::Storage {

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -646,7 +646,7 @@ mod tests {
         engine::{Engine, EngineError},
         engine_ops::EngineOps,
         engine_types::{
-            AccessTier, Preconditions, Representation, SecretBytes, ValidatedWorldPath,
+            AccessTier, AuditHmacKey, Preconditions, Representation, ValidatedWorldPath,
         },
         AuthGate,
     };
@@ -695,7 +695,7 @@ mod tests {
         let root = temp_root("snapshots");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .read_token(b"reader".to_vec())
             .max_storage_bytes(Some(64))
             .build()

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -198,10 +198,13 @@ impl Engine {
     ///
     /// This is an async API. Awaiting it runs the complete ordered write
     /// transition: auth proof, per-world write lock, precondition check,
-    /// storage update, audit-chain append, and subscriber notification.
+    /// storage update, audit-chain append for durable worlds, and subscriber
+    /// notification.
     ///
     /// Creates the world if it does not exist; otherwise overwrites the
-    /// body, content type, and headers, then advances the audit chain.
+    /// body, content type, and headers. Durable worlds advance the audit chain;
+    /// memory worlds update only their transient body, metadata, and SHA-256
+    /// ETag.
     ///
     /// # Errors
     /// - [`EngineError::Auth`] if `tier` is below the namespace's write
@@ -233,7 +236,7 @@ impl Engine {
             .await
     }
 
-    /// Appends bytes to a world's body and advances the audit chain.
+    /// Appends bytes to a world's body.
     ///
     /// This is an async API with the same ordered write boundary as
     /// [`Engine::replace`]. It appends to the existing body instead of replacing
@@ -243,7 +246,9 @@ impl Engine {
     /// create the initial representation, then append to it.
     ///
     /// Same auth requirements and error variants as [`Engine::replace`].
-    /// The world's content type and metadata headers are unchanged.
+    /// The world's content type and metadata headers are unchanged. Durable
+    /// worlds advance the audit chain; memory worlds update only their
+    /// transient body and SHA-256 ETag.
     ///
     /// # Errors
     /// Same as [`Engine::replace`], plus [`EngineError::NotFound`] if the
@@ -602,7 +607,7 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
-    use crate::engine_types::{ChangeVerb, SecretBytes};
+    use crate::engine_types::{AuditHmacKey, ChangeVerb};
 
     fn temp_root(name: &str) -> PathBuf {
         let nonce = SystemTime::now()
@@ -621,7 +626,7 @@ mod tests {
         let root = temp_root(name);
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .max_listen_connections(1)
             .build()
             .unwrap();
@@ -716,7 +721,7 @@ mod tests {
         let root = temp_root("subscribe");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .read_token(b"reader".to_vec())
             .build()
             .unwrap();
@@ -772,7 +777,7 @@ mod tests {
         let root = temp_root("subscribe-auth-slot");
         let engine = Engine::builder()
             .data_root(root.clone())
-            .key(SecretBytes::try_from_slice(b"key").unwrap())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
             .read_token(b"reader".to_vec())
             .max_listen_connections(1)
             .build()

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -12,7 +12,15 @@ use tokio::sync::{broadcast, watch, OwnedSemaphorePermit};
 
 use crate::auth::{self, NonEmptyBytes};
 
-/// HMAC key material for the audit chain.
+/// Minimum accepted audit-chain HMAC key length, in bytes.
+///
+/// RFC 2104 section 3 strongly discourages HMAC keys shorter than L, the hash
+/// function output length. SHA-256 outputs 32 bytes, so 32 bytes is the
+/// minimum. Shorter keys are rejected before a [`crate::Engine`] can be built,
+/// so weak audit-chain keys are not representable as [`AuditHmacKey`].
+pub const MIN_HMAC_KEY_BYTES: usize = 32;
+
+/// Secret byte material with zeroing-on-drop behaviour.
 ///
 /// Empty and all-whitespace keys are rejected. The key intentionally has no
 /// public `Debug`, `Display`, or `AsRef<[u8]>` implementation.
@@ -20,10 +28,34 @@ pub struct SecretBytes {
     bytes: NonEmptyBytes,
 }
 
-/// Returned when a secret key constructor receives an empty or all-whitespace
-/// byte string.
+/// HMAC key material strong enough for the audit chain.
+///
+/// This is the proof type accepted by [`crate::EngineBuilder::key`]. Callers
+/// can only construct it through checked constructors, so a short HMAC key
+/// cannot enter the Engine by accident.
+pub struct AuditHmacKey {
+    secret: SecretBytes,
+}
+
+/// Returned when a secret constructor receives an empty or all-whitespace byte
+/// string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EmptyKeyError;
+
+/// Returned when audit-chain HMAC key material is empty, whitespace, or too short.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InvalidHmacKey {
+    /// The input was empty or all whitespace.
+    Empty(EmptyKeyError),
+    /// The input was shorter than [`MIN_HMAC_KEY_BYTES`].
+    TooShort {
+        /// Minimum accepted length in bytes.
+        min: usize,
+        /// Actual input length in bytes.
+        actual: usize,
+    },
+}
 
 /// Canonical world key that passed Engine path validation.
 ///
@@ -300,7 +332,7 @@ pub enum SubscriptionRecvError {
 }
 
 impl SecretBytes {
-    /// Wraps owned bytes as an HMAC secret.
+    /// Wraps owned bytes as secret material.
     ///
     /// # Errors
     /// Returns [`EmptyKeyError`] if the byte slice is empty or all whitespace.
@@ -310,7 +342,7 @@ impl SecretBytes {
             .ok_or(EmptyKeyError)
     }
 
-    /// Copies the slice and wraps it as an HMAC secret.
+    /// Copies the slice and wraps it as secret material.
     ///
     /// # Errors
     /// Returns [`EmptyKeyError`] if the slice is empty or all whitespace.
@@ -327,6 +359,46 @@ impl SecretBytes {
     pub(crate) fn clone_secret(&self) -> Self {
         Self {
             bytes: self.bytes.clone(),
+        }
+    }
+}
+
+impl AuditHmacKey {
+    /// Wraps owned bytes as an audit-chain HMAC key.
+    ///
+    /// # Errors
+    /// Returns [`InvalidHmacKey`] if the byte slice is empty, all whitespace,
+    /// or shorter than [`MIN_HMAC_KEY_BYTES`].
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Result<Self, InvalidHmacKey> {
+        let secret = SecretBytes::new(bytes).map_err(InvalidHmacKey::Empty)?;
+        let actual = secret.as_slice().len();
+        if actual < MIN_HMAC_KEY_BYTES {
+            return Err(InvalidHmacKey::TooShort {
+                min: MIN_HMAC_KEY_BYTES,
+                actual,
+            });
+        }
+        Ok(Self { secret })
+    }
+
+    /// Copies the slice and wraps it as an audit-chain HMAC key.
+    ///
+    /// # Errors
+    /// Returns [`InvalidHmacKey`] if the slice is empty, all whitespace, or
+    /// shorter than [`MIN_HMAC_KEY_BYTES`].
+    pub fn try_from_slice(bytes: &[u8]) -> Result<Self, InvalidHmacKey> {
+        Self::new(bytes.to_vec())
+    }
+
+    /// Borrows the key bytes for immediate cryptographic use.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.secret.as_slice()
+    }
+
+    /// Creates an owned key copy for `'static` blocking jobs.
+    pub(crate) fn clone_secret(&self) -> Self {
+        Self {
+            secret: self.secret.clone_secret(),
         }
     }
 }
@@ -620,10 +692,60 @@ impl fmt::Display for EmptyKeyError {
 
 impl std::error::Error for EmptyKeyError {}
 
+impl fmt::Display for InvalidHmacKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty(err) => err.fmt(f),
+            Self::TooShort { min, actual } => {
+                write!(f, "HMAC key must be at least {min} bytes; got {actual}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for InvalidHmacKey {}
+
 #[cfg(test)]
 mod tests {
-    use super::{EtagMatcher, Preconditions, Representation, SubscribePattern, ValidatedWorldPath};
+    use super::{
+        AuditHmacKey, EtagMatcher, InvalidHmacKey, Preconditions, Representation, SecretBytes,
+        SubscribePattern, ValidatedWorldPath, MIN_HMAC_KEY_BYTES,
+    };
     use bytes::Bytes;
+
+    #[test]
+    fn audit_hmac_key_rejects_empty_whitespace_and_short_keys() {
+        assert!(matches!(
+            AuditHmacKey::try_from_slice(b""),
+            Err(InvalidHmacKey::Empty(_))
+        ));
+        assert!(matches!(
+            AuditHmacKey::try_from_slice(b" \t\r\n"),
+            Err(InvalidHmacKey::Empty(_))
+        ));
+        match AuditHmacKey::try_from_slice(b"short") {
+            Err(err) => assert_eq!(
+                err,
+                InvalidHmacKey::TooShort {
+                    min: MIN_HMAC_KEY_BYTES,
+                    actual: 5,
+                }
+            ),
+            Ok(_) => panic!("short HMAC key should be rejected"),
+        }
+        assert!(matches!(
+            AuditHmacKey::try_from_slice(b"0123456789abcdef0123456789abcde"),
+            Err(InvalidHmacKey::TooShort {
+                min: MIN_HMAC_KEY_BYTES,
+                actual: 31,
+            })
+        ));
+        assert!(AuditHmacKey::try_from_slice(b"0123456789abcdef0123456789abcdef").is_ok());
+
+        // SecretBytes remains a generic zeroing container; it is not proof
+        // that bytes are strong enough for the audit-chain HMAC key.
+        assert!(SecretBytes::try_from_slice(b"short").is_ok());
+    }
 
     #[test]
     fn validated_world_path_accepts_canonical_namespaced_worlds() {

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -25,7 +25,7 @@ use std::sync::Mutex as StdMutex;
 use rusqlite::Connection;
 
 use crate::audit;
-use crate::engine_types::SecretBytes;
+use crate::engine_types::AuditHmacKey;
 use crate::world;
 
 /// One audit append's input. Owns its strings/buffers because the
@@ -38,7 +38,7 @@ pub(crate) struct AuditAppendJob {
     pub(crate) size: i64,
     pub(crate) content_type: String,
     pub(crate) headers: Vec<(String, String)>,
-    pub(crate) key: SecretBytes,
+    pub(crate) key: AuditHmacKey,
 }
 
 /// Result of an audit append run inside `spawn_blocking`. Shared
@@ -113,7 +113,7 @@ impl LedgerWriter {
             job.size,
             &job.content_type,
             &job.headers,
-            job.key.as_slice(),
+            &job.key,
         )
         .map_err(BlockingSqliteError::Audit)
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,13 +47,13 @@
 //! # #[cfg(feature = "unstable-engine")]
 //! # async fn run() {
 //! use elastik_core::{
-//!     AccessTier, Engine, Preconditions, Representation, SecretBytes, ValidatedWorldPath,
+//!     AccessTier, AuditHmacKey, Engine, Preconditions, Representation, ValidatedWorldPath,
 //! };
 //! use bytes::Bytes;
 //!
 //! let engine = Engine::builder()
 //!     .data_root("./data")
-//!     .key(SecretBytes::new(b"shared-hmac-secret".to_vec()).expect("hmac key"))
+//!     .key(AuditHmacKey::new(b"0123456789abcdef0123456789abcdef".to_vec()).expect("hmac key"))
 //!     .build()
 //!     .expect("engine builds");
 //!
@@ -131,9 +131,9 @@
 //!   without per-call configuration.
 //! - **Versions everything.** Every successful write returns an ETag; reads,
 //!   replaces, and appends honour `Preconditions::if_match` / `if_none_match`.
-//! - **Audits everything.** HMAC-chained ledger; `Engine::verify_audit`
-//!   returns a typed [`AuditVerify`] result and refuses to start when an
-//!   existing chain is corrupted.
+//! - **Audits durable writes.** Durable worlds append to an HMAC-chained
+//!   ledger; `Engine::verify_audit` returns a typed [`AuditVerify`] result and
+//!   refuses to start when an existing chain is corrupted.
 //! - **Authenticates everything.** [`AccessTier`] (Anon / Read / Write /
 //!   Approve) plus token-bytes verification via [`Engine::verify_token`].
 //! - **Subscribes to changes.** [`Engine::subscribe`] returns an
@@ -209,9 +209,10 @@ pub use engine_introspection::{
 pub use engine_trace::{DeleteMetadata, EngineDeleteTraceHooks, EngineWriteTraceHooks};
 #[cfg(feature = "unstable-engine")]
 pub use engine_types::{
-    parse_etag_matchers, AccessTier, ChangeEvent, ChangeVerb, EmptyKeyError, EngineSubscription,
-    EtagMatcher, InvalidWorldPath, Preconditions, ReadResult, Representation, SecretBytes,
-    SubscribePattern, SubscriptionRecvError, ValidatedWorldPath, WriteKind, WriteResult,
+    parse_etag_matchers, AccessTier, AuditHmacKey, ChangeEvent, ChangeVerb, EmptyKeyError,
+    EngineSubscription, EtagMatcher, InvalidHmacKey, InvalidWorldPath, Preconditions, ReadResult,
+    Representation, SecretBytes, SubscribePattern, SubscriptionRecvError, ValidatedWorldPath,
+    WriteKind, WriteResult, MIN_HMAC_KEY_BYTES,
 };
 #[cfg(feature = "unstable-engine")]
 pub use path::{validate_world_name, NAMESPACE_PREFIXES};

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -441,9 +441,9 @@ impl ReadCache {
         &self,
         data: &std::path::Path,
         world: &str,
-        key: &[u8],
+        key: &crate::engine_types::AuditHmacKey,
     ) -> rusqlite::Result<Option<crate::audit::VerifyReport>> {
-        let key = key.to_vec();
+        let key = key.clone_secret();
         self.with_tracked_conn(data, world, move |conn| {
             crate::audit::verify_chain_via_conn(conn, &key)
         })
@@ -786,6 +786,11 @@ impl ReadCache {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    fn test_key() -> crate::engine_types::AuditHmacKey {
+        crate::engine_types::AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY)
+            .unwrap()
+    }
 
     fn scratch_dir(label: &str) -> PathBuf {
         let mut d = std::env::temp_dir();
@@ -1353,7 +1358,7 @@ mod tests {
             b"hello",
             "text/plain",
             &[],
-            b"key",
+            &test_key(),
             None,
         ) {
             Ok(_) => {}
@@ -1363,7 +1368,8 @@ mod tests {
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
 
         // Phase 3 lazy-init: first verify warms the cache.
-        let r1 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        let key = test_key();
+        let r1 = cache.cached_verify_chain(&dir, world, &key).unwrap();
         assert!(matches!(r1, Some(crate::audit::VerifyReport::Valid(_))));
         assert!(
             cache.read_conns.get(world).is_some(),
@@ -1373,18 +1379,18 @@ mod tests {
         );
 
         // Phase 1 cache hit: second verify reuses the cached slot.
-        let r2 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        let r2 = cache.cached_verify_chain(&dir, world, &key).unwrap();
         assert!(matches!(r2, Some(crate::audit::VerifyReport::Valid(_))));
 
         // Tombstone short-circuits verify (delete intent).
         cache.install_tombstone_blocking(world);
-        let r3 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        let r3 = cache.cached_verify_chain(&dir, world, &key).unwrap();
         assert!(r3.is_none());
 
         // After clear_tombstone the next verify re-opens through
         // Phase 3 lazy-init.
         cache.clear_tombstone(world);
-        let r4 = cache.cached_verify_chain(&dir, world, b"key").unwrap();
+        let r4 = cache.cached_verify_chain(&dir, world, &key).unwrap();
         assert!(matches!(r4, Some(crate::audit::VerifyReport::Valid(_))));
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::AtomicU64;
 use dashmap::DashMap;
 use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 
-use crate::engine_types::{SecretBytes, ValidatedWorldPath};
+use crate::engine_types::{AuditHmacKey, ValidatedWorldPath};
 use crate::ledger::LedgerWriter;
 pub(crate) use crate::ledger::{AuditAppendJob, BlockingSqliteError};
 use crate::read_cache::ReadCache;
@@ -76,7 +76,7 @@ pub(crate) struct StorageReservationError {
 pub(crate) struct Core {
     pub(crate) data: PathBuf,
     pub(crate) tokens: auth::Tokens,
-    pub(crate) hmac_key: SecretBytes,
+    pub(crate) hmac_key: AuditHmacKey,
     pub(crate) mem: Arc<store::MemoryStore>,
     pub(crate) max_world_bytes: usize,
     pub(crate) max_memory_bytes: usize,
@@ -221,7 +221,7 @@ impl Core {
             "cached_verify_chain only applies to durable worlds"
         );
         self.read_cache
-            .cached_verify_chain(&self.data, world, self.hmac_key.as_slice())
+            .cached_verify_chain(&self.data, world, &self.hmac_key)
     }
 
     /// Test-only fixture: seed a world directly without going through
@@ -249,7 +249,7 @@ impl Core {
                 body,
                 content_type,
                 headers,
-                self.hmac_key.as_slice(),
+                &self.hmac_key,
             )?;
             let prev = current_len.unwrap_or(0);
             let _ = self.storage_body_bytes.fetch_update(
@@ -387,14 +387,14 @@ impl Core {
 
 #[cfg(test)]
 mod tests {
-    use crate::engine_types::SecretBytes;
+    use crate::engine_types::AuditHmacKey;
 
     #[test]
-    fn core_hmac_key_is_stored_as_secret_bytes() {
+    fn core_hmac_key_is_stored_as_audit_hmac_key() {
         let (core, dir) = crate::test_support::test_core("core-secret-key-type");
 
-        fn assert_secret_bytes(_: &SecretBytes) {}
-        assert_secret_bytes(&core.hmac_key);
+        fn assert_audit_hmac_key(_: &AuditHmacKey) {}
+        assert_audit_hmac_key(&core.hmac_key);
 
         drop(core);
         std::fs::remove_dir_all(dir).ok();

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -345,7 +345,7 @@ mod tests {
             b"final",
             "text/plain; charset=utf-8",
             &[],
-            core.hmac_key.as_slice(),
+            &core.hmac_key,
         )
         .unwrap();
 

--- a/core/src/test_support.rs
+++ b/core/src/test_support.rs
@@ -12,9 +12,11 @@ use crate::{
         DEFAULT_LISTEN_REPLAY_MAX, DEFAULT_MAX_LISTEN_CONNECTIONS, DEFAULT_MAX_MEMORY_BYTES,
         DEFAULT_MAX_WORLD_BYTES,
     },
-    engine_types::SecretBytes,
+    engine_types::AuditHmacKey,
     store, Core,
 };
+
+pub(crate) const TEST_HMAC_KEY: &[u8; 32] = b"0123456789abcdef0123456789abcdef";
 
 pub(crate) fn test_core(label: &str) -> (Core, PathBuf) {
     test_core_with_read_cache_max(label, crate::read_cache::DEFAULT_READ_CACHE_MAX_ENTRIES)
@@ -44,7 +46,7 @@ pub(crate) fn test_core_with_read_cache_max(
                     write: None,
                     approve: None,
                 },
-                hmac_key: SecretBytes::try_from_slice(b"test-key").unwrap(),
+                hmac_key: AuditHmacKey::try_from_slice(TEST_HMAC_KEY).unwrap(),
                 mem: Arc::new(store::MemoryStore::new()),
                 max_world_bytes: DEFAULT_MAX_WORLD_BYTES,
                 max_memory_bytes: DEFAULT_MAX_MEMORY_BYTES,

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -25,7 +25,7 @@
 //! is the historical per-write view. The event chain stores structured
 //! audit facts, never JSON blobs.
 
-use crate::audit;
+use crate::{audit, engine_types::AuditHmacKey};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rusqlite::{ffi, params, Connection, OpenFlags, OptionalExtension, Transaction};
 use sha2::{Digest, Sha256};
@@ -371,7 +371,7 @@ pub fn write_with_audit(
     body: &[u8],
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
 ) -> Result<String, WriteAuditError> {
     write_with_audit_checked(data_root, world, body, content_type, headers, key, None)
         .map(|result| result.hmac)
@@ -383,7 +383,7 @@ pub fn write_with_audit_checked(
     body: &[u8],
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
     quota: Option<(usize, usize)>,
 ) -> Result<WriteAuditResult, WriteAuditError> {
     let existed = world_db(data_root, world).exists();
@@ -439,7 +439,6 @@ pub fn write_with_audit_checked(
         body.len() as i64,
         content_type,
         headers,
-        key,
     )?;
     tx.commit()?;
     Ok(WriteAuditResult {
@@ -450,16 +449,12 @@ pub fn write_with_audit_checked(
 }
 
 /// Append bytes to an existing world's body without entering the HMAC
-/// chain. Production appends go through `append_with_audit`; this
-/// raw form is unused after the lock refactor and is preserved with
-/// `#[allow(dead_code)]` against future direct callers (e.g. log
-/// rotation tooling). Returns Ok(None) if the world does not exist.
+/// chain. Test-only schema-corruption probes use this to make sure raw
+/// SQLite body errors are still detected; production durable appends must
+/// go through `append_with_audit`.
+#[cfg(test)]
 #[allow(dead_code)]
-pub fn append(
-    data_root: &Path,
-    world: &str,
-    body: &[u8],
-) -> rusqlite::Result<Option<AppendResult>> {
+fn append(data_root: &Path, world: &str, body: &[u8]) -> rusqlite::Result<Option<AppendResult>> {
     let path = world_db(data_root, world);
     if !path.exists() {
         return Ok(None);
@@ -490,7 +485,7 @@ pub fn append_with_audit(
     body: &[u8],
     content_type: &str,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
 ) -> Result<Option<(AppendResult, String)>, WriteAuditError> {
     let path = world_db(data_root, world);
     if !path.exists() {
@@ -520,7 +515,6 @@ pub fn append_with_audit(
         size_after as i64,
         content_type,
         headers,
-        key,
     )?;
     tx.commit()?;
     Ok(Some((
@@ -531,11 +525,11 @@ pub fn append_with_audit(
     )))
 }
 
-fn verify_appendable_world_tx<'tx, 'conn>(
+fn verify_appendable_world_tx<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
-    key: &[u8],
+    key: &'key AuditHmacKey,
     existed_before_open: bool,
-) -> Result<audit::VerifiedAuditTx<'tx, 'conn>, WriteAuditError> {
+) -> Result<audit::VerifiedAuditTx<'tx, 'conn, 'key>, WriteAuditError> {
     if !existed_before_open || is_empty_bootstrap_tx(tx)? {
         Ok(audit::verify_appendable_tx_genesis_checked(tx, key)?)
     } else {
@@ -684,6 +678,10 @@ fn list_matching_bounded(
 mod tests {
     use super::*;
 
+    fn test_key() -> AuditHmacKey {
+        AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
     fn test_root(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("elastik-world-test-{name}-{}", std::process::id()))
     }
@@ -779,7 +777,7 @@ mod tests {
             b"!",
             "text/plain; charset=utf-8",
             &[],
-            b"test-key",
+            &test_key(),
         )
         .is_err());
 
@@ -790,16 +788,15 @@ mod tests {
     fn audited_write_rejects_tampered_existing_chain() {
         let root = test_root("tampered-audit-chain");
         let _ = std::fs::remove_dir_all(&root);
-        write_with_audit(&root, "home/tamper", b"one", "text/plain", &[], b"key").unwrap();
+        let key = test_key();
+        write_with_audit(&root, "home/tamper", b"one", "text/plain", &[], &key).unwrap();
         {
             let c = Connection::open(world_db(&root, "home/tamper")).unwrap();
             c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
                 .unwrap();
         }
 
-        assert!(
-            write_with_audit(&root, "home/tamper", b"two", "text/plain", &[], b"key",).is_err()
-        );
+        assert!(write_with_audit(&root, "home/tamper", b"two", "text/plain", &[], &key,).is_err());
 
         let c = Connection::open(world_db(&root, "home/tamper")).unwrap();
         let count: i64 = c
@@ -815,7 +812,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         drop(open(&root, "home/retry").unwrap());
 
-        write_with_audit(&root, "home/retry", b"one", "text/plain", &[], b"key").unwrap();
+        write_with_audit(&root, "home/retry", b"one", "text/plain", &[], &test_key()).unwrap();
 
         let c = Connection::open(world_db(&root, "home/retry")).unwrap();
         let count: i64 = c
@@ -835,7 +832,9 @@ mod tests {
                 .unwrap();
         }
 
-        assert!(write_with_audit(&root, "home/orphan", b"two", "text/plain", &[], b"key").is_err());
+        assert!(
+            write_with_audit(&root, "home/orphan", b"two", "text/plain", &[], &test_key()).is_err()
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -843,7 +842,8 @@ mod tests {
     fn existing_world_missing_audit_table_is_not_recreated() {
         let root = test_root("missing-audit-table");
         let _ = std::fs::remove_dir_all(&root);
-        write_with_audit(&root, "home/drop-events", b"one", "text/plain", &[], b"key").unwrap();
+        let key = test_key();
+        write_with_audit(&root, "home/drop-events", b"one", "text/plain", &[], &key).unwrap();
         {
             let c = Connection::open(world_db(&root, "home/drop-events")).unwrap();
             c.execute("DROP TABLE events", []).unwrap();
@@ -851,8 +851,7 @@ mod tests {
 
         assert!(open(&root, "home/drop-events").is_err());
         assert!(
-            write_with_audit(&root, "home/drop-events", b"two", "text/plain", &[], b"key",)
-                .is_err()
+            write_with_audit(&root, "home/drop-events", b"two", "text/plain", &[], &key,).is_err()
         );
         let _ = std::fs::remove_dir_all(root);
     }

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -236,7 +236,7 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
             &req.body,
             &req.content_type,
             &req.headers,
-            core.hmac_key.as_slice(),
+            &core.hmac_key,
             None,
         ) {
             Ok(result) => {
@@ -339,7 +339,7 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
             &req.body,
             &content_type,
             &stored_headers,
-            core.hmac_key.as_slice(),
+            &core.hmac_key,
         ) {
             Ok(Some((_result, h))) => etag::hmac_etag(&h),
             Ok(None) => {

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-core"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "elastik-ffi"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "elastik-core",
  "rusqlite",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastik-ffi"
-version = "8.2.1"
+version = "8.3.0"
 edition = "2021"
 description = "AuditeDB FFI — UniFFI binding for the Elastik L5 Engine."
 license = "MIT"

--- a/ffi/OPENWRT.md
+++ b/ffi/OPENWRT.md
@@ -5,7 +5,6 @@ smoke today:
 
 - Linux x64: `libelastik_ffi.so`
 - Linux ARM64: `libelastik_ffi.so`
-- macOS x64: `libelastik_ffi.dylib`
 - macOS ARM64: `libelastik_ffi.dylib`
 - Windows x64: `elastik_ffi.dll`
 

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -54,7 +54,7 @@ from elastik_ffi import (
 
 engine = FfiEngine.open(FfiEngineConfig(
     data_root="/var/lib/elastik",
-    hmac_key=b"my-secret-key",
+    hmac_key=b"0123456789abcdef0123456789abcdef",
     read_token=b"reader",
     write_token=b"writer",
     approve_token=b"admin",
@@ -66,6 +66,9 @@ engine = FfiEngine.open(FfiEngineConfig(
     read_cache_max_entries=None,
 ))
 ```
+
+`hmac_key` is the audit-chain HMAC key and must be at least 32 bytes. Short,
+empty, or all-whitespace keys are rejected before the Engine opens.
 
 ### Handle
 
@@ -174,7 +177,6 @@ Python bindings for:
 
 - Linux x64 (`libelastik_ffi.so`)
 - Linux ARM64 (`libelastik_ffi.so`)
-- macOS x64 (`libelastik_ffi.dylib`)
 - macOS ARM64 (`libelastik_ffi.dylib`)
 - Windows x64 (`elastik_ffi.dll`)
 

--- a/ffi/STACK.md
+++ b/ffi/STACK.md
@@ -43,7 +43,6 @@ HTTP server, routes, status codes, or `/proc/*` paths.
    - Build and smoke native FFI libraries plus generated Python UniFFI binding:
      - Linux x64 (`.so`)
      - Linux ARM64 (`.so`)
-     - macOS x64 (`.dylib`)
      - macOS ARM64 (`.dylib`)
      - Windows x64 (`.dll`)
    - Upload zipped CI artifacts containing the native library, generated

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -11,7 +11,7 @@
 use std::{sync::Arc, time::Duration};
 
 use elastik_core::{
-    ChangeEvent, Engine, EngineDeleteTraceHooks, SecretBytes, SubscribePattern,
+    AuditHmacKey, ChangeEvent, Engine, EngineDeleteTraceHooks, SubscribePattern,
     SubscriptionRecvError, ValidatedWorldPath,
 };
 use tokio::{
@@ -57,7 +57,7 @@ impl FfiEngine {
     pub fn open(config: FfiEngineConfig) -> Result<Arc<Self>, FfiError> {
         let summary = config.summary();
         let mut builder = Engine::builder().data_root(config.data_root);
-        let key = SecretBytes::new(config.hmac_key).map_err(|err| FfiError::InvalidSecret {
+        let key = AuditHmacKey::new(config.hmac_key).map_err(|err| FfiError::InvalidSecret {
             message: err.to_string(),
         })?;
         builder = builder.key(key);
@@ -462,7 +462,7 @@ mod tests {
         let dir = unique_test_dir("opens");
         let engine = FfiEngine::open(FfiEngineConfig {
             data_root: dir.clone(),
-            hmac_key: b"ffi-test-key".to_vec(),
+            hmac_key: b"0123456789abcdef0123456789abcdef".to_vec(),
             read_token: Some(b"read".to_vec()),
             write_token: Some(b"write".to_vec()),
             approve_token: Some(b"approve".to_vec()),
@@ -491,7 +491,7 @@ mod tests {
     fn engine_handle_drop_shuts_down_cleanly() {
         let engine = FfiEngine::open(FfiEngineConfig {
             data_root: unique_test_dir("drop-shutdown"),
-            hmac_key: b"ffi-test-key".to_vec(),
+            hmac_key: b"0123456789abcdef0123456789abcdef".to_vec(),
             read_token: None,
             write_token: None,
             approve_token: None,
@@ -511,7 +511,7 @@ mod tests {
     fn config_summary_uses_engine_normalization_rules() {
         let engine = FfiEngine::open(FfiEngineConfig {
             data_root: unique_test_dir("summary-normalization"),
-            hmac_key: b"ffi-test-key".to_vec(),
+            hmac_key: b"0123456789abcdef0123456789abcdef".to_vec(),
             read_token: Some(b" \t\n".to_vec()),
             write_token: Some(Vec::new()),
             approve_token: Some(vec![0xff, 0xfe]),
@@ -642,7 +642,7 @@ mod tests {
         let dir = unique_test_dir("delete-meta");
         let engine = FfiEngine::open(FfiEngineConfig {
             data_root: dir.clone(),
-            hmac_key: b"ffi-test-key".to_vec(),
+            hmac_key: b"0123456789abcdef0123456789abcdef".to_vec(),
             read_token: None,
             write_token: None,
             approve_token: None,
@@ -845,7 +845,7 @@ mod tests {
     fn subscription_close_releases_receiver_without_waiting_for_drop() {
         let engine = FfiEngine::open(FfiEngineConfig {
             data_root: unique_test_dir("subscribe-explicit-close"),
-            hmac_key: b"ffi-test-key".to_vec(),
+            hmac_key: b"0123456789abcdef0123456789abcdef".to_vec(),
             read_token: None,
             write_token: None,
             approve_token: None,
@@ -921,24 +921,29 @@ mod tests {
     }
 
     #[test]
-    fn engine_handle_rejects_empty_key() {
-        let result = FfiEngine::open(FfiEngineConfig {
-            data_root: unique_test_dir("empty-key"),
-            hmac_key: b"   ".to_vec(),
-            read_token: None,
-            write_token: None,
-            approve_token: None,
-            max_world_bytes: None,
-            max_memory_bytes: None,
-            max_storage_bytes: None,
-            max_listen_connections: None,
-            listen_replay_max: None,
-            read_cache_max_entries: None,
-        });
-        let Err(err) = result else {
-            panic!("empty key should fail");
-        };
-        assert!(matches!(err, FfiError::InvalidSecret { .. }));
+    fn engine_handle_rejects_invalid_hmac_keys() {
+        for (label, hmac_key) in [
+            ("empty-key", b"   ".to_vec()),
+            ("short-key", b"short".to_vec()),
+        ] {
+            let result = FfiEngine::open(FfiEngineConfig {
+                data_root: unique_test_dir(label),
+                hmac_key,
+                read_token: None,
+                write_token: None,
+                approve_token: None,
+                max_world_bytes: None,
+                max_memory_bytes: None,
+                max_storage_bytes: None,
+                max_listen_connections: None,
+                listen_replay_max: None,
+                read_cache_max_entries: None,
+            });
+            let Err(err) = result else {
+                panic!("{label} should fail");
+            };
+            assert!(matches!(err, FfiError::InvalidSecret { .. }));
+        }
     }
 
     #[test]
@@ -1064,7 +1069,7 @@ mod tests {
     fn test_engine(label: &str) -> Arc<FfiEngine> {
         FfiEngine::open(FfiEngineConfig {
             data_root: unique_test_dir(label),
-            hmac_key: b"ffi-test-key".to_vec(),
+            hmac_key: b"0123456789abcdef0123456789abcdef".to_vec(),
             read_token: None,
             write_token: None,
             approve_token: None,

--- a/release_notes/RELEASE-NOTES-v8.3.0.md
+++ b/release_notes/RELEASE-NOTES-v8.3.0.md
@@ -1,0 +1,79 @@
+# AuditeDB v8.3.0 - audit key seal
+
+v8.3.0 is a minor release for the v8 Engine line.
+
+This release tightens the audit-chain key boundary. The unstable Rust Engine
+builder and shipped adapters now require audit HMAC keys to be at least 32
+bytes, so short keys cannot enter the audit chain by accident.
+
+## Highlights
+
+- **Audit HMAC keys are type-sealed.** `EngineBuilder::key` now accepts an
+  `AuditHmacKey` proof type instead of generic secret bytes.
+- **Short audit keys fail loudly.** The HTTP binary, FFI layer, Rust Engine
+  builder, and Python launcher reject audit-chain HMAC keys shorter than 32
+  bytes.
+- **Secret containers stay generic.** `SecretBytes` remains a zeroing byte
+  container; only `AuditHmacKey` carries the audit-chain strength policy.
+- **Boundary tests added.** The test suite pins empty, whitespace, short,
+  31-byte, and 32-byte audit key cases.
+
+## Compatibility notes
+
+- This is a breaking change for the unstable Rust Engine builder API:
+  `EngineBuilder::key` requires `AuditHmacKey`.
+- HTTP, CoAP, SSE, MQTT, JavaScript SDK, and FFI protocol shapes are not
+  intentionally changed by this release.
+- The Rust library package remains `elastik-core`.
+- The server binary package remains `elastik-bin`, and still produces the
+  `elastik-core` executable.
+- The Python package remains `elastik`.
+- The JavaScript packages remain `@elastikjs/client` and
+  `@elastikjs/core-*`.
+- Environment variables remain `ELASTIK_*`.
+
+## Migration notes
+
+- Audit-chain HMAC keys shorter than 32 bytes are rejected at startup and by
+  the Rust Engine builder. Chains created with shorter keys cannot be opened by
+  this release; that does not mean the data is silently corrupted, only that
+  the chain is bound to the old key policy. Keep those data roots on a build
+  that accepted the old key, or reinitialize the data with a 32-byte-or-longer
+  key. A rekey tool is not available yet; rekeying an existing chain means
+  rebuilding the chain with a new HMAC key. Rekey tooling is tracked in #323.
+- Generate a fresh key with at least 32 random bytes. Hex-encoded 32-byte
+  output, such as `python -c "import secrets; print(secrets.token_hex(32))"`,
+  is acceptable because it provides 64 ASCII bytes of key material.
+
+## Operational notes
+
+- CI and tag release jobs run `tools/version_consistency_check.py`, which fails
+  if Rust manifests, Cargo locks, Python metadata, JavaScript package metadata,
+  npm companion metadata, active docs, release notes, or the tag version drift.
+
+## Packages
+
+These are the planned v8.3.0 release artifacts. The release workflow validates
+the version surface against the tag before publishing.
+
+- Rust library crate: `elastik-core` `8.3.0`
+- Repository Rust server binary package: `elastik-bin` `8.3.0`,
+  producing the `elastik-core` executable
+- Repository FFI Cargo package and GitHub Release assets: `elastik-ffi` `8.3.0`
+- Python SDK: `elastik` `8.3.0`
+- JavaScript SDK: `@elastikjs/client` `8.3.0`
+- npm binary companions:
+  - `@elastikjs/core-linux-x64` `8.3.0`
+  - `@elastikjs/core-linux-arm64` `8.3.0`
+  - `@elastikjs/core-darwin-arm64` `8.3.0`
+  - `@elastikjs/core-win32-x64` `8.3.0`
+- GitHub Release core assets:
+  - `elastik-core-linux-x64.zip`
+  - `elastik-core-linux-arm64.zip`
+  - `elastik-core-darwin-arm64.zip`
+  - `elastik-core-win32-x64.zip`
+- GitHub Release FFI assets:
+  - `elastik-ffi-linux-x64.zip`
+  - `elastik-ffi-linux-arm64.zip`
+  - `elastik-ffi-darwin-arm64.zip`
+  - `elastik-ffi-win32-x64.zip`

--- a/scripts/pre-push.ps1
+++ b/scripts/pre-push.ps1
@@ -54,7 +54,7 @@ function Run-JsSdkAgainstCore {
     $p = $null
     try {
         $env:ELASTIK_DATA = $temp
-        $env:ELASTIK_KEY = "test-key"
+        $env:ELASTIK_KEY = "0123456789abcdef0123456789abcdef"
         $env:ELASTIK_READ_TOKEN = "r"
         $env:ELASTIK_WRITE_TOKEN = "w"
         $env:ELASTIK_APPROVE_TOKEN = "a"

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -108,7 +108,7 @@ the same process tree.
 | `win32-x64`     | `@elastikjs/core-win32-x64`    |
 
 The npm matrix matches the Rust core's release matrix
-([Elastik L5 v8.2.1](https://github.com/rangersui/AuditeDB/releases/tag/v8.2.1)).
+([Elastik L5 v8.3.0](https://github.com/rangersui/AuditeDB/releases/tag/v8.3.0)).
 Linux binaries are statically linked against musl libc for distro
 compatibility. `darwin-x64` is intentionally not in the matrix (Apple
 Silicon only on the Mac side).
@@ -643,7 +643,7 @@ If you need the bytes, follow up with `e.get(ev.path)`.
 
 ```js
 await e.exists("home/note");   // → false only on 404; auth/network errors throw
-await e.version();             // → "elastik-core 8.2.1 (rust)"
+await e.version();             // → "elastik-core 8.3.0 (rust)"
 await e.worlds();              // → "home/note\nhome/log\n..."
 ```
 

--- a/sdk-js/core-darwin-arm64/package.json
+++ b/sdk-js/core-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-darwin-arm64",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "description": "Elastik L5 — bundled Rust core binary for macOS Apple Silicon. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-linux-arm64/package.json
+++ b/sdk-js/core-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-linux-arm64",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "description": "Elastik L5 — bundled Rust core binary for Linux ARM64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-linux-x64/package.json
+++ b/sdk-js/core-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-linux-x64",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "description": "Elastik L5 — bundled Rust core binary for Linux x64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core"

--- a/sdk-js/core-win32-x64/package.json
+++ b/sdk-js/core-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/core-win32-x64",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "description": "Elastik L5 — bundled Rust core binary for Windows x64. Installed transitively by @elastikjs/client when start() runs a local core.",
   "files": [
     "elastik-core.exe"

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastikjs/client",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "description": "AuditeDB JavaScript SDK for the Elastik L5 Engine; one import, zero dependencies.",
   "type": "module",
   "main": "./index.mjs",
@@ -53,10 +53,10 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "@elastikjs/core-linux-x64": "8.2.1",
-    "@elastikjs/core-linux-arm64": "8.2.1",
-    "@elastikjs/core-darwin-arm64": "8.2.1",
-    "@elastikjs/core-win32-x64": "8.2.1"
+    "@elastikjs/core-linux-x64": "8.3.0",
+    "@elastikjs/core-linux-arm64": "8.3.0",
+    "@elastikjs/core-darwin-arm64": "8.3.0",
+    "@elastikjs/core-win32-x64": "8.3.0"
   },
   "engines": {
     "node": ">=18"

--- a/sdk-js/scripts/pack-platform.mjs
+++ b/sdk-js/scripts/pack-platform.mjs
@@ -14,7 +14,7 @@
 // Usage:
 //   node scripts/pack-platform.mjs <plat> <arch> <binary-path> [--version <version>] [--pack]
 // Example:
-//   node scripts/pack-platform.mjs linux x64 /tmp/elastik-core --version 8.2.1 --pack
+//   node scripts/pack-platform.mjs linux x64 /tmp/elastik-core --version 8.3.0 --pack
 //
 // On the win32 runner the binary is elastik-core.exe; everywhere else it's
 // elastik-core. The script auto-detects from the source filename.

--- a/sdk-js/start.mjs
+++ b/sdk-js/start.mjs
@@ -65,8 +65,8 @@ loadDotenv();
 
 // Map of (process.platform, process.arch) → npm package name + binary file.
 // Keep in sync with the @elastikjs/core-* packages that actually exist.
-// darwin-x64 was deliberately dropped from the Rust release matrix in
-// 6.4.2 — Apple Silicon only on the Mac side.
+// darwin-x64 is deliberately absent from the current Rust release matrix:
+// Apple Silicon only on the Mac side.
 const PLATFORM_PACKAGES = {
     "linux-x64":     { pkg: "@elastikjs/core-linux-x64",    file: "elastik-core" },
     "linux-arm64":   { pkg: "@elastikjs/core-linux-arm64",  file: "elastik-core" },

--- a/sdk-js/test.mjs
+++ b/sdk-js/test.mjs
@@ -2,7 +2,7 @@
 // Elastik core. Pass ELASTIK_URL to point at Rust (3105) or Node (3106).
 //
 // Usage:
-//   ELASTIK_URL=http://127.0.0.1:3105 ELASTIK_KEY=test \
+//   ELASTIK_URL=http://127.0.0.1:3105 ELASTIK_KEY=0123456789abcdef0123456789abcdef \
 //     ELASTIK_READ_TOKEN=r ELASTIK_WRITE_TOKEN=w ELASTIK_APPROVE_TOKEN=a \
 //     node test.mjs
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -130,9 +130,11 @@ e = elastik.start(
 )
 ```
 
-`read-token`, `write-token`, `admin-token`, and `dev-hmac-key` in these examples
-are local placeholders only. The engine does not ship with built-in credentials. Use
-fresh per-deployment secrets outside throwaway demos.
+`read-token`, `write-token`, and `admin-token` in these examples are local
+placeholders only. The audit-chain HMAC key must be at least 32 bytes. The
+audit-chain HMAC key must also not be empty or all whitespace. The engine does
+not ship with built-in credentials. Use fresh per-deployment secrets outside
+throwaway demos.
 
 Python kwargs use underscores (`read_token`). CLI flags use hyphens
 (`--read-token`).
@@ -142,7 +144,7 @@ Python kwargs use underscores (`read_token`). CLI flags use hyphens
 Use this when you want a long-running local service:
 
 ```powershell
-py -m elastik run --key dev-hmac-key --read-token read-token --write-token write-token --approve-token admin-token
+py -m elastik run --key 0123456789abcdef0123456789abcdef --read-token read-token --write-token write-token --approve-token admin-token
 ```
 
 Then connect from another process:
@@ -522,7 +524,7 @@ least one handler.
 ```python
 import elastik
 
-e = elastik.start(key="dev-key", write_token="write-token")
+e = elastik.start(key="0123456789abcdef0123456789abcdef", write_token="write-token")
 
 @elastik.listen("/home/inbox/*")
 def on_inbox(body, path, meta, e):
@@ -599,7 +601,7 @@ assert e.get_text("note") == "hello"
 git clone https://github.com/rangersui/AuditeDB
 cd AuditeDB
 python -m pip install -e .\sdk
-python -m elastik run --key dev-hmac-key --read-token read-token --write-token write-token --approve-token admin-token
+python -m elastik run --key 0123456789abcdef0123456789abcdef --read-token read-token --write-token write-token --approve-token admin-token
 ```
 
 For the full project README, see:

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elastik"
-version = "8.2.1"
+version = "8.3.0"
 description = "AuditeDB: the db that listens. Python client for the Elastik L5 Engine."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -164,7 +164,7 @@ __all__ = [
     "list_worlds", "list_paths", "list_keys", "request",
 ]
 
-__version__ = "8.2.1"
+__version__ = "8.3.0"
 
 
 # ── module-level singleton client ──────────────────────────────────
@@ -247,9 +247,10 @@ def show_config() -> None:
     print(f"  approve: {_mask(os.getenv('ELASTIK_APPROVE_TOKEN'))}")
 
 
-# Re-export start() to also bind the singleton, so the next 模式 works:
-#   e = elastik.start()      # works (returns client)
-#   elastik.put("/x", "y")   # also works (uses the same client)
+# Re-export start() to also bind the singleton, so later module-level calls use
+# the same client:
+#   e = elastik.start(key=..., write_token=...)
+#   elastik.put("/x", "y")
 def start(
     port: int | None = None,
     host: str | None = None,

--- a/sdk/src/elastik/__main__.py
+++ b/sdk/src/elastik/__main__.py
@@ -87,7 +87,14 @@ def main() -> int:
     )
     p_run.add_argument("--host", default=None, help="bind host (default: ELASTIK_HOST or 127.0.0.1)")
     p_run.add_argument("--port", type=int, default=None, help="bind port (default: ELASTIK_PORT or 3105)")
-    p_run.add_argument("--key", default=None, help="audit-chain HMAC key; required unless ELASTIK_KEY/.env is set")
+    p_run.add_argument(
+        "--key",
+        default=None,
+        help=(
+            "audit-chain HMAC key, at least 32 UTF-8 bytes and not all "
+            "whitespace; required unless ELASTIK_KEY/.env is set"
+        ),
+    )
     p_run.add_argument("--read-token", dest="read_token", default=None, help="optional read gate; omit to keep reads public")
     p_run.add_argument("--write-token", default=None, help="optional write token for ordinary PUT/POST; omit to disable writes")
     p_run.add_argument("--approve-token", dest="approve_token", default=None, help="optional approve token for DELETE and system writes")
@@ -197,24 +204,29 @@ def main() -> int:
 
     if args.cmd == "run":
         try:
-            client = start(
-                host=args.host,
-                port=args.port,
-                key=args.key,
-                read_token=args.read_token,
-                write_token=args.write_token,
-                approve_token=args.approve_token,
-                data_dir=args.data_dir,
-                quiet=False,
-            )
-            print(f"elastik running at {client.url}", flush=True)
-            print("  Ctrl-C to stop", flush=True)
             try:
-                while True:
-                    import time
-                    time.sleep(3600)
-            except KeyboardInterrupt:
-                pass
+                client = start(
+                    host=args.host,
+                    port=args.port,
+                    key=args.key,
+                    read_token=args.read_token,
+                    write_token=args.write_token,
+                    approve_token=args.approve_token,
+                    data_dir=args.data_dir,
+                    quiet=False,
+                    _key_source="--key" if args.key is not None else None,
+                )
+                print(f"elastik running at {client.url}", flush=True)
+                print("  Ctrl-C to stop", flush=True)
+                try:
+                    while True:
+                        import time
+                        time.sleep(3600)
+                except KeyboardInterrupt:
+                    pass
+            except RuntimeError as exc:
+                print(f"elastik: {exc}", file=sys.stderr)
+                return 1
         finally:
             stop()
         return 0

--- a/sdk/src/elastik/_spawn.py
+++ b/sdk/src/elastik/_spawn.py
@@ -8,7 +8,7 @@ launches it in a subprocess and returns a pre-bound `Elastik` client.
 The user does:
 
     import elastik
-    e = elastik.start(write_token="x")
+    e = elastik.start(key="0123456789abcdef0123456789abcdef", write_token="x")
     e.put("/home/note", "hi")
     print(e.get("/home/note"))
     elastik.stop()
@@ -22,6 +22,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -35,6 +36,21 @@ _live_url: str | None = None
 _live_data_dir: str | None = None
 _last_live_url: str | None = None
 _last_live_data_dir: str | None = None
+
+
+def _captured_startup_output(capture) -> str:
+    if capture is None:
+        return ""
+    try:
+        capture.flush()
+        capture.seek(0)
+        raw = capture.read()
+    except OSError:
+        return ""
+    text = raw.decode("utf-8", "replace").strip()
+    if not text:
+        return ""
+    return "\nchild output:\n" + text[-4000:]
 
 
 def _load_dotenv(path: str = ".env") -> None:
@@ -91,11 +107,13 @@ def _binary_path() -> Path:
     return here / name
 
 
-def _wait_for_port(host: str, port: int, deadline_s: float = 10.0) -> bool:
+def _wait_for_port(host: str, port: int, deadline_s: float = 10.0, proc=None) -> bool:
     """Poll until the server accepts a TCP connection or we give up."""
     connect_host = _connect_host(host)
     end = time.time() + deadline_s
     while time.time() < end:
+        if proc is not None and proc.poll() is not None:
+            return False
         try:
             with socket.create_connection((connect_host, port), timeout=0.3):
                 return True
@@ -125,6 +143,16 @@ def _url_host(host: str) -> str:
 def _client_url(host: str, port: int) -> str:
     """URL a local client should use after the core binds."""
     return f"http://{_url_host(host)}:{port}"
+
+
+def _parse_port(value: str, source: str) -> int:
+    try:
+        port = int(value)
+    except ValueError:
+        raise RuntimeError(f"{source} must be an integer; got {value!r}") from None
+    if not 0 <= port <= 65535:
+        raise RuntimeError(f"{source} must be between 0 and 65535; got {port}")
+    return port
 
 
 def _port_is_free(host: str, port: int) -> bool:
@@ -209,6 +237,7 @@ def start(
     data_dir: Optional[str] = None,
     quiet: bool = True,
     debug: bool | str = False,
+    _key_source: str | None = None,
 ):
     """Launch the bundled elastik-core. Returns a pre-bound Elastik client.
 
@@ -227,18 +256,38 @@ def start(
 
     host = host or os.getenv("ELASTIK_HOST", "127.0.0.1")
     if port is None:
-        port = int(os.getenv("ELASTIK_PORT", "3105"))
+        port = _parse_port(os.getenv("ELASTIK_PORT", "3105"), "ELASTIK_PORT")
+    else:
+        port = _parse_port(str(port), "port")
     # ELASTIK_KEY: no constant default. The audit chain HMAC computed
     # against a publicly-known key is meaningless: anyone could forge
     # events. Caller passes `key=...`, the env provides ELASTIK_KEY,
     # or .env (already loaded by `import elastik`) supplies it.
     # Validate before checking the binary: a missing key is a config
     # error the user can fix; a missing binary is an install error.
-    key = key or os.getenv("ELASTIK_KEY")
-    if not key:
+    if key is None:
+        key = os.getenv("ELASTIK_KEY")
+        key_source = "ELASTIK_KEY"
+    else:
+        key_source = _key_source or "key="
+    if key is None:
         raise RuntimeError(
-            "ELASTIK_KEY required: set it in .env, export it in the shell, "
-            "or pass key=... to elastik.start().\n"
+            "audit key required: set ELASTIK_KEY to a 32-byte-or-longer value "
+            "in .env or the shell, pass key=... to elastik.start(), "
+            "or pass --key to python -m elastik run.\n"
+            "Generate one with: "
+            "python -c \"import secrets; print(secrets.token_hex(32))\""
+        )
+    try:
+        key_bytes = key.encode("utf-8")
+    except UnicodeError:
+        raise RuntimeError(
+            f"audit key is invalid: {key_source} value must be valid UTF-8 text."
+        ) from None
+    if not key.strip() or len(key_bytes) < 32:
+        raise RuntimeError(
+            f"audit key is invalid: {key_source} must be at least 32 UTF-8 bytes "
+            "and not all whitespace.\n"
             "Generate one with: "
             "python -c \"import secrets; print(secrets.token_hex(32))\""
         )
@@ -286,23 +335,42 @@ def start(
     else:
         env.pop("ELASTIK_DATA", None)
 
-    out = subprocess.DEVNULL if quiet else None
-    _proc = subprocess.Popen([str(binary)], env=env, stdout=out, stderr=out)
-    atexit.register(stop)
-
-    if not _wait_for_port(host, port):
-        stop()
-        raise RuntimeError(
-            f"elastik-core failed to start on {host}:{port} within 10s"
+    capture = tempfile.TemporaryFile() if quiet else None
+    out = capture if quiet else None
+    try:
+        _proc = subprocess.Popen(
+            [str(binary)],
+            env=env,
+            stdout=out,
+            stderr=subprocess.STDOUT if quiet else None,
         )
-    if _proc is None or _proc.poll() is not None:
-        code = None if _proc is None else _proc.returncode
-        stop()
-        raise RuntimeError(f"elastik-core exited during startup (code={code})")
-    probe_token = approve_token or write_token or read_token
-    if not _probe_core(host, port, probe_token):
-        stop()
-        raise RuntimeError(f"port {host}:{port} did not answer as elastik-core")
+        atexit.register(stop)
+
+        if not _wait_for_port(host, port, proc=_proc):
+            stop()
+            code = None if _proc is None else _proc.returncode
+            exited = "" if code is None else f" (child exited with code {code})"
+            raise RuntimeError(
+                f"elastik-core failed to start on {host}:{port} within 10s{exited}"
+                f"{_captured_startup_output(capture)}"
+            )
+        if _proc is None or _proc.poll() is not None:
+            code = None if _proc is None else _proc.returncode
+            stop()
+            raise RuntimeError(
+                f"elastik-core exited during startup (code={code})"
+                f"{_captured_startup_output(capture)}"
+            )
+        probe_token = approve_token or write_token or read_token
+        if not _probe_core(host, port, probe_token):
+            stop()
+            raise RuntimeError(
+                f"port {host}:{port} did not answer as elastik-core"
+                f"{_captured_startup_output(capture)}"
+            )
+    finally:
+        if capture is not None:
+            capture.close()
     if not quiet:
         _warn_token_state(read_token, write_token, approve_token)
 
@@ -368,7 +436,7 @@ def default_url() -> str:
     if explicit:
         return explicit
     host = os.getenv("ELASTIK_HOST", "127.0.0.1")
-    port = int(os.getenv("ELASTIK_PORT", "3105"))
+    port = _parse_port(os.getenv("ELASTIK_PORT", "3105"), "ELASTIK_PORT")
     return _client_url(host, port)
 
 

--- a/sdk/src/elastik/_spawn.py
+++ b/sdk/src/elastik/_spawn.py
@@ -22,7 +22,7 @@ import os
 import socket
 import subprocess
 import sys
-import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -38,19 +38,54 @@ _last_live_url: str | None = None
 _last_live_data_dir: str | None = None
 
 
+class _BoundedOutputCapture:
+    """Drain child output without letting quiet-mode logs grow unbounded."""
+
+    def __init__(self, limit: int = 4000) -> None:
+        self._limit = limit
+        self._buffer = bytearray()
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+
+    def start(self, pipe) -> None:
+        thread = threading.Thread(target=self._drain, args=(pipe,), daemon=True)
+        self._thread = thread
+        thread.start()
+
+    def _drain(self, pipe) -> None:
+        try:
+            while True:
+                chunk = pipe.read(4096)
+                if not chunk:
+                    return
+                with self._lock:
+                    self._buffer.extend(chunk)
+                    overflow = len(self._buffer) - self._limit
+                    if overflow > 0:
+                        del self._buffer[:overflow]
+        except OSError:
+            return
+        finally:
+            try:
+                pipe.close()
+            except OSError:
+                pass
+
+    def text(self) -> str:
+        if self._thread is not None:
+            self._thread.join(timeout=0.2)
+        with self._lock:
+            raw = bytes(self._buffer)
+        return raw.decode("utf-8", "replace").strip()
+
+
 def _captured_startup_output(capture) -> str:
     if capture is None:
         return ""
-    try:
-        capture.flush()
-        capture.seek(0)
-        raw = capture.read()
-    except OSError:
-        return ""
-    text = raw.decode("utf-8", "replace").strip()
+    text = capture.text()
     if not text:
         return ""
-    return "\nchild output:\n" + text[-4000:]
+    return "\nchild output:\n" + text
 
 
 def _load_dotenv(path: str = ".env") -> None:
@@ -335,42 +370,40 @@ def start(
     else:
         env.pop("ELASTIK_DATA", None)
 
-    capture = tempfile.TemporaryFile() if quiet else None
-    out = capture if quiet else None
-    try:
-        _proc = subprocess.Popen(
-            [str(binary)],
-            env=env,
-            stdout=out,
-            stderr=subprocess.STDOUT if quiet else None,
-        )
-        atexit.register(stop)
+    capture = _BoundedOutputCapture() if quiet else None
+    out = subprocess.PIPE if quiet else None
+    _proc = subprocess.Popen(
+        [str(binary)],
+        env=env,
+        stdout=out,
+        stderr=subprocess.STDOUT if quiet else None,
+    )
+    if capture is not None and _proc.stdout is not None:
+        capture.start(_proc.stdout)
+    atexit.register(stop)
 
-        if not _wait_for_port(host, port, proc=_proc):
-            stop()
-            code = None if _proc is None else _proc.returncode
-            exited = "" if code is None else f" (child exited with code {code})"
-            raise RuntimeError(
-                f"elastik-core failed to start on {host}:{port} within 10s{exited}"
-                f"{_captured_startup_output(capture)}"
-            )
-        if _proc is None or _proc.poll() is not None:
-            code = None if _proc is None else _proc.returncode
-            stop()
-            raise RuntimeError(
-                f"elastik-core exited during startup (code={code})"
-                f"{_captured_startup_output(capture)}"
-            )
-        probe_token = approve_token or write_token or read_token
-        if not _probe_core(host, port, probe_token):
-            stop()
-            raise RuntimeError(
-                f"port {host}:{port} did not answer as elastik-core"
-                f"{_captured_startup_output(capture)}"
-            )
-    finally:
-        if capture is not None:
-            capture.close()
+    if not _wait_for_port(host, port, proc=_proc):
+        stop()
+        code = None if _proc is None else _proc.returncode
+        exited = "" if code is None else f" (child exited with code {code})"
+        raise RuntimeError(
+            f"elastik-core failed to start on {host}:{port} within 10s{exited}"
+            f"{_captured_startup_output(capture)}"
+        )
+    if _proc is None or _proc.poll() is not None:
+        code = None if _proc is None else _proc.returncode
+        stop()
+        raise RuntimeError(
+            f"elastik-core exited during startup (code={code})"
+            f"{_captured_startup_output(capture)}"
+        )
+    probe_token = approve_token or write_token or read_token
+    if not _probe_core(host, port, probe_token):
+        stop()
+        raise RuntimeError(
+            f"port {host}:{port} did not answer as elastik-core"
+            f"{_captured_startup_output(capture)}"
+        )
     if not quiet:
         _warn_token_state(read_token, write_token, approve_token)
 

--- a/tools/curlbench.py
+++ b/tools/curlbench.py
@@ -7,7 +7,7 @@ Usage:
       --out prompts/curlbench-$(date +%s).json
 
 Pre-flight (one-shot, in another terminal):
-  $env:ELASTIK_KEY = "test-key"
+  $env:ELASTIK_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   $env:ELASTIK_WRITE_TOKEN = "write-token"
   $env:ELASTIK_APPROVE_TOKEN = "approve-token"
   $env:ELASTIK_PERSIST_HEADERS = "x-author,x-meta-*"


### PR DESCRIPTION
## Summary
- add `AuditHmacKey` as the proof type for audit-chain HMAC keys and require at least 32 bytes at construction
- change `EngineBuilder::key`, core state, audit append/verify paths, read-cache verify, and delete ledger jobs to require the sealed key type instead of generic secret bytes or raw `&[u8]`
- update HTTP/FFI/Python SDK boundaries and examples so short HMAC keys fail before reaching the engine

## Why
`SecretBytes` only proved that bytes were non-empty and not all whitespace, so `b"x"` could be used as the audit-chain HMAC key. Because chain HMACs are exposed through ETags and audit verification, a weak key is offline brute-force material. This change makes weak audit HMAC keys unrepresentable at the Engine boundary.

`SecretBytes` remains a generic zeroing byte container. `AuditHmacKey` is the actual audit-chain key capability.

## Impact
This is a breaking hardening change for deployments using an `ELASTIK_KEY` shorter than 32 bytes. Those deployments will now fail startup instead of running with a brute-forceable audit key. Existing audit chains remain valid when the same sufficiently long key is used; the chain format and HMAC input are unchanged.

## Validation
- `cargo test --manifest-path core/Cargo.toml --features bundled-sqlite,unstable-engine`
- `cargo test --manifest-path bin/Cargo.toml --features bundled-sqlite,unstable-engine`
- `cargo test --manifest-path ffi/Cargo.toml`
- `cargo clippy --manifest-path core/Cargo.toml --features bundled-sqlite,unstable-engine -- -D warnings`
- `cargo clippy --manifest-path bin/Cargo.toml --features bundled-sqlite,unstable-engine -- -D warnings`
- `cargo clippy --manifest-path ffi/Cargo.toml -- -D warnings`
- `powershell -ExecutionPolicy Bypass -File scripts/pre-push.ps1`