### PR TITLE
audit: expose chain_head() for external anchoring (anchoring stack 1/4)

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -278,6 +278,37 @@ struct EventHmacInput<'a> {
     meta_sha256: &'a str,
 }
 
+/// O(1) chain-head read through the SlotState-tracked read path: the
+/// newest event's `(id, hmac)` without re-walking the chain.
+///
+/// This is the unit of external anchoring (the O(1) subset of what
+/// `verify_chain_via_conn` reports as `latest`): a host that remembers the
+/// returned stamp can later prove tail truncation or rollback whenever the
+/// observed head is behind the anchored seq — which in-file verification
+/// structurally cannot. (A rolled-back or replaced chain re-grown past the
+/// anchor needs the at-seq divergence check, a later PR.) Returns
+/// `Ok(None)` for an empty chain (bootstrap-shape DB) — nothing to anchor
+/// yet.
+///
+/// Same type gate as `verify_chain_via_conn`: no bare-connection path, so
+/// a delete on the same world drains in-flight head reads via the usual
+/// SlotState write guard.
+pub fn chain_head_via_conn(
+    tracked: &mut crate::read_cache::TrackedReadConnection,
+) -> rusqlite::Result<Option<(i64, String)>> {
+    tracked
+        .as_mut_conn()
+        .query_row(
+            "SELECT id, hmac FROM events ORDER BY id DESC LIMIT 1",
+            [],
+            // hmac_label: same `hmac-` rendering as VerifyOk's
+            // genesis/latest, so a stamp compares byte-for-byte with
+            // what verify reports and what subscribers witness.
+            |r| Ok((r.get::<_, i64>(0)?, hmac_label(&r.get::<_, String>(1)?))),
+        )
+        .optional()
+}
+
 /// Verify the audit chain through a `TrackedReadConnection` (the
 /// SlotState-tracked read path). Mirrors `world::read_with_hmac_via_conn`
 /// -- the cache layer drives the slot-before-open dance and hands us

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -277,33 +277,14 @@ struct EventHmacInput<'a> {
     content_type: &'a str,
     meta_sha256: &'a str,
 }
-
-/// O(1) chain-head read through the SlotState-tracked read path: the
-/// newest event's `(id, hmac)` without re-walking the chain.
-///
-/// This is the unit of external anchoring (the O(1) subset of what
-/// `verify_chain_via_conn` reports as `latest`): a host that remembers the
-/// returned stamp can later prove tail truncation or rollback whenever the
-/// observed head is behind the anchored seq — which in-file verification
-/// structurally cannot. (A rolled-back or replaced chain re-grown past the
-/// anchor needs the at-seq divergence check, a later PR.) Returns
-/// `Ok(None)` for an empty chain (bootstrap-shape DB) — nothing to anchor
-/// yet.
-///
-/// Same type gate as `verify_chain_via_conn`: no bare-connection path, so
-/// a delete on the same world drains in-flight head reads via the usual
-/// SlotState write guard.
 pub fn chain_head_via_conn(
     tracked: &mut crate::read_cache::TrackedReadConnection,
 ) -> rusqlite::Result<Option<(i64, String)>> {
     tracked
         .as_mut_conn()
         .query_row(
-            "SELECT id, hmac FROM events ORDER BY id DESC LIMIT 1",
+            "SELECT (SELECT COUNT(*) FROM events), hmac FROM events ORDER BY id DESC LIMIT 1",
             [],
-            // hmac_label: same `hmac-` rendering as VerifyOk's
-            // genesis/latest, so a stamp compares byte-for-byte with
-            // what verify reports and what subscribers witness.
             |r| Ok((r.get::<_, i64>(0)?, hmac_label(&r.get::<_, String>(1)?))),
         )
         .optional()

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -101,7 +101,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     check_preconditions(core, &permit.world, &req.preconditions.into())?;
 
     let Some(stage) = core
-        .read_world(world_name)
+        .read_world(&permit.world)
         .map_err(|err| classify_storage_error("storage read", &permit.world, err))?
     else {
         return Err(DeleteError::NotFound);
@@ -222,7 +222,7 @@ fn check_preconditions(
         return Ok(());
     }
     let current = core
-        .read_world_with_etag(world.as_str())
+        .read_world_with_etag(world)
         .map_err(|err| classify_storage_error("precondition read", world, err))?;
     let current_tag = current.as_ref().map(|(_, etag)| etag.as_str());
     etag::check_preconditions(preconditions, current_tag)

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -146,6 +146,34 @@ pub enum AuditVerify {
     NotApplicable,
 }
 
+/// The audit chain's current head: the newest event's sequence number and
+/// chain HMAC. Returned by [`crate::Engine::chain_head`].
+///
+/// This is the unit of external anchoring. In-file verification proves
+/// "nobody tampered with what is here"; it structurally cannot prove
+/// "everything that happened is here" — every non-empty prefix of a valid
+/// chain is itself a valid chain, and a rolled-back file is self-
+/// consistent. A host that remembers a `HeadStamp` (on another machine, a
+/// subscriber, an RFC 3161 timestamp) can later **prove** truncation or
+/// rollback whenever the observed head is behind the anchored `seq`. A
+/// rolled-back or replaced (deleted-and-recreated) chain that has re-grown
+/// past the anchor is not caught by the seq comparison alone
+/// (`sqlite_sequence` rolls back with the file, so ids are reissued);
+/// catching that requires comparing the hmac at the anchored seq — the
+/// divergence check, a later PR in this stack.
+///
+/// When the chain verifies, `hmac` equals [`AuditValid::latest`] — the
+/// stamp is the O(1) subset of a full [`crate::Engine::verify_audit`]
+/// walk.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeadStamp {
+    /// Sequence number (rowid) of the newest event on the chain.
+    pub seq: i64,
+    /// Chain HMAC of the newest event.
+    pub hmac: String,
+}
+
 struct IntrospectionPermit {
     path: ValidatedProcPath,
 }
@@ -455,6 +483,36 @@ impl EngineOps<'_> {
         }
     }
 
