### PR TITLE
timeline: add address contract types

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -179,6 +179,7 @@ mod storage_class;
 mod store;
 #[cfg(test)]
 mod test_support;
+mod timeline;
 mod world;
 mod world_ops;
 

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -96,7 +96,7 @@ impl TimelineBody {
 impl TimelineRead {
     pub(crate) fn body(address: TimelineAddress, representation: Representation) -> Self {
         let actual = crate::world::sha256_hex(&representation.body);
-        if actual != address.body_sha256().as_str() {
+        if !crate::auth::ct_eq(actual.as_bytes(), address.body_sha256().as_str().as_bytes()) {
             return Self::Corrupt {
                 address,
                 reason: TimelineCorruption::BodyHashMismatch,
@@ -154,12 +154,14 @@ impl WorldGeneration {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         &self.0
     }
 }
 
 impl TimelineSeq {
+    /// Internal SQLite `events.id` coordinate only. This is not an SSE `id`,
+    /// not `Last-Event-ID`, and not a durable external cursor by itself.
     pub(crate) fn new(raw: i64) -> Result<Self, InvalidTimelineSeq> {
         NonZeroI64::new(raw)
             .filter(|seq| seq.get() > 0)
@@ -167,7 +169,7 @@ impl TimelineSeq {
             .ok_or(InvalidTimelineSeq::NonPositive)
     }
 
-    pub(crate) fn get(self) -> i64 {
+    fn get(self) -> i64 {
         self.0.get()
     }
 }
@@ -184,7 +186,7 @@ impl BodySha256 {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -1,0 +1,409 @@
+//! Core timeline address contract for Path 3.
+//!
+//! This module intentionally defines only the typed contract. It does not read
+//! SQLite, retain CAS bodies, render HTTP, expose FFI, or implement migration.
+//! Later layers wire storage into these types.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::num::NonZeroI64;
+
+use crate::engine_types::{Representation, ValidatedWorldPath};
+
+/// Local Path 3 invariant: a world generation is a 128-bit identity rendered as
+/// 32 lowercase hexadecimal characters.
+const WORLD_GEN_HEX_LEN: usize = 32;
+/// FIPS 180-4 defines SHA-256 output as 256 bits; hex renders 4 bits per char.
+const BODY_SHA256_HEX_LEN: usize = 64;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TimelineAddress {
+    world: ValidatedWorldPath,
+    gen: WorldGeneration,
+    seq: TimelineSeq,
+    body_sha256: BodySha256,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorldGeneration(String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct TimelineSeq(NonZeroI64);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BodySha256(String);
+
+pub(crate) struct TimelineBody {
+    address: TimelineAddress,
+    representation: Representation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum InvalidWorldGeneration {
+    WrongLength,
+    NotLowerHex,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum InvalidTimelineSeq {
+    NonPositive,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum InvalidBodySha256 {
+    WrongLength,
+    NotLowerHex,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TimelineCorruption {
+    MissingBodyForPresentRow,
+    BodyHashMismatch,
+    InvalidEventShape,
+}
+
+pub(crate) enum TimelineRead {
+    Body(TimelineBody),
+    Expired {
+        address: TimelineAddress,
+    },
+    Gone {
+        address: TimelineAddress,
+    },
+    GenMismatch {
+        requested: TimelineAddress,
+        actual: WorldGeneration,
+    },
+    MissingRow {
+        address: TimelineAddress,
+    },
+    Corrupt {
+        address: TimelineAddress,
+        reason: TimelineCorruption,
+    },
+}
+
+impl TimelineBody {
+    pub(crate) fn address(&self) -> &TimelineAddress {
+        &self.address
+    }
+
+    pub(crate) fn representation(&self) -> &Representation {
+        &self.representation
+    }
+}
+
+impl TimelineRead {
+    pub(crate) fn body(address: TimelineAddress, representation: Representation) -> Self {
+        let actual = crate::world::sha256_hex(&representation.body);
+        if actual != address.body_sha256().as_str() {
+            return Self::Corrupt {
+                address,
+                reason: TimelineCorruption::BodyHashMismatch,
+            };
+        }
+
+        Self::Body(TimelineBody {
+            address,
+            representation,
+        })
+    }
+}
+
+impl TimelineAddress {
+    pub(crate) fn new(
+        world: ValidatedWorldPath,
+        gen: WorldGeneration,
+        seq: TimelineSeq,
+        body_sha256: BodySha256,
+    ) -> Self {
+        Self {
+            world,
+            gen,
+            seq,
+            body_sha256,
+        }
+    }
+
+    pub(crate) fn world(&self) -> &ValidatedWorldPath {
+        &self.world
+    }
+
+    pub(crate) fn gen(&self) -> &WorldGeneration {
+        &self.gen
+    }
+
+    pub(crate) fn seq(&self) -> TimelineSeq {
+        self.seq
+    }
+
+    pub(crate) fn body_sha256(&self) -> &BodySha256 {
+        &self.body_sha256
+    }
+}
+
+impl WorldGeneration {
+    pub(crate) fn new(raw: impl Into<String>) -> Result<Self, InvalidWorldGeneration> {
+        let raw = raw.into();
+        if raw.len() != WORLD_GEN_HEX_LEN {
+            return Err(InvalidWorldGeneration::WrongLength);
+        }
+        if !is_lower_hex(&raw) {
+            return Err(InvalidWorldGeneration::NotLowerHex);
+        }
+        Ok(Self(raw))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TimelineSeq {
+    pub(crate) fn new(raw: i64) -> Result<Self, InvalidTimelineSeq> {
+        NonZeroI64::new(raw)
+            .filter(|seq| seq.get() > 0)
+            .map(Self)
+            .ok_or(InvalidTimelineSeq::NonPositive)
+    }
+
+    pub(crate) fn get(self) -> i64 {
+        self.0.get()
+    }
+}
+
+impl BodySha256 {
+    pub(crate) fn new(raw: impl Into<String>) -> Result<Self, InvalidBodySha256> {
+        let raw = raw.into();
+        if raw.len() != BODY_SHA256_HEX_LEN {
+            return Err(InvalidBodySha256::WrongLength);
+        }
+        if !is_lower_hex(&raw) {
+            return Err(InvalidBodySha256::NotLowerHex);
+        }
+        Ok(Self(raw))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+
+    fn world() -> ValidatedWorldPath {
+        ValidatedWorldPath::new("home/timeline").unwrap()
+    }
+
+    fn gen() -> WorldGeneration {
+        WorldGeneration::new("0123456789abcdef0123456789abcdef").unwrap()
+    }
+
+    fn body_hash() -> BodySha256 {
+        BodySha256::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef").unwrap()
+    }
+
+    fn address(seq: i64) -> TimelineAddress {
+        TimelineAddress::new(world(), gen(), TimelineSeq::new(seq).unwrap(), body_hash())
+    }
+
+    fn address_for_body(seq: i64, body: &[u8]) -> TimelineAddress {
+        TimelineAddress::new(
+            world(),
+            gen(),
+            TimelineSeq::new(seq).unwrap(),
+            BodySha256::new(crate::world::sha256_hex(body)).unwrap(),
+        )
+    }
+
+    #[test]
+    fn timeline_address_carries_full_coordinate() {
+        let address =
+            TimelineAddress::new(world(), gen(), TimelineSeq::new(42).unwrap(), body_hash());
+
+        assert_eq!(address.world().as_str(), "home/timeline");
+        assert_eq!(address.gen().as_str(), "0123456789abcdef0123456789abcdef");
+        assert_eq!(address.seq().get(), 42);
+        assert_eq!(
+            address.body_sha256().as_str(),
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn generation_is_128_bit_lower_hex() {
+        assert!(WorldGeneration::new("0123456789abcdef0123456789abcdef").is_ok());
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcde").unwrap_err(),
+            InvalidWorldGeneration::WrongLength
+        );
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcdef0").unwrap_err(),
+            InvalidWorldGeneration::WrongLength
+        );
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcdeF").unwrap_err(),
+            InvalidWorldGeneration::NotLowerHex
+        );
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcdeg").unwrap_err(),
+            InvalidWorldGeneration::NotLowerHex
+        );
+    }
+
+    #[test]
+    fn timeline_seq_is_positive_sqlite_rowid() {
+        assert_eq!(TimelineSeq::new(1).unwrap().get(), 1);
+        assert_eq!(
+            TimelineSeq::new(0).unwrap_err(),
+            InvalidTimelineSeq::NonPositive
+        );
+        assert_eq!(
+            TimelineSeq::new(-1).unwrap_err(),
+            InvalidTimelineSeq::NonPositive
+        );
+    }
+
+    #[test]
+    fn body_sha256_is_256_bit_lower_hex() {
+        assert!(BodySha256::new(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .is_ok());
+        assert_eq!(
+            BodySha256::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde")
+                .unwrap_err(),
+            InvalidBodySha256::WrongLength
+        );
+        assert_eq!(
+            BodySha256::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0")
+                .unwrap_err(),
+            InvalidBodySha256::WrongLength
+        );
+        assert_eq!(
+            BodySha256::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeF")
+                .unwrap_err(),
+            InvalidBodySha256::NotLowerHex
+        );
+        assert_eq!(
+            BodySha256::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg")
+                .unwrap_err(),
+            InvalidBodySha256::NotLowerHex
+        );
+    }
+
+    #[test]
+    fn timeline_read_body_carries_representation() {
+        let address = address_for_body(1, b"value");
+        let representation =
+            Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new());
+
+        let result = TimelineRead::body(address.clone(), representation);
+
+        match result {
+            TimelineRead::Body(body) => {
+                assert_eq!(body.address(), &address);
+                assert_eq!(body.representation().body, Bytes::from_static(b"value"));
+                assert_eq!(body.representation().content_type, "text/plain");
+                assert!(body.representation().headers.is_empty());
+            }
+            _ => panic!("expected body read"),
+        }
+    }
+
+    #[test]
+    fn timeline_read_body_rejects_hash_mismatch() {
+        let address = address_for_body(1, b"expected");
+        let representation =
+            Representation::new(Bytes::from_static(b"actual"), "text/plain", Vec::new());
+
+        let result = TimelineRead::body(address.clone(), representation);
+
+        match result {
+            TimelineRead::Corrupt {
+                address: got,
+                reason,
+            } => {
+                assert_eq!(got, address);
+                assert_eq!(reason, TimelineCorruption::BodyHashMismatch);
+            }
+            _ => panic!("expected corrupt read"),
+        }
+    }
+
+    #[test]
+    fn timeline_read_enumerates_absence_and_mismatch_modes() {
+        let actual = WorldGeneration::new("fedcba9876543210fedcba9876543210").unwrap();
+
+        let reads = [
+            TimelineRead::Expired {
+                address: address(2),
+            },
+            TimelineRead::Gone {
+                address: address(3),
+            },
+            TimelineRead::MissingRow {
+                address: address(4),
+            },
+            TimelineRead::GenMismatch {
+                requested: address(5),
+                actual: actual.clone(),
+            },
+        ];
+
+        for read in reads {
+            match read {
+                TimelineRead::Expired { address } => assert_eq!(address.seq().get(), 2),
+                TimelineRead::Gone { address } => assert_eq!(address.seq().get(), 3),
+                TimelineRead::MissingRow { address } => assert_eq!(address.seq().get(), 4),
+                TimelineRead::GenMismatch {
+                    requested,
+                    actual: got,
+                } => {
+                    assert_eq!(requested.seq().get(), 5);
+                    assert_eq!(got, actual);
+                }
+                TimelineRead::Body(_) | TimelineRead::Corrupt { .. } => {
+                    panic!("unexpected read mode")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn timeline_corruption_reasons_are_part_of_the_contract() {
+        let reasons = [
+            TimelineCorruption::MissingBodyForPresentRow,
+            TimelineCorruption::BodyHashMismatch,
+            TimelineCorruption::InvalidEventShape,
+        ];
+
+        for (idx, reason) in reasons.into_iter().enumerate() {
+            let result = TimelineRead::Corrupt {
+                address: address((idx + 10) as i64),
+                reason: reason.clone(),
+            };
+
+            match result {
+                TimelineRead::Corrupt {
+                    address,
+                    reason: got,
+                } => {
+                    assert_eq!(address.seq().get(), (idx + 10) as i64);
+                    assert_eq!(got, reason);
+                }
+                _ => panic!("expected corrupt read"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a private `timeline` contract module for the Path 3 / CAS timeline work.

This layer intentionally does **not** wire storage, Engine APIs, HTTP, FFI, SDKs, migrations, or release behaviour. It only defines the typed coordinate and read-result contract that later layers can build on.

## Stack

- Base: `master` after PR #328 (`c269f6e`)
- Head: `stack/15-timeline-contract` (`f8b4e6d`)
- Maintainer sign-off: stack-depth hard cap waived for this thread; all other AGENTS.md gates still apply.

## What changed

- Adds `core/src/timeline.rs` as a private module.
- Defines `TimelineAddress = world + generation + seq + body_sha256`.
- Defines typed constructors for:
  - `WorldGeneration` (32 lowercase hex, local Path 3 invariant)
  - `TimelineSeq` (positive internal SQLite `events.id`; not SSE `id`, not `Last-Event-ID`, not an external cursor)
  - `BodySha256` (64 lowercase hex, SHA-256 / FIPS 180-4)
- Adds `TimelineRead` outcomes for body, expired, gone, generation mismatch, missing row, and corruption.
- Seals successful body reads through `TimelineRead::body(...)`, which checks `sha256(representation.body) == address.body_sha256` before returning `Body`.
- Keeps proof-bearing primitive accessors module-private until a real final sink lands.
- Uses `auth::ct_eq` for body-hash comparison.

## Non-goals

- No timeline storage.
- No body retention policy.
- No generation minting.
- No Engine API changes.
- No listen/SSE wire changes.
- No HTTP/FFI/SDK changes.

## Size

- `core/src/timeline.rs`: 411 total lines; tests start at line 200; production surface is 199 lines.
- Production PR diff: 200 lines including the private `mod timeline;` declaration.
- Total diff: +412 / -0.

## Verification

Local merge-result checks in `C:\Users\chenh\Elastik-franchise\AuditeDB-pr329-clean-review` over `master c269f6e + f8b4e6d`:

- `git diff --cached --check` passed.
- `cargo fmt --manifest-path core/Cargo.toml -- --check` passed.
- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings` passed.
- `cargo test --manifest-path core/Cargo.toml` passed: 107 unit tests passed, 2 ignored; 5 doctests passed.
- `scripts/pre-push.ps1` passed: core/bin fmt, clippy, tests, version consistency, bundled SQLite check, cargo audit, Python SDK smoke, header policy scanner, JS syntax, and whitespace.

Remote checks for `f8b4e6d` on base `master` passed: GitGuardian, rust core checks, rust supply-chain audit, SDK blackbox on Ubuntu/macOS/Windows, all FFI artifact builds, and all wheel dry-runs.

## Review ledger

Round 1 on the original head found blockers:

- Linnaeus the 2nd / Mencius + type-seal: P2, `WorldGeneration::as_str`, `TimelineSeq::get`, and `BodySha256::as_str` exposed proof-bearing raw primitives crate-wide before any final sink existed. Also P3, hash comparison used ordinary equality.
- Pascal the 2nd / QA-Enforcement + Bacon: P1/P2 process blockers, PR base/checks/body were stale after PR #328 merged.

Fixes applied in `f8b4e6d`:

- Made raw primitive accessors module-private.
- Added `TimelineSeq` documentation explicitly excluding SSE `id`, `Last-Event-ID`, and external cursor semantics.
- Changed body-hash comparison to `auth::ct_eq`.
- Retargeted PR #329 to `master` after PR #328 (`c269f6e`).

Fresh round after fixes:

- Helmholtz the 2nd / Mencius + type-seal + HTTP type-seal: no P0-P3. Confirmed raw primitive accessors are private, successful `TimelineRead::Body` can only be minted through the hash-checking gate, and `ct_eq` is used.
- Erdos the 2nd / Popper + Precondition: no P0-P2. Confirmed `TimelineSeq` remains an internal SQLite `events.id` shape proof only, not an SSE id, `Last-Event-ID`, or durable external cursor. P3 ledger: `WorldGeneration::new` proves shape only, not minted entropy; generation minting belongs to a later layer.
- Kant the 2nd / Noether + Sagan: no P0-P3. Confirmed generation/hash/seq invariants, hash conservation, absence/corruption modes, standard citations, and tests.
- Newton the 2nd / QA-Enforcement + Bacon: no code P0-P3. Confirmed base `master c269f6e`, head `f8b4e6d`, line budgets, merge-result local checks, remote all-green checks, and worktree merge shape. This PR body update records the remaining ledger requirement.

## Active skills checked

- `http-type-seal-review`
- `rust-type-seal-enforcement`
- `assign-scientist-reviewers`
- `precondition-problem`
- `monte-carlo-review`
- `stacked-pr`
- `delegation-doctrine`
