### PR TITLE
timeline: add minted generation proof

### DIFF
--- a/bin/Cargo.lock
+++ b/bin/Cargo.lock
@@ -532,6 +532,7 @@ version = "8.3.0"
 dependencies = [
  "bytes",
  "dashmap",
+ "getrandom 0.2.17",
  "hex",
  "hmac",
  "percent-encoding",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -116,6 +116,7 @@ version = "8.3.0"
 dependencies = [
  "bytes",
  "dashmap",
+ "getrandom",
  "hex",
  "hmac",
  "percent-encoding",
@@ -142,6 +143,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -385,6 +397,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-link"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4"
 percent-encoding = "2"
 dashmap = "6"
 tracing = { version = "0.1", optional = true }
+getrandom = { version = "0.2", default-features = false }
 
 [features]
 default = ["bundled-sqlite", "unstable-engine"]

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -6,7 +6,7 @@
 
 #![cfg_attr(not(test), allow(dead_code))]
 
-use std::num::NonZeroI64;
+use std::{fmt, num::NonZeroI64};
 
 use crate::engine_types::{Representation, ValidatedWorldPath};
 
@@ -24,8 +24,19 @@ pub(crate) struct TimelineAddress {
     body_sha256: BodySha256,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MintedTimelineAddress {
+    world: ValidatedWorldPath,
+    gen: MintedWorldGeneration,
+    seq: TimelineSeq,
+    body_sha256: BodySha256,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WorldGeneration(String);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MintedWorldGeneration(WorldGeneration);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct TimelineSeq(NonZeroI64);
@@ -42,6 +53,11 @@ pub(crate) struct TimelineBody {
 pub(crate) enum InvalidWorldGeneration {
     WrongLength,
     NotLowerHex,
+}
+
+#[derive(Debug)]
+pub(crate) enum MintWorldGenerationError {
+    Entropy(getrandom::Error),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -111,7 +127,7 @@ impl TimelineRead {
 }
 
 impl TimelineAddress {
-    pub(crate) fn new(
+    fn new(
         world: ValidatedWorldPath,
         gen: WorldGeneration,
         seq: TimelineSeq,
@@ -142,7 +158,45 @@ impl TimelineAddress {
     }
 }
 
+impl MintedTimelineAddress {
+    pub(crate) fn new(
+        world: ValidatedWorldPath,
+        gen: MintedWorldGeneration,
+        seq: TimelineSeq,
+        body_sha256: BodySha256,
+    ) -> Self {
+        Self {
+            world,
+            gen,
+            seq,
+            body_sha256,
+        }
+    }
+
+    pub(crate) fn world(&self) -> &ValidatedWorldPath {
+        &self.world
+    }
+
+    pub(crate) fn gen(&self) -> &MintedWorldGeneration {
+        &self.gen
+    }
+
+    pub(crate) fn seq(&self) -> TimelineSeq {
+        self.seq
+    }
+
+    pub(crate) fn body_sha256(&self) -> &BodySha256 {
+        &self.body_sha256
+    }
+}
+
 impl WorldGeneration {
+    pub(crate) fn mint() -> Result<MintedWorldGeneration, MintWorldGenerationError> {
+        let mut bytes = [0u8; 16];
+        getrandom::getrandom(&mut bytes).map_err(MintWorldGenerationError::Entropy)?;
+        Ok(MintedWorldGeneration(Self(hex::encode(bytes))))
+    }
+
     pub(crate) fn new(raw: impl Into<String>) -> Result<Self, InvalidWorldGeneration> {
         let raw = raw.into();
         if raw.len() != WORLD_GEN_HEX_LEN {
@@ -158,6 +212,28 @@ impl WorldGeneration {
         &self.0
     }
 }
+
+impl MintedWorldGeneration {
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[cfg(test)]
+    // Deterministic minting bypass for stable assertions only.
+    fn test_only_from_entropy_bytes(bytes: [u8; 16]) -> Self {
+        Self(WorldGeneration(hex::encode(bytes)))
+    }
+}
+
+impl fmt::Display for MintWorldGenerationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Entropy(err) => write!(f, "world generation entropy failed: {err:?}"),
+        }
+    }
+}
+
+impl std::error::Error for MintWorldGenerationError {}
 
 impl TimelineSeq {
     pub(crate) fn new(raw: i64) -> Result<Self, InvalidTimelineSeq> {
@@ -241,6 +317,25 @@ mod tests {
     }
 
     #[test]
+    fn minted_timeline_address_consumes_minted_generation() {
+        let minted = MintedWorldGeneration::test_only_from_entropy_bytes([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f,
+        ]);
+
+        let address =
+            MintedTimelineAddress::new(world(), minted, TimelineSeq::new(7).unwrap(), body_hash());
+
+        assert_eq!(address.world().as_str(), "home/timeline");
+        assert_eq!(address.gen().as_str(), "000102030405060708090a0b0c0d0e0f");
+        assert_eq!(address.seq().get(), 7);
+        assert_eq!(
+            address.body_sha256().as_str(),
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
     fn generation_is_128_bit_lower_hex() {
         assert!(WorldGeneration::new("0123456789abcdef0123456789abcdef").is_ok());
         assert_eq!(
@@ -259,6 +354,23 @@ mod tests {
             WorldGeneration::new("0123456789abcdef0123456789abcdeg").unwrap_err(),
             InvalidWorldGeneration::NotLowerHex
         );
+    }
+
+    #[test]
+    fn generation_from_entropy_bytes_renders_lower_hex() {
+        let minted = MintedWorldGeneration::test_only_from_entropy_bytes([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f,
+        ]);
+
+        assert_eq!(minted.as_str(), "000102030405060708090a0b0c0d0e0f");
+    }
+
+    #[test]
+    fn mint_generation_preserves_contract_shape() {
+        let minted = WorldGeneration::mint().unwrap();
+
+        assert!(WorldGeneration::new(minted.as_str()).is_ok());
     }
 
     #[test]

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -112,7 +112,7 @@ impl TimelineBody {
 impl TimelineRead {
     pub(crate) fn body(address: TimelineAddress, representation: Representation) -> Self {
         let actual = crate::world::sha256_hex(&representation.body);
-        if actual != address.body_sha256().as_str() {
+        if !crate::auth::ct_eq(actual.as_bytes(), address.body_sha256().as_str().as_bytes()) {
             return Self::Corrupt {
                 address,
                 reason: TimelineCorruption::BodyHashMismatch,
@@ -208,13 +208,13 @@ impl WorldGeneration {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         &self.0
     }
 }
 
 impl MintedWorldGeneration {
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         self.0.as_str()
     }
 
@@ -243,7 +243,9 @@ impl TimelineSeq {
             .ok_or(InvalidTimelineSeq::NonPositive)
     }
 
-    pub(crate) fn get(self) -> i64 {
+    /// Internal SQLite `events.id` coordinate only. This is not an SSE `id`,
+    /// not `Last-Event-ID`, and not a durable external cursor by itself.
+    fn get(self) -> i64 {
         self.0.get()
     }
 }
@@ -260,7 +262,7 @@ impl BodySha256 {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -256,6 +256,7 @@ version = "8.3.0"
 dependencies = [
  "bytes",
  "dashmap",
+ "getrandom 0.2.17",
  "hex",
  "hmac",
  "percent-encoding",
@@ -328,6 +329,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -772,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1042,6 +1054,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"


### PR DESCRIPTION
## Summary

Adds the Path 3 mint proof layer for timeline generation identities.

This PR introduces:

- `WorldGeneration::mint()` as the only production entropy gate for new world generations.
- `MintedWorldGeneration`, a non-`Clone`/non-`Copy` proof token produced by `mint()`.
- `MintedTimelineAddress`, a creation-candidate address that consumes `MintedWorldGeneration` by value.
- `getrandom = { version = "0.2", default-features = false }` in `elastik-core` for OS entropy.

This layer intentionally does not wire SQLite schema, HMAC signing, retention, subscribe, HTTP, FFI, SDKs, or migration. It is only the typed contract for fresh timeline generation minting.

## Stack

Base: `master` at `3dca0380ae1fde8df8256fba4ca4b627bbed1ec7`.
Head: `stack/16-generation-mint` at `cc38c0e06fdaef8e8604a6df4652699790b66d93`.

The branch includes a non-squash merge of current `origin/master` so #330 can be reviewed against master after #329 merged. Maintainer note: stack depth was explicitly signed off in-thread for the Path 3 work; scope remains intentionally narrow.

## Diff Budget

PR diff vs current master:

```text
bin/Cargo.lock       |   1 +
core/Cargo.lock      |  18 ++++++++
core/Cargo.toml      |   1 +
core/src/timeline.rs | 116 ++++++++++++++++++++++++++++++++++++++++++++++++++-
ffi/Cargo.lock       |  20 ++++++++-
5 files changed, 153 insertions(+), 3 deletions(-)
```

`core/src/timeline.rs` is about 275 production lines before its `#[cfg(test)]` block, under the 500-line AGENTS.md budget. This PR adds about 114 Rust production lines and 39 lockfile/manifest lines.

## Active Instructions Checked

- `AGENTS.md` in this repo: 500-line budget, type-seal discipline, no unguarded fallback, PR body ledger, fresh zero-P0/P1/P2 review round.
- `stacked-pr`: layer must be independently mergeable and reviewable.
- `delegation-doctrine`: independent QA lanes, not generic subagent theatre.
- `assign-scientist-reviewers`: named lenses with concrete deliverables.
- `rust-type-seal-enforcement`: opaque proof, controlled gate, proof consumed at protected constructor, test bypass fenced.
- `http-type-seal-review`: fail-loud and type-seal review shape.
- `precondition-problem`: challenge whether generation can remain shape-only.
- `cargo-supply-chain`: verify dependency version, features, MSRV, audit state.
- `monte-carlo-review`: fresh independent review after the interrupted run and branch update.

## Invariants

Path 3 requires `gen` to be a 128-bit minted incarnation id rendered as 32 lowercase hex chars.

Production minting now yields `MintedWorldGeneration` only through `WorldGeneration::mint()`. The deterministic entropy helper is private, `#[cfg(test)]`, and named `test_only_from_entropy_bytes`. `MintedTimelineAddress::new` consumes `MintedWorldGeneration`, so parsed historical `WorldGeneration` values are not confused with freshly minted creation identities.

`TimelineAddress` remains the parsed/read coordinate type for future historical reads. Its constructor is module-private, so sibling core modules cannot construct a timeline address from a parsed generation by accident.

`TimelineSeq` remains documented as an internal SQLite `events.id` coordinate only. It is not an SSE `id`, not `Last-Event-ID`, and not a durable external cursor by itself.

## Supply-chain ledger

- Added direct core runtime dependency: `getrandom = { version = "0.2", default-features = false }`.
- Need: mint 128-bit world generation IDs from OS entropy; `std` has no CSPRNG, and `rand`/`uuid` would add broader abstractions for a raw lower-hex token.
- Resolved version: `getrandom 0.2.17`.
- Licence: `MIT OR Apache-2.0`.
- Version choice: latest observed `getrandom 0.4.2` declares `rust-version = 1.85` and has a different 0.x feature/dependency surface; `0.2` avoids a silent MSRV bump.
- Feature choice: `default-features = false`; active feature set is empty for the direct core edge.
- Lock impact: `core` adds `getrandom 0.2.17` and `wasi 0.11.1`; `bin` and `ffi` lockfiles update because they consume core.
- Duplicate getrandom: acceptable. `core` selects only `0.2.17`; `ffi` also has `0.4.2` through UniFFI/tempfile; `bin --all-features` can also select `0.4.2` through optional MQTT/uuid/rand edges.
- Advisory check: `cargo audit` clean for `core`, `bin`, and `ffi` lockfiles.

## Review ledger

Initial independent review found one real P1/P2: the minted proof was optional while `TimelineAddress::new(WorldGeneration)` remained `pub(crate)`. Fixed by making `TimelineAddress::new` module-private and keeping `MintedTimelineAddress::new` as the crate-visible creation-candidate constructor.

After #329 merged, this branch was refreshed top-down without rebasing: stack/16 received the already-merged #329 seal fixes, then merged `origin/master`. A clean merge-result worktree was built at `C:\Users\chenh\Elastik-franchise\AuditeDB-pr330-clean-review-cc38c0e`.

Fresh subagent QA after the interrupted run:

- Maxwell the 2nd / Mencius + Noether + type-seal: **No P0-P3 findings**. Confirmed private raw extractors, private `TimelineAddress::new`, consumed minted proof, no Clone/Copy replay, test-only bypass fenced.
- Franklin the 2nd / Popper + Precondition: **No P0-P2 findings**. P3 only: future production caller should test entropy-error mapping; compile-fail can be added later if the seal becomes public-facing.
- Aristotle the 2nd / Carson + Bacon: **No P0-P2 findings**. P3 only: keep the `getrandom 0.2.17`/0.4.2 MSRV and duplicate-version ledger explicit.
- Hooke the 2nd / Newton + QA-Enforcement + Bacon: found one process P2, stale PR body ledger. This update resolves it. Also noted one transient pre-push SDK-tool failure in its own run that passed on rerun.

## Validation

Local on branch before push:

```text
git diff --check
cargo fmt --manifest-path core/Cargo.toml -- --check
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path core/Cargo.toml
scripts/pre-push.ps1
```

Branch push hook passed twice after the seal fix and master merge:

```text
pre-push: all Elastik local gates passed
core tests: 110 passed, 2 ignored; doc tests: 5 passed
bin tests: 108 passed
version consistency ok: 8.3.0
bundled SQLite: 3.53.1
cargo audit: core/bin/ffi clean
Python SDK smoke: PASS
header policy scanner: ok
whitespace check: ok
```

Clean merge-result validation at `AuditeDB-pr330-clean-review-cc38c0e`:

```text
git merge --no-commit --no-ff origin/stack/16-generation-mint
# Automatic merge went well
git diff --cached --check
cargo fmt --manifest-path core/Cargo.toml -- --check
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path core/Cargo.toml
cargo tree --manifest-path core/Cargo.toml -e features -i getrandom
cargo info getrandom@0.2.17
cargo info getrandom@0.4.2
cargo audit -f core/Cargo.lock
powershell -ExecutionPolicy Bypass -File scripts/pre-push.ps1
```

Observed merge-result evidence:

```text
core tests: 110 passed, 2 ignored; doc tests: 5 passed
bin tests: 108 passed
pre-push: all Elastik local gates passed
cargo audit core/bin/ffi: clean
getrandom core direct edge: 0.2.17
getrandom latest checked: 0.4.2, rust-version 1.85
```