+    pub(crate) fn chain_head(
+        &self,
+        world: &ValidatedWorldPath,
+        tier: auth::Tier,
+    ) -> Result<Option<HeadStamp>, EngineError> {
+        if !crate::can_read(self.core(), tier) {
+            return Err(EngineError::Auth(AuthGate::Read));
+        }
+        if store::is_memory_world(world.as_str()) {
+            if !self.core().mem.contains(world.as_str()) {
+                return Err(EngineError::NotFound);
+            }
+            // Memory worlds have no audit chain: nothing to anchor.
+            return Ok(None);
+        }
+        match self.core().cached_chain_head(world.as_str()) {
+            Ok(Some(Some((seq, hmac)))) => Ok(Some(HeadStamp { seq, hmac })),
+            // Existing DB with an empty chain (bootstrap shape): nothing to
+            // anchor yet.
+            Ok(Some(None)) => Ok(None),
+            Ok(None) => Err(EngineError::NotFound),
+            Err(err) => Err(storage_error_to_engine(
+                "chain head",
+                err,
+                "chain_head",
+                Some(world.as_str()),
+            )),
+        }
+    }
+
     fn authorize_introspection(
         &self,
         path: &ValidatedProcPath,
@@ -571,6 +629,51 @@ impl Engine {
     ) -> Result<AuditVerify, EngineError> {
         let path = ValidatedProcPath::audit_verify(world.clone());
         EngineOps::new(self.core()).verify_audit(&path, tier.into())
+    }
+
+    /// Returns the audit chain's current head for external anchoring.
+    ///
+    /// This is a synchronous, O(1) API: it reads the newest event's
+    /// sequence number and chain HMAC through the cached read path without
+    /// walking the chain. It does **not** verify the chain — pair it with
+    /// [`Engine::verify_audit`] when integrity matters; when the chain
+    /// verifies, [`HeadStamp::hmac`] equals [`AuditValid::latest`].
+    ///
+    /// Push the returned stamp somewhere — ideally somewhere this machine
+    /// cannot rewrite (another host, a subscriber, an RFC 3161 timestamp;
+    /// the further from this machine, the stronger the guarantee). A later
+    /// head whose `seq` went backwards proves truncation or rollback that
+    /// in-file verification cannot detect — and so does a durable world
+    /// that previously had a stamp **persistently** returning `Ok(None)`
+    /// or [`EngineError::NotFound`] (total truncation or deletion). A
+    /// delete in flight also reads as `NotFound`, and a delete that failed
+    /// before touching the chain file restores the head — re-poll before
+    /// treating a single `NotFound` observation as loss.
+    ///
+    /// This method applies the read gate directly and intentionally
+    /// bypasses proc-path authorization; do not expose it directly as a
+    /// network endpoint (the proc endpoint comes in a later PR of this
+    /// stack).
+    ///
+    /// # Returns
+    /// - `Ok(Some(HeadStamp))` — the durable world's current chain head.
+    /// - `Ok(None)` — the world exists but has no chain head to anchor:
+    ///   an in-memory world (no audit chain) or an empty bootstrap-shape
+    ///   chain. Note: [`Engine::verify_audit`] reports an existing durable
+    ///   world with an empty chain as `Broken` (`no-events`) — `Ok(None)`
+    ///   here is not a clean bill of health.
+    ///
+    /// # Errors
+    /// - [`EngineError::Auth`] if `tier` is below `Read`.
+    /// - [`EngineError::NotFound`] if `world` does not exist.
+    /// - [`EngineError::TransientStorage`] / [`EngineError::Storage`] /
+    ///   [`EngineError::InsufficientStorage`] for storage failures.
+    pub fn chain_head(
+        &self,
+        world: &ValidatedWorldPath,
+        tier: AccessTier,
+    ) -> Result<Option<HeadStamp>, EngineError> {
+        EngineOps::new(self.core()).chain_head(world, tier.into())
     }
 }
 
