### PR TITLE
world: extract schema helpers

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -182,6 +182,7 @@ mod test_support;
 mod timeline;
 mod world;
 mod world_ops;
+mod world_schema;
 
 // Re-export protocol-neutral helpers at the crate root.
 pub(crate) use crate::state::*;

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -25,9 +25,9 @@
 //! is the historical per-write view. The event chain stores structured
 //! audit facts, never JSON blobs.
 
-use crate::{audit, engine_types::AuditHmacKey, event::AuditEventKind};
+use crate::{audit, engine_types::AuditHmacKey, event::AuditEventKind, world_schema};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-use rusqlite::{ffi, params, Connection, OpenFlags, OptionalExtension, Transaction};
+use rusqlite::{ffi, params, Connection, OpenFlags, Transaction};
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -87,63 +87,11 @@ pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
         "#,
     )?;
     if db_existed {
-        verify_schema(&c)?;
+        world_schema::verify(&c)?;
     } else {
-        c.execute_batch(
-            r#"
-        CREATE TABLE IF NOT EXISTS stage_meta(
-            id INTEGER PRIMARY KEY CHECK(id=1),
-            body BLOB DEFAULT x'',
-            content_type TEXT DEFAULT 'application/octet-stream'
-        );
-        INSERT OR IGNORE INTO stage_meta(id, body) VALUES(1, x'');
-        CREATE TABLE IF NOT EXISTS meta_headers(
-            name TEXT NOT NULL,
-            value TEXT NOT NULL,
-            PRIMARY KEY(name)
-        );
-        CREATE TABLE IF NOT EXISTS events(
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp TEXT NOT NULL,
-            event_type TEXT NOT NULL,
-            target TEXT DEFAULT '',
-            body_sha256 TEXT DEFAULT '',
-            size INTEGER DEFAULT 0,
-            content_type TEXT DEFAULT '',
-            meta_sha256 TEXT DEFAULT '',
-            hmac TEXT NOT NULL,
-            prev_hmac TEXT DEFAULT ''
-        );
-        CREATE TABLE IF NOT EXISTS event_headers(
-            event_id INTEGER NOT NULL,
-            name TEXT NOT NULL,
-            value TEXT NOT NULL
-        );
-        "#,
-        )?;
+        world_schema::create(&c)?;
     }
     Ok(c)
-}
-
-fn verify_schema(c: &Connection) -> rusqlite::Result<()> {
-    for table in ["stage_meta", "meta_headers", "events", "event_headers"] {
-        let exists = c
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
-                [table],
-                |r| r.get::<_, i64>(0),
-            )
-            .optional()?
-            .is_some();
-        if !exists {
-            return Err(schema_error(format!("missing required table: {table}")));
-        }
-    }
-    Ok(())
-}
-
-fn schema_error(msg: String) -> rusqlite::Error {
-    rusqlite::Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), Some(msg))
 }
 
 fn create_dir_error(err: std::io::Error) -> rusqlite::Error {

--- a/core/src/world_schema.rs
+++ b/core/src/world_schema.rs
@@ -1,0 +1,59 @@
+//! SQLite schema helpers for one durable world database.
+
+use rusqlite::{ffi, Connection, OptionalExtension};
+
+pub(crate) fn create(c: &Connection) -> rusqlite::Result<()> {
+    c.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS stage_meta(
+            id INTEGER PRIMARY KEY CHECK(id=1),
+            body BLOB DEFAULT x'',
+            content_type TEXT DEFAULT 'application/octet-stream'
+        );
+        INSERT OR IGNORE INTO stage_meta(id, body) VALUES(1, x'');
+        CREATE TABLE IF NOT EXISTS meta_headers(
+            name TEXT NOT NULL,
+            value TEXT NOT NULL,
+            PRIMARY KEY(name)
+        );
+        CREATE TABLE IF NOT EXISTS events(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            target TEXT DEFAULT '',
+            body_sha256 TEXT DEFAULT '',
+            size INTEGER DEFAULT 0,
+            content_type TEXT DEFAULT '',
+            meta_sha256 TEXT DEFAULT '',
+            hmac TEXT NOT NULL,
+            prev_hmac TEXT DEFAULT ''
+        );
+        CREATE TABLE IF NOT EXISTS event_headers(
+            event_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            value TEXT NOT NULL
+        );
+        "#,
+    )
+}
+
+pub(crate) fn verify(c: &Connection) -> rusqlite::Result<()> {
+    for table in ["stage_meta", "meta_headers", "events", "event_headers"] {
+        let exists = c
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                [table],
+                |r| r.get::<_, i64>(0),
+            )
+            .optional()?
+            .is_some();
+        if !exists {
+            return Err(schema_error(format!("missing required table: {table}")));
+        }
+    }
+    Ok(())
+}
+
+fn schema_error(msg: String) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), Some(msg))
+}


### PR DESCRIPTION
## Summary

Pure mechanical extraction of durable world schema helpers out of `world.rs` into `world_schema.rs`.

This PR moves the existing schema create/verify SQL into a private crate module:

- `world_schema::create(&Connection)` owns the current v5 table creation block.
- `world_schema::verify(&Connection)` owns the current required-table check.
- `world::open()` keeps the same `db_existed` branch structure and delegates to those helpers.

No storage format, SQL body, migration policy, read/write behaviour, audit behaviour, HTTP/FFI/SDK surface, or Path 3 runtime semantics change in this layer.

## Stack

