### PR TITLE
listen: signal stale pre-restart cursors (CursorAhead + SSE reset)

### DIFF
--- a/bin/Cargo.lock
+++ b/bin/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "elastik-core",
  "futures-util",
  "hex",
+ "http-body-util",
  "percent-encoding",
  "rumqttd",
  "rusqlite",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -30,6 +30,8 @@ unstable-engine = []
 [dev-dependencies]
 base64 = "0.22"
 hex = "0.4"
+# Already in Cargo.lock transitively via axum; dev-only, zero new supply chain.
+http-body-util = "0.1"
 rusqlite = { version = "0.40", default-features = false }
 tower = { version = "0.5", features = ["util"] }
 

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -79,6 +79,11 @@ pub(crate) async fn handler(
                     .data(format!("missed: {skipped}"))),
                 subscription,
             )),
+            // The client's Last-Event-ID predates an engine restart: its id
+            // space no longer exists. The stream continues live.
+            Err(SubscriptionRecvError::CursorAhead { since, newest }) => {
+                Some((Ok(sse_reset_event(since, newest)), subscription))
+            }
             Err(SubscriptionRecvError::Closed) => None,
             Err(_err) => {
                 #[cfg(feature = "unstable-engine")]
@@ -95,6 +100,20 @@ pub(crate) async fn handler(
                 .text("keepalive"),
         )
         .into_response()
+}
+
+/// Builds the `reset` frame for a cursor that predates an engine restart.
+///
+/// The `id:` field rebases the client's Last-Event-ID buffer to `newest`
+/// (the SSE spec applies id updates on named events too), so an
+/// auto-reconnecting client resumes via normal ring replay instead of
+/// looping on reset. One key per `data:` line, matching every other
+/// multi-field frame on this stream.
+fn sse_reset_event(since: u64, newest: u64) -> Event {
+    Event::default()
+        .event("reset")
+        .id(newest.to_string())
+        .data(format!("since: {since}\nnewest: {newest}"))
 }
 
 fn sse_change_event(change: EngineChangeEvent) -> Event {
@@ -165,6 +184,94 @@ mod tests {
         assert!(wire.contains("hmac-"));
         assert!(!wire.contains("body"));
         assert!(!wire.contains("secret-body"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn sse_reset_event_rebases_cursor_for_stale_subscribers() {
+        let (engine, dir) = test_engine_for_server("listen-sse-reset");
+        let mut subscription = engine
+            .subscribe(
+                &SubscribePattern::new("home/task/*"),
+                AccessTier::Read,
+                Some(500),
+            )
+            .expect("stale-cursor subscription should be accepted");
+
+        let err = subscription
+            .recv()
+            .await
+            .expect_err("first item must be the reset signal");
+        let SubscriptionRecvError::CursorAhead { since, newest } = err else {
+            panic!("expected CursorAhead, got {err:?}");
+        };
+
+        let event = sse_reset_event(since, newest);
+        let wire = format!("{event:?}");
+        assert!(
+            wire.contains("event: reset\\n") || wire.contains("event: reset\n"),
+            "event name must be exactly reset: {wire}"
+        );
+        assert!(
+            wire.contains("id: 0"),
+            "id field must rebase Last-Event-ID to newest: {wire}"
+        );
+        assert!(
+            wire.contains("data: since: 500\\ndata: newest: 0")
+                || wire.contains("data: since: 500\ndata: newest: 0"),
+            "one key per data line, in since/newest order: {wire}"
+        );
+
+        // Nonzero newest pins the variable plumbing: a hard-coded-zero
+        // mutant of sse_reset_event passes every engine-driven test above
+        // (fresh engines always have newest == 0).
+        let warm = format!("{:?}", sse_reset_event(500, 7));
+        assert!(warm.contains("id: 7"), "{warm}");
+        assert!(
+            warm.contains("data: since: 500\\ndata: newest: 7")
+                || warm.contains("data: since: 500\ndata: newest: 7"),
+            "{warm}"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn handler_emits_reset_frame_for_stale_last_event_id() {
+        // Pins the handler wiring itself: if the CursorAhead arm were
+        // deleted, the stream would fall into the wildcard and close, and
+        // this test would fail on a missing first frame — the silent
+        // reconnect loop cannot come back unnoticed.
+        use http_body_util::BodyExt;
+
+        let (engine, dir) = test_engine_for_server("listen-reset-wire");
+        let mut headers = HeaderMap::new();
+        headers.insert("last-event-id", "500".parse().unwrap());
+
+        let resp = handler(
+            State(server_state_for_engine_for_tests(engine)),
+            Method::GET,
+            headers,
+            AxPath("home/task/*".to_string()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut body = resp.into_body();
+        let frame = tokio::time::timeout(Duration::from_secs(10), body.frame())
+            .await
+            .expect("first SSE frame must arrive promptly")
+            .expect("stream must yield a reset frame, not end")
+            .expect("frame must not error");
+        let bytes = frame.into_data().expect("first frame carries data");
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("event: reset"), "{text}");
+        assert!(text.contains("id: 0"), "{text}");
+        assert!(
+            text.contains("data: since: 500\ndata: newest: 0"),
+            "two data lines in since/newest order: {text}"
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/bin/src/server/mqtt/session.rs
+++ b/bin/src/server/mqtt/session.rs
@@ -449,6 +449,17 @@ pub(super) async fn subscription_loop(
                 ));
                 continue;
             }
+            // Defensive arm: currently unreachable — this adapter always
+            // subscribes with since=None (no MQTT resume-cursor concept), and
+            // CursorAhead is only produced for Some(cursor). Kept explicit so
+            // a future resume feature cannot silently fall into a wildcard.
+            Err(SubscriptionRecvError::CursorAhead { since, newest }) => {
+                mqtt_warn(format_args!(
+                    "mqtt: subscription cursor {since} predates an engine restart \
+                     (newest issued id is {newest}); continuing live"
+                ));
+                continue;
+            }
             Err(SubscriptionRecvError::Closed) => break,
             #[allow(unreachable_patterns)]
             Err(_) => continue,

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -149,11 +149,11 @@ impl<'a> EngineOps<'a> {
 
     fn open_subscription(&self, permit: SubscribePermit, since: Option<u64>) -> EngineSubscription {
         let rx = self.core.events.subscribe();
-        let (lag, replay, live_floor) = replay_after(self.core, since, &permit.pattern);
+        let (interruption, replay, live_floor) = replay_after(self.core, since, &permit.pattern);
         let replay_mode = since.is_some();
         let mut initial = VecDeque::new();
-        if let Some(skipped) = lag {
-            initial.push_back(Err(SubscriptionRecvError::Lagged { skipped }));
+        if let Some(err) = interruption {
+            initial.push_back(Err(err.into()));
         }
         initial.extend(replay.into_iter().map(Ok));
         EngineSubscription::new(
@@ -321,7 +321,11 @@ impl Engine {
     /// `id > since` from the in-memory ring before switching to the live
     /// stream. Replay is bounded by the configured `listen_replay_max`; if
     /// `since` is older than the ring's floor, the first `recv` call yields
-    /// a [`crate::SubscriptionRecvError::Lagged`] error.
+    /// a [`crate::SubscriptionRecvError::Lagged`] error. If `since` is ahead
+    /// of the newest id this process has issued (a cursor saved before an
+    /// engine restart), the first `recv` call yields
+    /// [`crate::SubscriptionRecvError::CursorAhead`] and the subscription
+    /// continues in live-only mode.
     ///
     /// The returned [`EngineSubscription`] holds a subscription slot until
     /// dropped; drop it promptly when finished so other subscribers can
@@ -350,11 +354,40 @@ struct NoopDeleteTrace;
 
 impl DeleteTraceHooks for NoopDeleteTrace {}
 
+/// A non-terminal condition surfaced as the first `recv` result of a
+/// resuming subscription. Deliberately narrower than
+/// [`SubscriptionRecvError`]: a replay interruption can never be `Closed`,
+/// so the production construction path (`replay_after` →
+/// `open_subscription`) cannot queue a fake terminal error.
+/// (`EngineSubscription::new` itself still accepts any error in its replay
+/// queue; that seam is exercised by tests and is on the ledger for the
+/// planned `ReplayCursor` consolidation.)
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReplayInterruption {
+    /// The ring evicted `skipped` events between the cursor and the oldest
+    /// retained event.
+    Lagged { skipped: u64 },
+    /// The cursor is ahead of every id this process has issued (it predates
+    /// an engine restart).
+    CursorAhead { since: u64, newest: u64 },
+}
+
+impl From<ReplayInterruption> for SubscriptionRecvError {
+    fn from(value: ReplayInterruption) -> Self {
+        match value {
+            ReplayInterruption::Lagged { skipped } => Self::Lagged { skipped },
+            ReplayInterruption::CursorAhead { since, newest } => {
+                Self::CursorAhead { since, newest }
+            }
+        }
+    }
+}
+
 pub(crate) fn replay_after(
     core: &Core,
     since: Option<u64>,
     pattern: &SubscribePattern,
-) -> (Option<u64>, Vec<ChangeEvent>, u64) {
+) -> (Option<ReplayInterruption>, Vec<ChangeEvent>, u64) {
     let Some(last_id) = since else {
         return (None, Vec::new(), 0);
     };
@@ -362,6 +395,28 @@ pub(crate) fn replay_after(
         .event_log
         .lock()
         .unwrap_or_else(|poison| poison.into_inner());
+    // The counter is read only after acquiring the log lock: writers push
+    // under this lock after allocating their id, so the acquire edge
+    // guarantees the load observes every id whose event is already visible
+    // to replay — the CursorAhead check below cannot misfire for a cursor
+    // whose event is in the log.
+    let newest = crate::last_issued_event_id(&core.next_event);
+    if last_id > newest {
+        // A cursor this process never issued: it predates an engine restart
+        // (listen ids are process-local and the counter resets to zero).
+        // Surface the discontinuity and fall back to live-only mode with a
+        // zero floor — filtering live events against an id space that no
+        // longer exists would silently drop everything until the counter
+        // caught up.
+        return (
+            Some(ReplayInterruption::CursorAhead {
+                since: last_id,
+                newest,
+            }),
+            Vec::new(),
+            0,
+        );
+    }
     let gap = log.front().and_then(|oldest| {
         let expected_next = last_id.saturating_add(1);
         if expected_next < oldest.id {
@@ -377,7 +432,11 @@ pub(crate) fn replay_after(
         .map(Into::into)
         .collect();
     let live_floor = replay.last().map(|change| change.id).unwrap_or(last_id);
-    (gap, replay, live_floor)
+    (
+        gap.map(|skipped| ReplayInterruption::Lagged { skipped }),
+        replay,
+        live_floor,
+    )
 }
 
 impl From<Preconditions> for etag::Preconditions {
@@ -647,11 +706,15 @@ mod tests {
                 });
             }
         }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, 12);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (gap, replay, floor) = replay_after(engine.core(), Some(5), &pattern);
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(5), &pattern);
 
-        assert_eq!(gap, Some(4));
+        assert_eq!(
+            interruption,
+            Some(ReplayInterruption::Lagged { skipped: 4 })
+        );
         assert_eq!(replay.len(), 3);
         assert_eq!(replay[0].id, 10);
         assert_eq!(replay[0].path.as_str(), "home/task/10");
@@ -673,13 +736,66 @@ mod tests {
                 etag: "hmac-max".to_string(),
             });
         }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, u64::MAX);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (gap, replay, floor) = replay_after(engine.core(), Some(u64::MAX), &pattern);
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(u64::MAX), &pattern);
 
-        assert_eq!(gap, None);
+        assert_eq!(interruption, None);
         assert!(replay.is_empty());
         assert_eq!(floor, u64::MAX);
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn replay_after_flags_cursor_from_previous_boot() {
+        let (engine, root) = test_engine("replay-cursor-ahead");
+        {
+            let mut log = engine.core().event_log.lock().unwrap();
+            for id in 1..=3 {
+                log.push_back(event::ChangeEvent {
+                    id,
+                    verb: ChangeVerb::Replace,
+                    path: format!("/home/task/{id}"),
+                    etag: format!("hmac-{id}"),
+                });
+            }
+        }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, 3);
+
+        let pattern = SubscribePattern::new("home/task/*");
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(500), &pattern);
+
+        assert_eq!(
+            interruption,
+            Some(ReplayInterruption::CursorAhead {
+                since: 500,
+                newest: 3
+            })
+        );
+        assert!(replay.is_empty(), "a foreign cursor must not replay");
+        assert_eq!(floor, 0, "live-only mode must not filter anything");
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn replay_after_accepts_cursor_at_newest_id() {
+        let (engine, root) = test_engine("replay-cursor-at-newest");
+        crate::state::test_only_set_event_counter(&engine.core().next_event, 7);
+
+        let pattern = SubscribePattern::new("*");
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(7), &pattern);
+
+        assert_eq!(
+            interruption, None,
+            "a cursor equal to the newest issued id is legitimate"
+        );
+        assert!(replay.is_empty());
+        assert_eq!(floor, 7);
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);
@@ -814,6 +930,53 @@ mod tests {
             subscription.recv().await,
             Err(SubscriptionRecvError::Closed)
         ));
+
+        drop(subscription);
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn engine_subscription_with_stale_cursor_signals_then_streams_live() {
+        // Regression: before CursorAhead existed, a cursor saved before an
+        // engine restart was filtered against the reset id space — the
+        // subscription stayed open, authorized, and silently empty. The
+        // timeouts make that regression fail fast instead of hanging the
+        // suite: the silent-drop failure mode is recv() never returning.
+        let recv_budget = std::time::Duration::from_secs(10);
+        let (engine, root) = test_engine("subscribe-stale-cursor");
+        let pattern = SubscribePattern::new("home/stale/*");
+        let mut subscription = engine
+            .subscribe(&pattern, AccessTier::Anon, Some(500))
+            .expect("subscription opens with a stale cursor");
+
+        let first = tokio::time::timeout(recv_budget, subscription.recv())
+            .await
+            .expect("first recv must yield CursorAhead, not block");
+        assert!(matches!(
+            first,
+            Err(SubscriptionRecvError::CursorAhead {
+                since: 500,
+                newest: 0
+            })
+        ));
+
+        let world = ValidatedWorldPath::new("home/stale/a").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"alive"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let change = tokio::time::timeout(recv_budget, subscription.recv())
+            .await
+            .expect("live recv must not block after the cursor warning")
+            .expect("live events must flow after the cursor warning");
+        assert_eq!(change.path.as_str(), "home/stale/a");
 
         drop(subscription);
         drop(engine);

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -329,6 +329,28 @@ pub enum SubscriptionRecvError {
         /// Number of events the receiver missed.
         skipped: u64,
     },
+    /// The subscriber's resume cursor (`since`) is ahead of the newest event
+    /// id this engine process has issued.
+    ///
+    /// Listen ids are process-local: the counter starts at zero on every
+    /// engine start, so a cursor saved before a restart can point past
+    /// everything the current process has issued. Without this signal such a
+    /// cursor would silently filter out every live event until the counter
+    /// caught up.
+    ///
+    /// Recoverable as a **new** stream: the subscription continues in
+    /// live-only mode — no replay, no event-id filtering (the subscribe
+    /// pattern still applies). The caller must discard its saved cursor;
+    /// there is no continuity between the cursor's id space and the events
+    /// that follow. Callers that also want this process's buffered history
+    /// should resubscribe with `since = Some(0)` instead.
+    CursorAhead {
+        /// The cursor the subscriber presented.
+        since: u64,
+        /// The newest event id this process had issued when the
+        /// subscription was opened.
+        newest: u64,
+    },
 }
 
 impl SecretBytes {
@@ -584,7 +606,10 @@ impl EngineSubscription {
     ///
     /// Drains the replay queue first (in increasing event id order), then
     /// switches to the live broadcast stream. If the caller passed `since` to
-    /// [`crate::Engine::subscribe`], events with id `<= since` are filtered.
+    /// [`crate::Engine::subscribe`], events with id `<= since` are filtered —
+    /// unless `since` was ahead of the newest issued id (see
+    /// [`SubscriptionRecvError::CursorAhead`]), in which case no id filtering
+    /// is applied.
     ///
     /// # Errors
     /// - [`SubscriptionRecvError::Closed`] when the engine shut down or the
@@ -593,6 +618,10 @@ impl EngineSubscription {
     /// - [`SubscriptionRecvError::Lagged`] when the broadcast ring buffer
     ///   overflowed and events were lost. Recoverable: the next call resumes
     ///   with fresh events.
+    /// - [`SubscriptionRecvError::CursorAhead`] when `since` points past the
+    ///   newest id this process has issued (the cursor predates an engine
+    ///   restart). Recoverable as a new stream: subsequent calls yield live
+    ///   events; the saved cursor must be discarded.
     pub async fn recv(&mut self) -> Result<ChangeEvent, SubscriptionRecvError> {
         loop {
             let state = std::mem::replace(&mut self.state, SubscriptionState::Closed);

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -67,6 +67,41 @@ fn next_event_id(counter: &EventCounter) -> u64 {
     *next
 }
 
+/// Returns the newest event id this process has issued (0 before the first
+/// event). Ids are allocated before their events are published, so a cursor
+/// legitimately obtained from this process can never exceed this value; a
+/// larger cursor must come from a previous process lifetime.
+#[cfg(target_has_atomic = "64")]
+#[inline]
+pub(crate) fn last_issued_event_id(counter: &EventCounter) -> u64 {
+    counter.load(Ordering::Relaxed)
+}
+
+#[cfg(not(target_has_atomic = "64"))]
+#[inline]
+pub(crate) fn last_issued_event_id(counter: &EventCounter) -> u64 {
+    *counter
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Test bypass: forges the event counter so tests can simulate a process
+/// that has already issued ids. Production code must never set the counter
+/// directly — it only advances through `next_event_id`.
+#[cfg(test)]
+pub(crate) fn test_only_set_event_counter(counter: &EventCounter, value: u64) {
+    #[cfg(target_has_atomic = "64")]
+    {
+        counter.store(value, Ordering::Relaxed);
+    }
+    #[cfg(not(target_has_atomic = "64"))]
+    {
+        *counter
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = value;
+    }
+}
+
 pub(crate) struct StorageReservationError {
     pub(crate) used: usize,
     pub(crate) quota: usize,

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -617,7 +617,7 @@ Event shape:
 
 ```js
 {
-    type:   "put" | "post" | "delete" | "lag" | "message" | "error",
+    type:   "put" | "post" | "delete" | "lag" | "reset" | "message" | "error",
     id:     "42",
     path:   "/home/task/123",
     method: "PUT",

--- a/sdk-js/index.d.ts
+++ b/sdk-js/index.d.ts
@@ -130,7 +130,7 @@ export interface GetMetaResult {
     status: number;
 }
 
-export type ListenEventType = "put" | "post" | "delete" | "lag" | "message" | "error";
+export type ListenEventType = "put" | "post" | "delete" | "lag" | "reset" | "message" | "error";
 
 export interface ListenEvent {
     type: ListenEventType;

--- a/sdk-js/index.mjs
+++ b/sdk-js/index.mjs
@@ -283,7 +283,10 @@ export class Elastik {
     // ─── LISTEN ──────────────────────────────────────────
     // Subscribe to /listen/<pattern>. Calls callback(event) for each SSE event.
     // event: { type, id, path, method, etag, data }
-    //   type   "put" | "post" | "delete" | "lag" | "message" | "error"
+    //   type   "put" | "post" | "delete" | "lag" | "reset" | "message" | "error"
+    //          "reset": your lastEventId predates an engine restart; the
+    //          stream continues live. This SDK keeps no cursor — pass this
+    //          event's id as options.lastEventId on your next listen() call.
     //   data   raw multi-line data string (rarely needed; structured fields above suffice)
     // Returns: () => void (unsubscribe)
     listen(pattern, callback, options = {}) {

--- a/skills/elastik.skill/references/http-worlds.md
+++ b/skills/elastik.skill/references/http-worlds.md
@@ -249,12 +249,20 @@ data: method: DELETE
 event: lag
 data: missed: 12
 
+event: reset
+id: 7
+data: since: 500
+data: newest: 7
+
 : keepalive
 ```
 
 The server (`axum::Sse` with a 15-second `KeepAlive`) emits a `: keepalive`
-SSE comment on idle, a `lag` event when the listener falls behind, and a
-`put` / `delete` / similar event on each change.
+SSE comment on idle, a `lag` event when the listener falls behind or
+resumes from an id older than the replay ring retains, a `reset` event when
+the client's `Last-Event-ID` predates an engine restart (ids are
+process-local; the `id:` field rebases the client's cursor and the stream
+continues live), and a `put` / `delete` / similar event on each change.
 
 ### Client compatibility
 


### PR DESCRIPTION
## Ledger item 1.3 (cheap fix) — kill the silent event loss

Event ids are process-local: the counter resets to 0 on engine restart. A client resuming with `Last-Event-ID` saved before a restart previously got **no gap signal, empty replay, and a live filter that silently dropped every event** until the counter grew past the stale cursor. The wiki promised lag-as-safety-net; this bug bypassed exactly that signal — a published-contract violation.

## What this does

**Engine (core):**
- `replay_after` detects `since > last_issued_event_id` and yields the new non-terminal **`SubscriptionRecvError::CursorAhead { since, newest }`** as the first `recv()` result, then continues live-only (`live_floor = 0`, nothing id-filtered; subscribe pattern still applies).
- The counter is read **under the event_log lock** — writers push under the same lock after allocating, so the check cannot misfire for any cursor whose event is visible to replay. Zero false positives within a boot (ids are allocated before publish).
- Internal `ReplayInterruption` enum (Lagged | CursorAhead only): the production queueing path cannot represent a fake terminal `Closed`.

**SSE adapter (bin):**
- New `reset` wire frame via `sse_reset_event`: `event: reset` / `id: <newest>` / two `data:` lines (`since:`, `newest:`). The `id:` field **rebases a standard EventSource's Last-Event-ID** into the current id space, so auto-reconnect resumes via normal ring replay instead of looping on reset (WHATWG: id updates apply on named events).
- MQTT: explicit defensive arm, commented as currently unreachable (adapter always subscribes `since=None`).
- FFI: wildcard `Unknown`+close retained as documented interim until the epoch work designs the cross-adapter resync contract.

**Contract surfaces:** sdk-js `ListenEventType` union + README + listen() comment; `http-worlds.md` frame list (lag prose now covers both triggers). Wiki updates (Across Restarts section, Audit-Chain Limits & Anchoring) are staged on the wiki repo branch `draft/cursor-ahead-docs` for review.

## Known limitation (by design of the cheap fix)

A pre-restart cursor that the new counter has **already grown past** is undetectable until boot epochs are persisted (ledger: 1.3 正确修). The wiki documents this gap explicitly, including the possibly-an-ordinary-lag nuance.

## Review provenance

4 rounds of multi-agent Monte Carlo review to convergence (5 blind scientist lenses per round, 2 adversarial skeptics per finding, fresh agents every round):
- **R1**: 1×P1 + 4×P2 confirmed (undocumented wire contract, missing id rebase, doc contradictions, hang-prone test) → fixed
- **R2**: 4×P2 confirmed (zero wire-mapping test coverage, comma-packed data line, wiki overclaim, headers-mechanism prose) → fixed
- **R3**: 4×P2 confirmed — incl. two **real pre-existing engine gaps** surfaced by doc-precision review: live `meta_headers` view not covered by any verification surface, and `meta_sha256` canonical form lacks length prefixes (NUL-boundary collision). Both documented in the wiki and ledger'd (L1 scope / chain-format migration) → fixed
- **R4**: **zero confirmed findings** across Popper/Noether/Mencius/Heisenberg ✅

Tests: core **99 passed** (4 `replay_after` units + e2e with recv timeouts — a regression now fails fast instead of hanging the suite); bin **110 passed** incl. a frame-shape unit test and a handler-level wire test that fails if the CursorAhead arm is deleted. fmt/clippy clean. `http-body-util` added as dev-dependency (already in Cargo.lock transitively via axum — zero new supply chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
