### PR TITLE
timeline: extract world generation identity

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -181,6 +181,7 @@ mod store;
 mod test_support;
 mod timeline;
 mod world;
+mod world_generation;
 mod world_ops;
 mod world_schema;
 

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -245,7 +245,7 @@ mod tests {
             TimelineAddress::new(world(), gen(), TimelineSeq::new(42).unwrap(), body_hash());
 
         assert_eq!(address.world().as_str(), "home/timeline");
-        assert_eq!(address.gen().as_str(), "0123456789abcdef0123456789abcdef");
+        assert_eq!(address.gen(), &gen());
         assert_eq!(address.seq().get(), 42);
         assert_eq!(
             address.body_sha256().as_str(),
@@ -255,16 +255,18 @@ mod tests {
 
     #[test]
     fn minted_timeline_address_consumes_minted_generation() {
-        let minted = MintedWorldGeneration::test_only_from_entropy_bytes([
+        let entropy = [
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
             0x0e, 0x0f,
-        ]);
+        ];
+        let minted = MintedWorldGeneration::test_only_from_entropy_bytes(entropy);
+        let expected = MintedWorldGeneration::test_only_from_entropy_bytes(entropy);
 
         let address =
             MintedTimelineAddress::new(world(), minted, TimelineSeq::new(7).unwrap(), body_hash());
 
         assert_eq!(address.world().as_str(), "home/timeline");
-        assert_eq!(address.gen().as_str(), "000102030405060708090a0b0c0d0e0f");
+        assert_eq!(address.gen(), &expected);
         assert_eq!(address.seq().get(), 7);
         assert_eq!(
             address.body_sha256().as_str(),

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -6,13 +6,10 @@
 
 #![cfg_attr(not(test), allow(dead_code))]
 
-use std::{fmt, num::NonZeroI64};
-
 use crate::engine_types::{Representation, ValidatedWorldPath};
+use crate::world_generation::{MintedWorldGeneration, WorldGeneration};
+use std::num::NonZeroI64;
 
-/// Local Path 3 invariant: a world generation is a 128-bit identity rendered as
-/// 32 lowercase hexadecimal characters.
-const WORLD_GEN_HEX_LEN: usize = 32;
 /// FIPS 180-4 defines SHA-256 output as 256 bits; hex renders 4 bits per char.
 const BODY_SHA256_HEX_LEN: usize = 64;
 
@@ -32,12 +29,6 @@ pub(crate) struct MintedTimelineAddress {
     body_sha256: BodySha256,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct WorldGeneration(String);
-
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct MintedWorldGeneration(WorldGeneration);
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct TimelineSeq(NonZeroI64);
 
@@ -47,17 +38,6 @@ pub(crate) struct BodySha256(String);
 pub(crate) struct TimelineBody {
     address: TimelineAddress,
     representation: Representation,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum InvalidWorldGeneration {
-    WrongLength,
-    NotLowerHex,
-}
-
-#[derive(Debug)]
-pub(crate) enum MintWorldGenerationError {
-    Entropy(getrandom::Error),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -190,51 +170,6 @@ impl MintedTimelineAddress {
     }
 }
 
-impl WorldGeneration {
-    pub(crate) fn mint() -> Result<MintedWorldGeneration, MintWorldGenerationError> {
-        let mut bytes = [0u8; 16];
-        getrandom::getrandom(&mut bytes).map_err(MintWorldGenerationError::Entropy)?;
-        Ok(MintedWorldGeneration(Self(hex::encode(bytes))))
-    }
-
-    pub(crate) fn new(raw: impl Into<String>) -> Result<Self, InvalidWorldGeneration> {
-        let raw = raw.into();
-        if raw.len() != WORLD_GEN_HEX_LEN {
-            return Err(InvalidWorldGeneration::WrongLength);
-        }
-        if !is_lower_hex(&raw) {
-            return Err(InvalidWorldGeneration::NotLowerHex);
-        }
-        Ok(Self(raw))
-    }
-
-    pub(crate) fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl MintedWorldGeneration {
-    pub(crate) fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    #[cfg(test)]
-    // Deterministic minting bypass for stable assertions only.
-    fn test_only_from_entropy_bytes(bytes: [u8; 16]) -> Self {
-        Self(WorldGeneration(hex::encode(bytes)))
-    }
-}
-
-impl fmt::Display for MintWorldGenerationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Entropy(err) => write!(f, "world generation entropy failed: {err:?}"),
-        }
-    }
-}
-
-impl std::error::Error for MintWorldGenerationError {}
-
 impl TimelineSeq {
     pub(crate) fn new(raw: i64) -> Result<Self, InvalidTimelineSeq> {
         NonZeroI64::new(raw)
@@ -333,44 +268,6 @@ mod tests {
             address.body_sha256().as_str(),
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
-    }
-
-    #[test]
-    fn generation_is_128_bit_lower_hex() {
-        assert!(WorldGeneration::new("0123456789abcdef0123456789abcdef").is_ok());
-        assert_eq!(
-            WorldGeneration::new("0123456789abcdef0123456789abcde").unwrap_err(),
-            InvalidWorldGeneration::WrongLength
-        );
-        assert_eq!(
-            WorldGeneration::new("0123456789abcdef0123456789abcdef0").unwrap_err(),
-            InvalidWorldGeneration::WrongLength
-        );
-        assert_eq!(
-            WorldGeneration::new("0123456789abcdef0123456789abcdeF").unwrap_err(),
-            InvalidWorldGeneration::NotLowerHex
-        );
-        assert_eq!(
-            WorldGeneration::new("0123456789abcdef0123456789abcdeg").unwrap_err(),
-            InvalidWorldGeneration::NotLowerHex
-        );
-    }
-
-    #[test]
-    fn generation_from_entropy_bytes_renders_lower_hex() {
-        let minted = MintedWorldGeneration::test_only_from_entropy_bytes([
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
-            0x0e, 0x0f,
-        ]);
-
-        assert_eq!(minted.as_str(), "000102030405060708090a0b0c0d0e0f");
-    }
-
-    #[test]
-    fn mint_generation_preserves_contract_shape() {
-        let minted = WorldGeneration::mint().unwrap();
-
-        assert!(WorldGeneration::new(minted.as_str()).is_ok());
     }
 
     #[test]

--- a/core/src/world_generation.rs
+++ b/core/src/world_generation.rs
@@ -1,0 +1,120 @@
+//! World incarnation identity for storage addressing.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::fmt;
+
+/// Local Path 3 invariant: a world generation is a 128-bit identity rendered as
+/// 32 lowercase hexadecimal characters.
+const WORLD_GEN_HEX_LEN: usize = 32;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorldGeneration(String);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MintedWorldGeneration(WorldGeneration);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum InvalidWorldGeneration {
+    WrongLength,
+    NotLowerHex,
+}
+
+#[derive(Debug)]
+pub(crate) enum MintWorldGenerationError {
+    Entropy(getrandom::Error),
+}
+
+impl WorldGeneration {
+    pub(crate) fn mint() -> Result<MintedWorldGeneration, MintWorldGenerationError> {
+        let mut bytes = [0u8; 16];
+        getrandom::getrandom(&mut bytes).map_err(MintWorldGenerationError::Entropy)?;
+        Ok(MintedWorldGeneration(Self(hex::encode(bytes))))
+    }
+
+    pub(crate) fn new(raw: impl Into<String>) -> Result<Self, InvalidWorldGeneration> {
+        let raw = raw.into();
+        if raw.len() != WORLD_GEN_HEX_LEN {
+            return Err(InvalidWorldGeneration::WrongLength);
+        }
+        if !is_lower_hex(&raw) {
+            return Err(InvalidWorldGeneration::NotLowerHex);
+        }
+        Ok(Self(raw))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl MintedWorldGeneration {
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[cfg(test)]
+    // Deterministic minting bypass for stable assertions only.
+    pub(crate) fn test_only_from_entropy_bytes(bytes: [u8; 16]) -> Self {
+        Self(WorldGeneration(hex::encode(bytes)))
+    }
+}
+
+impl fmt::Display for MintWorldGenerationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Entropy(err) => write!(f, "world generation entropy failed: {err:?}"),
+        }
+    }
+}
+
+impl std::error::Error for MintWorldGenerationError {}
+
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_is_128_bit_lower_hex() {
+        assert!(WorldGeneration::new("0123456789abcdef0123456789abcdef").is_ok());
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcde").unwrap_err(),
+            InvalidWorldGeneration::WrongLength
+        );
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcdef0").unwrap_err(),
+            InvalidWorldGeneration::WrongLength
+        );
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcdeF").unwrap_err(),
+            InvalidWorldGeneration::NotLowerHex
+        );
+        assert_eq!(
+            WorldGeneration::new("0123456789abcdef0123456789abcdeg").unwrap_err(),
+            InvalidWorldGeneration::NotLowerHex
+        );
+    }
+
+    #[test]
+    fn generation_from_entropy_bytes_renders_lower_hex() {
+        let minted = MintedWorldGeneration::test_only_from_entropy_bytes([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f,
+        ]);
+
+        assert_eq!(minted.as_str(), "000102030405060708090a0b0c0d0e0f");
+    }
+
+    #[test]
+    fn mint_generation_preserves_contract_shape() {
+        let minted = WorldGeneration::mint().unwrap();
+
+        assert!(WorldGeneration::new(minted.as_str()).is_ok());
+    }
+}

--- a/core/src/world_generation.rs
+++ b/core/src/world_generation.rs
@@ -43,13 +43,13 @@ impl WorldGeneration {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         &self.0
     }
 }
 
 impl MintedWorldGeneration {
-    pub(crate) fn as_str(&self) -> &str {
+    fn as_str(&self) -> &str {
         self.0.as_str()
     }
 


### PR DESCRIPTION
## Summary

Extracts world generation identity into `core/src/world_generation.rs`.

This PR keeps `timeline` as a consumer of generation identity instead of its owner:

- `WorldGeneration` and `MintedWorldGeneration` move out of `timeline.rs`.
- `WorldGeneration::mint()` remains the only production entropy gate for minted generations.
- `MintedTimelineAddress::new` still consumes `MintedWorldGeneration` by value.
- `TimelineAddress::new` remains private to `timeline.rs`.

No schema persistence, SQLite runtime storage change, public API change, HTTP/FFI/SDK change, lockfile change, or Cargo dependency change is introduced in this layer.

## Stack

Base: `stack/17-generation-schema` / PR #331 at `11b4a92431ffbe46680bae271982f817745072b0`.
Head: `stack/18-generation-persistence` at `fc89b416eef7a58b981c12e477b661f2e4688b37`.

This branch was refreshed top-down by merging current `origin/stack/17-generation-schema`; no rebase and no squash. The merge conflict was only the already-moved generation impl block in `core/src/timeline.rs`, resolved by keeping generation ownership in `world_generation.rs`.

## Diff Budget

Current PR diff vs `origin/stack/17-generation-schema`:

```text
core/src/lib.rs              |   1 +
core/src/timeline.rs         | 117 +++--------------------------------------
core/src/world_generation.rs | 120 +++++++++++++++++++++++++++++++++++++++++++
3 files changed, 129 insertions(+), 109 deletions(-)
```

All touched production files remain under the AGENTS.md 500-line budget. The layer has one concern: generation identity module extraction.

## Active Instructions Checked

- `AGENTS.md`: stack discipline, 500-line budget, type-seal discipline, no unguarded fallback, fresh QA ledger.
- `stacked-pr`: independently mergeable, focused layer, top-down refresh.
- `delegation-doctrine`: bounded independent QA lanes with concrete deliverables.
- `assign-scientist-reviewers`: named reviewer lenses, findings by severity.
- `rust-type-seal-enforcement`: opaque proof token, controlled mint gate, no raw bypass.
- `http-type-seal-review`: fail-loud / no fallback review shape.
- `precondition-problem`: challenged whether this layer is really extraction-only.
- `monte-carlo-review`: fresh independent review after the interrupted run and base refresh.

## Behaviour Contract

- Parsed generation identity remains `WorldGeneration`.
- Fresh creation identity remains `MintedWorldGeneration`.
- `MintedWorldGeneration` is still not `Clone` or `Copy`.
- `WorldGeneration::mint()` still uses OS entropy through `getrandom`.
- The deterministic generation helper remains `#[cfg(test)]` and named `test_only_from_entropy_bytes`.
- Raw generation string access remains module-private after the fresh P3 fix.
- `TimelineSeq` is still documented as an internal SQLite `events.id` coordinate, not an SSE `id`, not `Last-Event-ID`, and not a durable external cursor by itself.

## Review Ledger

Initial older round on the pre-refresh branch found and fixed:

- Noether: P2 deterministic timeline test regressed to live entropy. Fixed by moving deterministic helper to `world_generation` under `#[cfg(test)]` and keeping deterministic assertions.
- Poincare: P3 module doc still centred timeline. Fixed by making `world_generation` own "World incarnation identity for storage addressing".
- Popper / Hypatia QA: process issues around untracked/new file and missing durable PR ledger. Fixed before the first push.

Fresh round after top-down merge to current #331:

- Boyle the 2nd / Noether + Mencius: **No P0-P3 findings**. Verified only expected diff files changed, no public re-export, minted proof remains opaque and non-Clone/non-Copy, production minting still uses entropy, test bypass remains `#[cfg(test)]`, and `MintedTimelineAddress::new` consumes the minted proof.
- Arendt the 2nd / Popper + Precondition: **No P0-P2 findings**. Found one P3: `WorldGeneration::as_str` and `MintedWorldGeneration::as_str` had widened from private to `pub(crate)`. Fixed in `fc89b41` by making both private again and updating timeline tests to compare typed values instead of raw strings.
- Russell the 2nd / Poincare + Linnaeus: **No P0-P2 findings**. Found one P3: `is_lower_hex` remains duplicated privately in `timeline.rs` and `world_generation.rs`. Accepted for this extraction layer: body-hash hex and generation hex are separate domain validators, and extracting a new shared helper would add a cross-domain utility surface unrelated to this PR.
- Chandrasekhar the 2nd / Hypatia QA + Bacon: found two process P2s: stale remote PR artefact after the local top-down merge, and missing explicit AGENTS/active-skill enforcement ledger. This push and PR body update resolve both.

## Validation

Local branch validation after the top-down merge and P3 visibility fix:

```text
git diff --check
cargo fmt --manifest-path core/Cargo.toml -- --check
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path core/Cargo.toml
powershell -ExecutionPolicy Bypass -File scripts/pre-push.ps1
```

Observed local evidence:

```text
core tests: 110 passed, 2 ignored
core doctests: 5 passed
bin tests: 108 passed
version consistency ok: 8.3.0
bundled SQLite: 3.53.1
cargo audit: core/bin/ffi clean
Python SDK smoke: PASS
header policy scanner: ok
whitespace check: ok
pre-push: all Elastik local gates passed
```

Clean merge-result validation at `C:\Users\chenh\Elastik-franchise\AuditeDB-pr332-clean-review-ea2352c`:

```text
git merge --no-commit --no-ff stack/18-generation-persistence
# Automatic merge went well
git diff --cached --check
cargo fmt --manifest-path core/Cargo.toml -- --check
cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path core/Cargo.toml
```

Observed clean-merge evidence:

```text
PR diff: 3 files changed, 129 insertions(+), 109 deletions(-)
core tests: 110 passed, 2 ignored
core doctests: 5 passed
```

GitHub checks were restarted by the `fc89b41` push and are pending at the time of this body refresh.