Base: `stack/16-generation-mint` / PR #330 at `cc38c0e06fdaef8e8604a6df4652699790b66d93`.
Head: `stack/17-generation-schema` at `11b4a92431ffbe46680bae271982f817745072b0`.

This branch includes a non-squash merge of current `stack/16-generation-mint` so the review base matches #330's refreshed head. Maintainer note: stack depth was explicitly signed off in-thread for the Path 3 work; scope remains narrow. This is a prep layer for the following generation-persistence schema PR.

## Why This Layer Exists

The next Path 3 layer needs to persist the minted world generation in the durable world schema. This PR first creates a small schema-only module and keeps the generation behaviour change out of the mechanical extraction.

This lets reviewers separately check:

1. schema helper extraction preserves behaviour;
2. generation persistence changes schema semantics.

## Diff Budget

PR diff vs current `stack/16-generation-mint`:

```text
core/src/lib.rs          |  1 +
core/src/world.rs        | 60 ++++--------------------------------------------
core/src/world_schema.rs | 59 +++++++++++++++++++++++++++++++++++++++++++++++
3 files changed, 64 insertions(+), 56 deletions(-)
```

Production surface after this PR:

```text
core/src/lib.rs          179 production lines
core/src/world.rs        286 production lines before #[cfg(test)]
core/src/world_schema.rs  59 production lines
```

All touched production files are under the 500-line AGENTS.md budget.

## Active Instructions Checked

- `AGENTS.md` in this repo: 500-line budget, type-seal discipline, no unguarded fallback, PR body ledger, fresh zero-P0/P1/P2 review round.
- `stacked-pr`: layer must be independently mergeable and reviewable.
- `delegation-doctrine`: independent QA lanes, not generic subagent theatre.
- `assign-scientist-reviewers`: named lenses with concrete deliverables.
- `rust-type-seal-enforcement`: private module boundary, no new raw bypass, no fallback around a guard.
- `http-type-seal-review`: fail-loud status/error semantics stay true; missing schema remains corruption, not silent recreation.
- `precondition-problem`: challenged the assumption that extraction is harmless by checking missing-table, read-only-open, bootstrap, and audit genesis/existing counterexamples.
- `monte-carlo-review`: fresh independent review after stack/16 moved.

## Behaviour Contract

- Existing durable DB: `world::open()` still verifies required tables and fails loud if schema is incomplete.
- New durable DB: `world::open()` still creates all v5 tables and inserts the singleton `stage_meta` row.
- Read-only/open-existing paths still do not create directories, files, schema, or bootstrap rows.
- Missing required table still maps through `schema_error` to `SQLITE_CORRUPT`.
- Audit genesis vs existing-chain split is unchanged.
- `world_schema` is a private crate module (`mod world_schema;`), not public API.

## Review Ledger

Initial review round:

- Noether/behaviour preservation: approved; normalized schema create SQL and verifier body matched the prior code.
- Poincare/module topology: approved; `world_schema` is schema-only, private, and a good base for the next generation column PR.
- Mencius/type-seal: approved; no new raw-value bypass or proof-bearing API was introduced.
- Hypatia/QA: found one P2 process issue: `core/src/world_schema.rs` was initially untracked, so the PR surface would have been incomplete. Fixed by staging the file.

Fresh review after stack/16 moved:

- Confucius the 2nd / Noether + Heisenberg: **No P0-P3 findings**. Confirmed `CREATE_SQL_EXACT_MATCH`, preserved `db_existed` branch, preserved verifier semantics, and missing tables still classify as `SQLITE_CORRUPT`.
- Einstein the 2nd / Mencius + Poincare: **No P0-P3 findings**. Confirmed `world_schema` is private, helpers are acceptable crate-private internal module functions, no existing-DB recreate fallback, no public raw `Connection` bypass, no generation persistence mixed in.
- Hilbert the 2nd / Popper + Precondition: **No P0-P2 findings; no P3 hardening**. Checked counterexamples for missing tables, bootstrap row creation, read-only open paths, genesis/existing audit split, and corrupt classification.
- Socrates the 2nd / Hooke + Bacon + QA-Enforcement: found two process P2s: stale base/head ledger and missing active-skill ledger. This PR body update resolves both. CI was pending at the time of that review, with no failed checks observed.

P3 guardrail for the next PR: keep `world_schema` responsible for schema shape only. Generation row persistence should use sealed generation types at write/read boundaries, with raw strings only at SQLite bind/unbind and validation constructors.

## Validation

Local on branch after merging current stack/16:

```text
git diff --check
cargo fmt --manifest-path core/Cargo.toml -- --check
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path core/Cargo.toml
```

Observed:

```text
core tests: 110 passed, 2 ignored
core doctests: 5 passed
```

Branch push hook:

```text
pre-push: all Elastik local gates passed
core tests: 110 passed, 2 ignored; doc tests: 5 passed
bin tests: 108 passed
version consistency ok: 8.3.0
bundled SQLite: 3.53.1
cargo audit: core/bin/ffi clean
Python SDK smoke: PASS
header policy scanner: ok
whitespace check: ok
```

Clean merge-result validation at `C:\Users\chenh\Elastik-franchise\AuditeDB-pr331-clean-review-11b4a92`:

```text
git merge --no-commit --no-ff origin/stack/17-generation-schema
# Automatic merge went well
git diff --cached --check
cargo fmt --manifest-path core/Cargo.toml -- --check
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path core/Cargo.toml
```

Observed merge-result evidence:

```text
PR diff: 3 files changed, 64 insertions(+), 56 deletions(-)
core tests: 110 passed, 2 ignored
core doctests: 5 passed
```