@@ -761,6 +864,109 @@ mod tests {
                 "proc permit endpoint mismatch"
             ))
         ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn chain_head_is_the_o1_subset_of_verify() {
+        let root = temp_root("chain-head");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
+            .read_token(b"reader".to_vec())
+            .build()
+            .unwrap();
+        let disk = ValidatedWorldPath::new("home/anchored").unwrap();
+        let memory = ValidatedWorldPath::new("tmp/anchored").unwrap();
+
+        assert!(matches!(
+            engine.chain_head(&disk, AccessTier::Anon),
+            Err(EngineError::Auth(AuthGate::Read))
+        ));
+        assert!(matches!(
+            engine.chain_head(&disk, AccessTier::Read),
+            Err(EngineError::NotFound)
+        ));
+
+        for body in [b"one".as_slice(), b"two", b"three"] {
+            engine
+                .replace(
+                    &disk,
+                    Representation::new(Bytes::copy_from_slice(body), "text/plain", Vec::new()),
+                    Preconditions::none(),
+                    AccessTier::Write,
+                )
+                .await
+                .unwrap();
+        }
+        engine
+            .replace(
+                &memory,
+                Representation::new(Bytes::from_static(b"ram"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let head = engine
+            .chain_head(&disk, AccessTier::Read)
+            .unwrap()
+            .expect("durable world has a chain head");
+        let AuditVerify::Valid(valid) = engine.verify_audit(&disk, AccessTier::Read).unwrap()
+        else {
+            panic!("chain must verify");
+        };
+        // The stamp is the O(1) subset of a full verify walk.
+        assert_eq!(head.hmac, valid.latest);
+        assert_eq!(head.seq, valid.events as i64);
+
+        // Memory world exists but has no chain to anchor. The auth gate
+        // must also hold on the memory path (pins gate-before-branch).
+        assert!(matches!(
+            engine.chain_head(&memory, AccessTier::Anon),
+            Err(EngineError::Auth(AuthGate::Read))
+        ));
+        assert_eq!(engine.chain_head(&memory, AccessTier::Read).unwrap(), None);
+        let missing_memory = ValidatedWorldPath::new("tmp/anchored-missing").unwrap();
+        assert!(matches!(
+            engine.chain_head(&missing_memory, AccessTier::Read),
+            Err(EngineError::NotFound)
+        ));
+
+        // Bootstrap-shape durable DB (schema committed, zero events):
+        // nothing to anchor — while verify_audit reports the same state
+        // as Broken (no-events). The contrast is documented on the
+        // chain_head facade.
+        drop(crate::world::open(&engine.core().data, "home/anchored-bootstrap").unwrap());
+        let bootstrap = ValidatedWorldPath::new("home/anchored-bootstrap").unwrap();
+        assert_eq!(
+            engine.chain_head(&bootstrap, AccessTier::Read).unwrap(),
+            None
+        );
+        assert!(matches!(
+            engine.verify_audit(&bootstrap, AccessTier::Read).unwrap(),
+            AuditVerify::Broken(b) if b.actual == "no-events"
+        ));
+
+        // The head advances with the chain and never repeats.
+        engine
+            .replace(
+                &disk,
+                Representation::new(Bytes::from_static(b"four"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        let advanced = engine
+            .chain_head(&disk, AccessTier::Read)
+            .unwrap()
+            .expect("head persists after another write");
+        assert_eq!(advanced.seq, head.seq + 1);
+        assert_ne!(advanced.hmac, head.hmac);
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -146,29 +146,29 @@ pub enum AuditVerify {
     NotApplicable,
 }
 
-/// The audit chain's current head: the newest event's sequence number and
-/// chain HMAC. Returned by [`crate::Engine::chain_head`].
+/// The audit chain's current head: the number of events currently in the
+/// chain and the newest event's chain HMAC. Returned by
+/// [`crate::Engine::chain_head`].
 ///
 /// This is the unit of external anchoring. In-file verification proves
 /// "nobody tampered with what is here"; it structurally cannot prove
 /// "everything that happened is here" — every non-empty prefix of a valid
-/// chain is itself a valid chain, and a rolled-back file is self-
-/// consistent. A host that remembers a `HeadStamp` (on another machine, a
-/// subscriber, an RFC 3161 timestamp) can later **prove** truncation or
-/// rollback whenever the observed head is behind the anchored `seq`. A
-/// rolled-back or replaced (deleted-and-recreated) chain that has re-grown
-/// past the anchor is not caught by the seq comparison alone
-/// (`sqlite_sequence` rolls back with the file, so ids are reissued);
-/// catching that requires comparing the hmac at the anchored seq — the
-/// divergence check, a later PR in this stack.
+/// chain is itself a valid chain, and a rolled-back file is
+/// self-consistent. A host that remembers a `HeadStamp` (on another machine,
+/// a subscriber, an RFC 3161 timestamp) can later **prove** truncation or
+/// rollback whenever the observed event count is behind the anchored `seq`.
+/// A rolled-back or replaced (deleted-and-recreated) chain that has re-grown
+/// past the anchor is not caught by the seq comparison alone; catching that
+/// requires comparing the hmac at the anchored seq -- the divergence check,
+/// a later PR in this stack.
 ///
-/// When the chain verifies, `hmac` equals [`AuditValid::latest`] — the
-/// stamp is the O(1) subset of a full [`crate::Engine::verify_audit`]
-/// walk.
+/// When the chain verifies, `seq` equals [`AuditValid::events`] and `hmac`
+/// equals [`AuditValid::latest`]. `seq` is not a raw SQLite rowid; rowids are
+/// mutable storage detail, not an anchoring contract.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeadStamp {
-    /// Sequence number (rowid) of the newest event on the chain.
+    /// Number of events currently on the chain.
     pub seq: i64,
     /// Chain HMAC of the newest event.
     pub hmac: String,
@@ -466,7 +466,7 @@ impl EngineOps<'_> {
             }
             return Ok(AuditVerify::NotApplicable);
         }
-        match self.core().cached_verify_chain(world.as_str()) {
+        match self.core().cached_verify_chain(world) {
             Ok(Some(crate::audit::VerifyReport::Valid(report))) => {
                 Ok(AuditVerify::Valid(report.into()))
             }
@@ -498,7 +498,7 @@ impl EngineOps<'_> {
             // Memory worlds have no audit chain: nothing to anchor.
             return Ok(None);
         }
-        match self.core().cached_chain_head(world.as_str()) {
+        match self.core().cached_chain_head(world) {
             Ok(Some(Some((seq, hmac)))) => Ok(Some(HeadStamp { seq, hmac })),
             // Existing DB with an empty chain (bootstrap shape): nothing to
             // anchor yet.
@@ -633,11 +633,12 @@ impl Engine {
 
     /// Returns the audit chain's current head for external anchoring.
     ///
-    /// This is a synchronous, O(1) API: it reads the newest event's
-    /// sequence number and chain HMAC through the cached read path without
-    /// walking the chain. It does **not** verify the chain — pair it with
+    /// This is a synchronous API: it reads the current event count and
+    /// newest event HMAC through the cached read path without re-computing
+    /// every HMAC. It does **not** verify the chain -- pair it with
     /// [`Engine::verify_audit`] when integrity matters; when the chain
-    /// verifies, [`HeadStamp::hmac`] equals [`AuditValid::latest`].
+    /// verifies, [`HeadStamp::seq`] equals [`AuditValid::events`] and
+    /// [`HeadStamp::hmac`] equals [`AuditValid::latest`].
     ///
     /// Push the returned stamp somewhere — ideally somewhere this machine
     /// cannot rewrite (another host, a subscriber, an RFC 3161 timestamp;
@@ -870,7 +871,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chain_head_is_the_o1_subset_of_verify() {
+    async fn chain_head_matches_verify_head_without_trusting_rowid() {
         let root = temp_root("chain-head");
         let engine = Engine::builder()
             .data_root(root.clone())
@@ -919,9 +920,15 @@ mod tests {
         else {
             panic!("chain must verify");
         };
-        // The stamp is the O(1) subset of a full verify walk.
+        // The stamp is the cheap subset of a full verify walk.
         assert_eq!(head.hmac, valid.latest);
         assert_eq!(head.seq, valid.events as i64);
+        let max_id: i64 =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, disk.as_str()))
+                .unwrap()
+                .query_row("SELECT MAX(id) FROM events", [], |row| row.get(0))
+                .unwrap();
+        assert_eq!(head.seq, max_id);
 
         // Memory world exists but has no chain to anchor. The auth gate
         // must also hold on the memory path (pins gate-before-branch).
@@ -967,6 +974,62 @@ mod tests {
             .expect("head persists after another write");
         assert_eq!(advanced.seq, head.seq + 1);
         assert_ne!(advanced.hmac, head.hmac);
+
+        // `seq` is the event count, not a mutable SQLite rowid. A truncated
+        // but otherwise self-consistent prefix cannot hide rollback by
+        // inflating the surviving tail event id.
+        let tampered = ValidatedWorldPath::new("home/anchored-rowid-tamper").unwrap();
+        for body in [
+            Bytes::from_static(b"one"),
+            Bytes::from_static(b"two"),
+            Bytes::from_static(b"three"),
+        ] {
+            engine
+                .replace(
+                    &tampered,
+                    Representation::new(body, "text/plain", Vec::new()),
+                    Preconditions::none(),
+                    AccessTier::Write,
+                )
+                .await
+                .unwrap();
+        }
+        {
+            let c = rusqlite::Connection::open(crate::world::world_db(
+                &engine.core().data,
+                tampered.as_str(),
+            ))
+            .unwrap();
+            c.execute(
+                "DELETE FROM events WHERE id = (SELECT MAX(id) FROM events)",
+                [],
+            )
+            .unwrap();
+            c.execute(
+                "UPDATE events SET id = 100 WHERE id = (SELECT MAX(id) FROM events)",
+                [],
+            )
+            .unwrap();
+        }
+        let tampered_head = engine
+            .chain_head(&tampered, AccessTier::Read)
+            .unwrap()
+            .expect("tampered prefix still has a head");
+        let AuditVerify::Valid(tampered_valid) =
+            engine.verify_audit(&tampered, AccessTier::Read).unwrap()
+        else {
+            panic!("prefix remains HMAC-valid");
+        };
+        assert_eq!(tampered_head.seq, 2);
+        assert_eq!(tampered_head.seq, tampered_valid.events as i64);
+        assert_eq!(tampered_head.hmac, tampered_valid.latest);
+
+        engine.core().install_tombstone(disk.as_str()).await;
+        assert!(matches!(
+            engine.chain_head(&disk, AccessTier::Read),
+            Err(EngineError::NotFound)
+        ));
+        engine.core().clear_tombstone(disk.as_str());
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -202,8 +202,8 @@ pub use engine::ShutdownToken;
 pub use engine::{Engine, EngineBuildError, EngineBuilder, EngineError};
 #[cfg(feature = "unstable-engine")]
 pub use engine_introspection::{
-    AuditBroken, AuditValid, AuditVerify, DfSnapshot, InvalidProcPath, PoolSnapshot, ProcEndpoint,
-    ValidatedProcPath, WorldUsage,
+    AuditBroken, AuditValid, AuditVerify, DfSnapshot, HeadStamp, InvalidProcPath, PoolSnapshot,
+    ProcEndpoint, ValidatedProcPath, WorldUsage,
 };
 #[cfg(feature = "unstable-engine")]
 pub use engine_trace::{DeleteMetadata, EngineDeleteTraceHooks, EngineWriteTraceHooks};

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -53,7 +53,7 @@ use std::time::Duration;
 use dashmap::DashMap;
 use rusqlite::{ffi::ErrorCode, Connection, OpenFlags};
 
-use crate::world;
+use crate::{engine_types::ValidatedWorldPath, world};
 
 /// Default ceiling on the number of cached read slots. Per-conn
 /// memory is bounded to ~250KB (PRAGMA cache_size=-200), so 5000
@@ -427,12 +427,12 @@ impl ReadCache {
     pub(crate) fn cached_read_with_hmac(
         &self,
         data: &std::path::Path,
-        world: &str,
+        world: &ValidatedWorldPath,
     ) -> rusqlite::Result<Option<(world::Stage, Option<String>)>> {
         self.with_tracked_conn(data, world, world::read_with_hmac_via_conn)
     }
 
-    /// O(1) chain-head read through the cached read path. Same
+    /// Chain-head read through the cached read path. Same
     /// SlotState protocol as `cached_verify_chain` -- delete drains
     /// in-flight head reads via the slot's write guard. Outer `None`
     /// means the world's DB is missing; inner `None` means the chain
@@ -440,7 +440,7 @@ impl ReadCache {
     pub(crate) fn cached_chain_head(
         &self,
         data: &std::path::Path,
-        world: &str,
+        world: &ValidatedWorldPath,
     ) -> rusqlite::Result<Option<Option<(i64, String)>>> {
         self.with_tracked_conn(data, world, crate::audit::chain_head_via_conn)
     }
@@ -453,7 +453,7 @@ impl ReadCache {
     pub(crate) fn cached_verify_chain(
         &self,
         data: &std::path::Path,
-        world: &str,
+        world: &ValidatedWorldPath,
         key: &crate::engine_types::AuditHmacKey,
     ) -> rusqlite::Result<Option<crate::audit::VerifyReport>> {
         let key = key.clone_secret();
@@ -474,12 +474,13 @@ impl ReadCache {
     fn with_tracked_conn<F, R>(
         &self,
         data: &std::path::Path,
-        world: &str,
+        world: &ValidatedWorldPath,
         f: F,
     ) -> rusqlite::Result<Option<R>>
     where
         F: FnOnce(&mut TrackedReadConnection) -> rusqlite::Result<R>,
     {
+        let world = world.as_str();
         let path = world::world_db(data, world);
         let mut f = Some(f);
         let mut counted_miss = false;
@@ -805,6 +806,10 @@ mod tests {
             .unwrap()
     }
 
+    fn v(world: &str) -> crate::engine_types::ValidatedWorldPath {
+        crate::engine_types::ValidatedWorldPath::new(world).unwrap()
+    }
+
     fn scratch_dir(label: &str) -> PathBuf {
         let mut d = std::env::temp_dir();
         d.push(format!(
@@ -828,12 +833,12 @@ mod tests {
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
 
-        let r1 = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let r1 = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(r1.is_some());
         assert_eq!(cache.metrics.read_cache_hits.load(Ordering::Relaxed), 0);
         assert_eq!(cache.metrics.read_cache_misses.load(Ordering::Relaxed), 1);
 
-        let r2 = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let r2 = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(r2.is_some());
         assert_eq!(cache.metrics.read_cache_hits.load(Ordering::Relaxed), 1);
         assert_eq!(cache.metrics.read_cache_misses.load(Ordering::Relaxed), 1);
@@ -850,7 +855,7 @@ mod tests {
         }
 
         let cache = ReadCache::new(2);
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
         let a_first = cache
             .read_conns
             .get("home/a")
@@ -858,7 +863,7 @@ mod tests {
             .last_access
             .load(Ordering::Relaxed);
 
-        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/b")).unwrap();
         let b_first = cache
             .read_conns
             .get("home/b")
@@ -870,7 +875,7 @@ mod tests {
             "later insert should receive a newer access tick"
         );
 
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
         let a_second = cache
             .read_conns
             .get("home/a")
@@ -889,7 +894,7 @@ mod tests {
     fn missing_world_returns_none_via_phase3() {
         let dir = scratch_dir("missing");
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        let r = cache.cached_read_with_hmac(&dir, "home/none").unwrap();
+        let r = cache.cached_read_with_hmac(&dir, &v("home/none")).unwrap();
         assert!(r.is_none());
         assert!(cache.read_conns.get("home/none").is_none());
         let _ = std::fs::remove_dir_all(&dir);
@@ -903,13 +908,13 @@ mod tests {
         world::write(&dir, world, b"x", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         cache.install_tombstone_blocking(world);
-        let r = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let r = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(r.is_none());
 
         cache.clear_tombstone(world);
-        let r2 = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let r2 = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(r2.is_some());
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -924,12 +929,12 @@ mod tests {
         }
 
         let cache = ReadCache::new(2);
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
-        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/b")).unwrap();
         assert_eq!(cache.read_conns.len(), 2);
         assert_eq!(cache.metrics.read_cache_capped.load(Ordering::Relaxed), 0);
 
-        let r = cache.cached_read_with_hmac(&dir, "home/c").unwrap();
+        let r = cache.cached_read_with_hmac(&dir, &v("home/c")).unwrap();
         assert!(r.is_some());
         assert!(
             cache.read_conns.get("home/a").is_none(),
@@ -960,15 +965,15 @@ mod tests {
         }
 
         let cache = ReadCache::new(2);
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
-        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/b")).unwrap();
 
         let a_arc = cache.read_conns.get("home/a").unwrap().value().clone();
         let b_arc = cache.read_conns.get("home/b").unwrap().value().clone();
         let a_guard = a_arc.inner.read().unwrap();
         let b_guard = b_arc.inner.read().unwrap();
 
-        let r = cache.cached_read_with_hmac(&dir, "home/c").unwrap();
+        let r = cache.cached_read_with_hmac(&dir, &v("home/c")).unwrap();
         assert!(r.is_some());
         assert!(cache.read_conns.get("home/c").is_none());
         assert!(cache.read_conns.get("home/a").is_some());
@@ -1000,7 +1005,7 @@ mod tests {
 
         let cache = ReadCache::new(1);
         for (idx, w) in worlds.iter().enumerate() {
-            let read = cache.cached_read_with_hmac(&dir, w).unwrap();
+            let read = cache.cached_read_with_hmac(&dir, &v(w)).unwrap();
             let (stage, _hmac) = read.expect("existing world must not look missing at cap=1");
             assert_eq!(stage.body, vec![b'a' + idx as u8]);
             assert!(
@@ -1045,7 +1050,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 for _ in 0..8 {
                     let read = cache
-                        .cached_read_with_hmac(&dir, world)
+                        .cached_read_with_hmac(&dir, &v(world))
                         .expect("cache-size-one concurrent read");
                     let (stage, _hmac) =
                         read.expect("existing world must not look missing at cache size 1");
@@ -1074,10 +1079,10 @@ mod tests {
         }
 
         let cache = ReadCache::new(2);
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
-        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/b")).unwrap();
         let hits_before = cache.metrics.read_cache_hits.load(Ordering::Relaxed);
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
         let hits_after = cache.metrics.read_cache_hits.load(Ordering::Relaxed);
         assert_eq!(hits_after, hits_before + 1);
         assert_eq!(cache.metrics.read_cache_capped.load(Ordering::Relaxed), 0);
@@ -1112,7 +1117,7 @@ mod tests {
             .read_conns
             .insert(world.to_string(), cache.new_slot(SlotState::Evicted));
 
-        let read = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let read = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         let (stage, _hmac) = read.expect("evicted cache slot must reopen existing world");
         assert_eq!(stage.body, b"still here");
         assert_eq!(
@@ -1141,7 +1146,7 @@ mod tests {
         world::write(&dir, world, b"busy", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         let arc = cache.read_conns.get(world).unwrap().value().clone();
         let read_guard = arc.inner.read().unwrap();
 
@@ -1166,7 +1171,7 @@ mod tests {
         world::write(&dir, world, b"idle", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         let arc = cache.read_conns.get(world).unwrap().value().clone();
 
         assert!(
@@ -1191,7 +1196,7 @@ mod tests {
         world::write(&dir, world, b"stale", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         let stale_arc = cache.read_conns.get(world).unwrap().value().clone();
         cache
             .read_conns
@@ -1222,7 +1227,7 @@ mod tests {
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         cache.install_tombstone_blocking(world);
-        let tombstone = cache.cached_read_with_hmac(&dir, world).unwrap();
+        let tombstone = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(tombstone.is_none());
         assert_eq!(
             cache.metrics.read_cache_hits.load(Ordering::Relaxed),
@@ -1267,7 +1272,7 @@ mod tests {
             .read_conns
             .insert(world.to_string(), cache.new_slot(SlotState::Opening));
 
-        let err = match cache.cached_read_with_hmac(&dir, world) {
+        let err = match cache.cached_read_with_hmac(&dir, &v(world)) {
             Ok(Some(_)) => panic!("stuck Opening must not resolve as a body"),
             Ok(None) => panic!("stuck Opening must not report a false 404"),
             Err(err) => err,
@@ -1295,7 +1300,7 @@ mod tests {
         }
 
         let cache = ReadCache::new(2);
-        let _ = cache.cached_read_with_hmac(&dir, "home/ready").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/ready")).unwrap();
         cache.install_tombstone_blocking("home/tomb");
 
         assert!(
@@ -1307,7 +1312,7 @@ mod tests {
             cache.read_conns.get("home/tomb").is_some(),
             "Tombstone is delete state, not an LRU eviction candidate"
         );
-        let tombstone_read = cache.cached_read_with_hmac(&dir, "home/tomb").unwrap();
+        let tombstone_read = cache.cached_read_with_hmac(&dir, &v("home/tomb")).unwrap();
         assert!(tombstone_read.is_none());
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1322,9 +1327,9 @@ mod tests {
         }
 
         let cache = ReadCache::new(3);
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
-        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
-        let _ = cache.cached_read_with_hmac(&dir, "home/c").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/b")).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/c")).unwrap();
 
         let a_arc = cache.read_conns.get("home/a").unwrap().value().clone();
         let b_arc = cache.read_conns.get("home/b").unwrap().value().clone();
@@ -1382,7 +1387,7 @@ mod tests {
 
         // Phase 3 lazy-init: first verify warms the cache.
         let key = test_key();
-        let r1 = cache.cached_verify_chain(&dir, world, &key).unwrap();
+        let r1 = cache.cached_verify_chain(&dir, &v(world), &key).unwrap();
         assert!(matches!(r1, Some(crate::audit::VerifyReport::Valid(_))));
         assert!(
             cache.read_conns.get(world).is_some(),
@@ -1392,18 +1397,18 @@ mod tests {
         );
 
         // Phase 1 cache hit: second verify reuses the cached slot.
-        let r2 = cache.cached_verify_chain(&dir, world, &key).unwrap();
+        let r2 = cache.cached_verify_chain(&dir, &v(world), &key).unwrap();
         assert!(matches!(r2, Some(crate::audit::VerifyReport::Valid(_))));
 
         // Tombstone short-circuits verify (delete intent).
         cache.install_tombstone_blocking(world);
-        let r3 = cache.cached_verify_chain(&dir, world, &key).unwrap();
+        let r3 = cache.cached_verify_chain(&dir, &v(world), &key).unwrap();
         assert!(r3.is_none());
 
         // After clear_tombstone the next verify re-opens through
         // Phase 3 lazy-init.
         cache.clear_tombstone(world);
-        let r4 = cache.cached_verify_chain(&dir, world, &key).unwrap();
+        let r4 = cache.cached_verify_chain(&dir, &v(world), &key).unwrap();
         assert!(matches!(r4, Some(crate::audit::VerifyReport::Valid(_))));
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1434,8 +1439,8 @@ mod tests {
 
         // cap=2 -> A and B fill it; C must go through transient.
         let cache = StdArc::new(ReadCache::new(2));
-        let _ = cache.cached_read_with_hmac(&dir, "home/a").unwrap();
-        let _ = cache.cached_read_with_hmac(&dir, "home/b").unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/a")).unwrap();
+        let _ = cache.cached_read_with_hmac(&dir, &v("home/b")).unwrap();
         let a_arc = cache.read_conns.get("home/a").unwrap().value().clone();
         let b_arc = cache.read_conns.get("home/b").unwrap().value().clone();
         let a_guard = a_arc.inner.read().unwrap();
@@ -1465,7 +1470,9 @@ mod tests {
             let cache = cache.clone();
             let dir = dir.clone();
             handles.push(thread::spawn(move || {
-                cache.cached_read_with_hmac(&dir, "home/c").expect("read")
+                cache
+                    .cached_read_with_hmac(&dir, &v("home/c"))
+                    .expect("read")
             }));
         }
         for h in handles {
@@ -1520,7 +1527,7 @@ mod tests {
         std::fs::set_permissions(&db_path, perms).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        let result = cache.cached_read_with_hmac(&dir, world);
+        let result = cache.cached_read_with_hmac(&dir, &v(world));
 
         // path.try_exists() returns Ok(true) for the still-on-disk
         // (but unreadable) file. The CANTOPEN error must propagate

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -432,6 +432,19 @@ impl ReadCache {
         self.with_tracked_conn(data, world, world::read_with_hmac_via_conn)
     }
 
+    /// O(1) chain-head read through the cached read path. Same
+    /// SlotState protocol as `cached_verify_chain` -- delete drains
+    /// in-flight head reads via the slot's write guard. Outer `None`
+    /// means the world's DB is missing; inner `None` means the chain
+    /// is empty (bootstrap shape).
+    pub(crate) fn cached_chain_head(
+        &self,
+        data: &std::path::Path,
+        world: &str,
+    ) -> rusqlite::Result<Option<Option<(i64, String)>>> {
+        self.with_tracked_conn(data, world, crate::audit::chain_head_via_conn)
+    }
+
     /// Verify the audit chain through the cached read path (Bug 58).
     /// Same SlotState protocol as `cached_read_with_hmac` -- delete
     /// drains in-flight verifies via the slot's write guard. Closes

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -148,7 +148,7 @@ impl Core {
         lock.lock_owned().await
     }
 
-    pub(crate) fn read_world(&self, world: &str) -> rusqlite::Result<Option<Stage>> {
+    pub(crate) fn read_world(&self, world: &ValidatedWorldPath) -> rusqlite::Result<Option<Stage>> {
         Ok(self.read_world_with_etag(world)?.map(|(stage, _)| stage))
     }
 
@@ -159,12 +159,13 @@ impl Core {
     /// `std::sync::RwLock`, matching the existing handler call shape.
     pub(crate) fn read_world_with_etag(
         &self,
-        world: &str,
+        world: &ValidatedWorldPath,
     ) -> rusqlite::Result<Option<(Stage, String)>> {
-        if store::is_memory_world(world) {
+        let world_name = world.as_str();
+        if store::is_memory_world(world_name) {
             Ok(self
                 .mem
-                .read_with_hash(world)
+                .read_with_hash(world_name)
                 .map(|(stage, hash)| (stage, format!("sha256-{hash}"))))
         } else {
             Ok(self
@@ -205,17 +206,17 @@ impl Core {
         self.read_cache.clear_tombstone(world);
     }
 
-    /// O(1) chain-head read through the read-cache SlotState protocol.
+    /// Chain-head read through the read-cache SlotState protocol.
     /// Outer `None` = world DB missing (callers map to NotFound); inner
     /// `None` = empty bootstrap-shape chain (nothing to anchor). Memory
     /// worlds have no audit chain; callers filter those before reaching
     /// here, same as `cached_verify_chain`.
     pub(crate) fn cached_chain_head(
         &self,
-        world: &str,
+        world: &ValidatedWorldPath,
     ) -> rusqlite::Result<Option<Option<(i64, String)>>> {
         debug_assert!(
-            !store::is_memory_world(world),
+            !store::is_memory_world(world.as_str()),
             "cached_chain_head only applies to durable worlds"
         );
         self.read_cache.cached_chain_head(&self.data, world)
@@ -230,10 +231,10 @@ impl Core {
     /// here.
     pub(crate) fn cached_verify_chain(
         &self,
-        world: &str,
+        world: &ValidatedWorldPath,
     ) -> rusqlite::Result<Option<audit::VerifyReport>> {
         debug_assert!(
-            !store::is_memory_world(world),
+            !store::is_memory_world(world.as_str()),
             "cached_verify_chain only applies to durable worlds"
         );
         self.read_cache

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -205,6 +205,22 @@ impl Core {
         self.read_cache.clear_tombstone(world);
     }
 
+    /// O(1) chain-head read through the read-cache SlotState protocol.
+    /// Outer `None` = world DB missing (callers map to NotFound); inner
+    /// `None` = empty bootstrap-shape chain (nothing to anchor). Memory
+    /// worlds have no audit chain; callers filter those before reaching
+    /// here, same as `cached_verify_chain`.
+    pub(crate) fn cached_chain_head(
+        &self,
+        world: &str,
+    ) -> rusqlite::Result<Option<Option<(i64, String)>>> {
+        debug_assert!(
+            !store::is_memory_world(world),
+            "cached_chain_head only applies to durable worlds"
+        );
+        self.read_cache.cached_chain_head(&self.data, world)
+    }
+
     /// Verify the audit chain through the read-cache SlotState
     /// protocol (Bug 58). Closes the gap that the bare
     /// `audit::verify_chain` path left: delete on the same world

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -283,7 +283,11 @@ pub fn list_all(data_root: &Path, mem: &MemoryStore) -> rusqlite::Result<Vec<Str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{audit, test_support::test_core};
+    use crate::{audit, engine_types::ValidatedWorldPath, test_support::test_core};
+
+    fn world_path(world: &str) -> ValidatedWorldPath {
+        ValidatedWorldPath::new(world).unwrap()
+    }
 
     #[test]
     fn worlds_store_content_type_not_private_extensions() {
@@ -291,7 +295,7 @@ mod tests {
         core.write_world("home/pdf", b"%PDF-1.7", "application/pdf", &[])
             .unwrap();
 
-        let stage = core.read_world("home/pdf").unwrap().unwrap();
+        let stage = core.read_world(&world_path("home/pdf")).unwrap().unwrap();
         assert_eq!(stage.content_type, "application/pdf");
         assert_eq!(stage.body, b"%PDF-1.7");
 
@@ -320,7 +324,10 @@ mod tests {
         )
         .unwrap();
 
-        let stage = core.read_world("tmp/scratch").unwrap().unwrap();
+        let stage = core
+            .read_world(&world_path("tmp/scratch"))
+            .unwrap()
+            .unwrap();
         assert_eq!(stage.body, b"draft");
         assert_eq!(stage.content_type, "text/plain; charset=utf-8");
         assert_eq!(
@@ -349,7 +356,10 @@ mod tests {
         )
         .unwrap();
 
-        let stage = core.read_world("home/report").unwrap().unwrap();
+        let stage = core
+            .read_world(&world_path("home/report"))
+            .unwrap()
+            .unwrap();
         assert_eq!(stage.body, b"final");
         assert!(world::world_db(&core.data, "home/report").exists());
         assert_eq!(audit::latest_hmac(&core.data, "home/report"), Some(h));

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -188,7 +188,7 @@ pub(crate) fn read_world_for(
     if &permit.world != world {
         return Err(ReadError::PermitWorldMismatch);
     }
-    match core.read_world_with_etag(world.as_str()) {
+    match core.read_world_with_etag(world) {
         Ok(Some((stage, etag))) => Ok(ReadOutcome::Found { stage, etag }),
         Ok(None) => Ok(ReadOutcome::Missing),
         Err(err) => Err(classify_read_error("storage read", err)),
@@ -202,7 +202,8 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
     hooks: &H,
 ) -> Result<WriteOutcome, WriteError> {
     ensure_write_permit(permit)?;
-    let world = permit.world.as_str();
+    let world_path = &permit.world;
+    let world = world_path.as_str();
     if req.body.len() > core.max_world_bytes {
         return Err(WriteError::PayloadTooLarge {
             max: core.max_world_bytes,
@@ -212,7 +213,7 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
     let _write_guard = core.acquire_world_lock(world).await;
     hooks.lock_acquired();
     core.clear_tombstone(world);
-    check_write_preconditions(core, world, &req.preconditions)?;
+    check_write_preconditions(core, world_path, &req.preconditions)?;
 
     let (existed, etag) = if store::is_persistent(world) {
         let prev_len_opt = world::body_len(&core.data, world).map_err(|err| {
@@ -297,11 +298,12 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
     hooks: &H,
 ) -> Result<WriteOutcome, WriteError> {
     ensure_write_permit(permit)?;
-    let world = permit.world.as_str();
+    let world_path = &permit.world;
+    let world = world_path.as_str();
     let _write_guard = core.acquire_world_lock(world).await;
     hooks.lock_acquired();
     core.clear_tombstone(world);
-    check_write_preconditions(core, world, &req.preconditions)?;
+    check_write_preconditions(core, world_path, &req.preconditions)?;
 
     let Some((body_len, content_type, stored_headers)) = (if store::is_memory_world(world) {
         core.mem.metadata(world)
@@ -399,7 +401,7 @@ fn ensure_write_permit(permit: &WritePermit) -> Result<(), WriteError> {
 
 fn check_write_preconditions(
     core: &Core,
-    world: &str,
+    world: &ValidatedWorldPath,
     preconditions: &etag::Preconditions,
 ) -> Result<(), WriteError> {
     if preconditions.is_empty() {
@@ -480,10 +482,16 @@ mod tests {
             .expect("permit writes only its bound world");
 
         assert_eq!(
-            core.read_world("home/permit-a").unwrap().unwrap().body,
+            core.read_world(&world_path("home/permit-a"))
+                .unwrap()
+                .unwrap()
+                .body,
             b"right-door"
         );
-        assert!(core.read_world("home/permit-b").unwrap().is_none());
+        assert!(core
+            .read_world(&world_path("home/permit-b"))
+            .unwrap()
+            .is_none());
 
         let _ = std::fs::remove_dir_all(dir);
     }


### PR DESCRIPTION
## Anchoring stack - PR 1 of 4: `chain_head()` head exposure

Ledger 1.1 PR1, repaired after fresh AGENTS.md enforcement review. In-file verification proves "nobody tampered with what is here" but structurally cannot prove "everything that happened is here": every non-empty prefix of a valid chain is itself a valid chain, and a rolled-back file is self-consistent. The remedy is external anchoring: the host remembers the chain head somewhere this machine cannot rewrite.

This PR ships only the head-exposure primitive. The at-seq divergence check, local anchor file / `ChainTruncated`, and builder knobs remain later stack layers.

## What this adds

- `audit::chain_head_via_conn` reads the current event count plus newest event HMAC through `TrackedReadConnection`. The query uses one SQLite statement, so the count and HMAC come from the same statement snapshot.
- `ReadCache::cached_chain_head` / `Core::cached_chain_head` mirror the `cached_verify_chain` SlotState path. Delete drains in-flight head reads; tombstone reads return `NotFound` at the Engine facade.
- `Engine::chain_head(world, tier) -> Result<Option<HeadStamp>, EngineError>` gates Read auth first, returns `Ok(None)` for memory worlds and empty bootstrap-shape durable DBs, returns `NotFound` for missing/tombstoned durable worlds, and maps storage failures through the normal Engine error classes.
- `HeadStamp { seq, hmac }` is exported under `unstable-engine`. `seq` is the number of events currently on the chain. It is deliberately not a SQLite rowid.
- Touched read/cache/precondition plumbing now carries `ValidatedWorldPath` down through `Core` and `ReadCache`; the new chain-head path does not unwrap to a raw string until the file/path primitive boundary.

## Detection model

- A later head with event count behind the anchored `seq` proves truncation or rollback.
- A persistent `Ok(None)` / `NotFound` after a previous stamp proves total loss, with normal re-poll caution around an in-flight delete.
- A rolled-back or replaced chain that has re-grown past the anchor is not caught by event-count comparison alone. That requires comparing the HMAC at the anchored seq, which is a later PR.
- `chain_head()` is not full verification. Pair it with `verify_audit()` when local integrity matters; when the chain verifies, `HeadStamp::seq == AuditValid::events` and `HeadStamp::hmac == AuditValid::latest`.

## Repair ledger

Original PR review found two real issues after the AGENTS.md/type-seal rules tightened:

- P2 type-seal leak: `chain_head` accepted `ValidatedWorldPath` at the facade but dropped to `&str` before the read-cache helper. Fixed by carrying `ValidatedWorldPath` through `Core::cached_chain_head`, `ReadCache::cached_chain_head`, and the shared tracked-read helper.
- P2 anchoring precondition bug: `seq` was SQLite rowid. Rowid is mutable and not HMAC-authenticated, so a truncated prefix could inflate the surviving id. Fixed by making `seq` the event count and adding a regression that deletes the tail event, rewrites the surviving max id to `100`, and still gets `seq == 2` with HMAC parity.

Fresh QA after repair:

- Hypatia, Mencius + HTTP-Type-Seal: PASS, no P0-P3. Confirmed `ValidatedWorldPath` reaches read-cache helper boundaries and `TrackedReadConnection` remains the SQL gate.
- Aquinas, Popper + Noether: PASS, no P0-P3. Confirmed the rowid counterexample is pinned and docs no longer overclaim rowid trust or full rollback detection.
- Anscombe, Bacon + QA-Enforcement: PASS, no P0-P2. Noted this body needed refresh before merge.

## Validation

Local before push:

- `cargo fmt --manifest-path core/Cargo.toml -- --check`
- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path core/Cargo.toml` -> 97 passed, 2 ignored, 5 doctests passed
- `cargo check --manifest-path bin/Cargo.toml`
- `cargo check --manifest-path ffi/Cargo.toml`
- `git diff --check`
- `audit.rs` production count: 497

Pre-push hook also passed the fast local gate stack: Rust format, clippy, core tests, bin tests, version consistency, bundled SQLite check, cargo audit for core/bin/ffi locks, Python SDK smoke, header policy scanner, JS syntax, and whitespace.
