### PR TITLE
world: persist generation in schema

### DIFF
--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -53,7 +53,7 @@ use std::time::Duration;
 use dashmap::DashMap;
 use rusqlite::{ffi::ErrorCode, Connection, OpenFlags};
 
-use crate::world;
+use crate::{world, world_schema};
 
 /// Default ceiling on the number of cached read slots. Per-conn
 /// memory is bounded to ~250KB (PRAGMA cache_size=-200), so 5000
@@ -111,6 +111,14 @@ fn read_cache_retry_budget_error(world: &str, mode: &str) -> rusqlite::Error {
     )
 }
 
+fn open_verified_read_conn(path: &std::path::Path) -> rusqlite::Result<Connection> {
+    let c = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    c.busy_timeout(Duration::from_millis(READ_CONN_BUSY_TIMEOUT_MS))?;
+    c.pragma_update(None, "cache_size", -200)?;
+    world_schema::verify(&c)?;
+    Ok(c)
+}
+
 /// Newtype around `rusqlite::Connection` that gates read access at
 /// the type level. The only constructor (`from_raw`) is reachable
 /// solely from `OpeningTransition::promote` below -- no other code
@@ -137,6 +145,10 @@ impl TrackedReadConnection {
     /// preserve the type gate.
     pub(crate) fn as_mut_conn(&mut self) -> &mut Connection {
         &mut self.0
+    }
+
+    fn verify_schema(&self) -> rusqlite::Result<()> {
+        world_schema::verify(&self.0)
     }
 }
 
@@ -557,13 +569,7 @@ impl ReadCache {
                 let mut g = new_guard;
                 if matches!(&*g, SlotState::Opening) {
                     let transition = OpeningTransition::new(&mut g);
-                    let init: rusqlite::Result<Connection> = (|| {
-                        let c =
-                            Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-                        c.busy_timeout(Duration::from_millis(READ_CONN_BUSY_TIMEOUT_MS))?;
-                        c.pragma_update(None, "cache_size", -200)?;
-                        Ok(c)
-                    })();
+                    let init = open_verified_read_conn(&path);
                     match init {
                         Ok(c) => transition.promote(c),
                         Err(e) => {
@@ -665,13 +671,7 @@ impl ReadCache {
                 let mut g = new_guard;
                 if matches!(&*g, SlotState::Opening) {
                     let transition = OpeningTransition::new(&mut g);
-                    let init: rusqlite::Result<Connection> = (|| {
-                        let c =
-                            Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-                        c.busy_timeout(Duration::from_millis(READ_CONN_BUSY_TIMEOUT_MS))?;
-                        c.pragma_update(None, "cache_size", -200)?;
-                        Ok(c)
-                    })();
+                    let init = open_verified_read_conn(path);
                     match init {
                         Ok(c) => transition.promote(c),
                         Err(e) => {
@@ -740,6 +740,7 @@ impl ReadCache {
         match &*read_guard {
             SlotState::Ready(tracked_mutex) => {
                 let mut tracked = tracked_mutex.lock().unwrap_or_else(|p| p.into_inner());
+                tracked.verify_schema()?;
                 let f = f.take().expect(
                     "invoke_via_slot closure slot is empty; SlotRead::Opening \
                      and SlotRead::Evicted may re-enter with the closure intact, \
@@ -838,6 +839,98 @@ mod tests {
         assert_eq!(cache.metrics.read_cache_hits.load(Ordering::Relaxed), 1);
         assert_eq!(cache.metrics.read_cache_misses.load(Ordering::Relaxed), 1);
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn create_legacy_world_without_generation(data_root: &std::path::Path, world: &str) {
+        std::fs::create_dir_all(world::world_dir(data_root, world)).unwrap();
+        let c = Connection::open(world::world_db(data_root, world)).unwrap();
+        c.execute_batch(
+            r#"
+            CREATE TABLE stage_meta(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                body BLOB DEFAULT x'',
+                content_type TEXT DEFAULT 'application/octet-stream'
+            );
+            INSERT INTO stage_meta(id, body) VALUES(1, x'');
+            CREATE TABLE meta_headers(
+                name TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY(name)
+            );
+            CREATE TABLE events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                target TEXT DEFAULT '',
+                body_sha256 TEXT DEFAULT '',
+                size INTEGER DEFAULT 0,
+                content_type TEXT DEFAULT '',
+                meta_sha256 TEXT DEFAULT '',
+                hmac TEXT NOT NULL,
+                prev_hmac TEXT DEFAULT ''
+            );
+            CREATE TABLE event_headers(
+                event_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                value TEXT NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+    }
+
+    fn drop_generation_column_from_cached_world(data_root: &std::path::Path, world: &str) {
+        let c = Connection::open(world::world_db(data_root, world)).unwrap();
+        c.execute_batch(
+            r#"
+            ALTER TABLE stage_meta RENAME TO stage_meta_with_generation;
+            CREATE TABLE stage_meta(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                body BLOB DEFAULT x'',
+                content_type TEXT DEFAULT 'application/octet-stream'
+            );
+            INSERT INTO stage_meta(id, body, content_type)
+                SELECT id, body, content_type FROM stage_meta_with_generation;
+            DROP TABLE stage_meta_with_generation;
+            "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn cache_open_rejects_legacy_stage_meta_without_generation() {
+        let dir = scratch_dir("legacy-generation-read-cache");
+        create_legacy_world_without_generation(&dir, "home/legacy");
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+
+        let err = match cache.cached_read_with_hmac(&dir, "home/legacy") {
+            Ok(_) => panic!("legacy schema must fail before read-cache promotion"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("stage_meta.generation"));
+        assert!(cache.read_conns.get("home/legacy").is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_hit_revalidates_generation_before_read() {
+        let dir = scratch_dir("generation-regression-cache-hit");
+        let world = "home/cached";
+        let _c = world::open(&dir, world).unwrap();
+        world::write(&dir, world, b"hello", "text/plain", &[]).unwrap();
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+
+        assert!(cache.cached_read_with_hmac(&dir, world).unwrap().is_some());
+        drop_generation_column_from_cached_world(&dir, world);
+
+        let err = match cache.cached_read_with_hmac(&dir, world) {
+            Ok(_) => panic!("cached read must revalidate stage_meta.generation"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("stage_meta.generation"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -202,7 +202,7 @@ struct ReadSlot {
     last_access: AtomicU64,
 }
 
-/// RAII guard for the Opening -> Ready/Tombstone transition. Without
+/// RAII guard for the Opening -> Ready/Evicted transition. Without
 /// it, a panic during `Connection::open`, `busy_timeout`, or
 /// `pragma_update` would leave the slot stuck in `Opening`.
 ///
@@ -233,8 +233,10 @@ impl<'a> OpeningTransition<'a> {
         self.finalized = true;
     }
 
+    /// Open or schema verification failed. This is a retry signal, not a
+    /// delete tombstone: a waiting reader must not turn it into `Ok(None)`.
     fn fail(mut self) {
-        *self.state = SlotState::Tombstone;
+        *self.state = SlotState::Evicted;
         self.finalized = true;
     }
 }
@@ -242,7 +244,7 @@ impl<'a> OpeningTransition<'a> {
 impl<'a> Drop for OpeningTransition<'a> {
     fn drop(&mut self) {
         if !self.finalized {
-            *self.state = SlotState::Tombstone;
+            *self.state = SlotState::Evicted;
         }
     }
 }
@@ -1187,7 +1189,7 @@ mod tests {
     }
 
     #[test]
-    fn opening_transition_drop_sets_tombstone_on_panic_path() {
+    fn opening_transition_drop_sets_evicted_on_panic_path() {
         let slot = Arc::new(ReadSlot {
             inner: StdRwLock::new(SlotState::Opening),
             last_access: AtomicU64::new(0),
@@ -1198,7 +1200,32 @@ mod tests {
             // Drop _t without finalize.
         }
         let g = slot.inner.read().unwrap();
-        assert!(matches!(*g, SlotState::Tombstone));
+        assert!(matches!(*g, SlotState::Evicted));
+    }
+
+    #[test]
+    fn opening_failure_is_retry_signal_not_cached_absence() {
+        let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
+        let slot = cache.new_slot(SlotState::Opening);
+        {
+            let mut g = slot.inner.write().unwrap();
+            OpeningTransition::new(&mut g).fail();
+        }
+
+        let mut f = Some(|_: &mut TrackedReadConnection| -> rusqlite::Result<()> {
+            panic!("failed Opening must retry, not run the read closure")
+        });
+        let read = cache.invoke_via_slot(slot, &mut f).unwrap();
+        assert!(
+            matches!(read, SlotRead::Evicted),
+            "open/schema failure must not be represented as Tombstone/Ok(None)"
+        );
+        assert!(f.is_some(), "retry signal must leave FnOnce intact");
+        assert_eq!(
+            cache.metrics.read_cache_hits.load(Ordering::Relaxed),
+            0,
+            "opening failure retries must not count as cache hits"
+        );
     }
 
     #[test]

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -76,10 +76,29 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 
 /// Open or create the world's universe.db with the v5.1 schema.
 pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
+    open_with_generation_minter(data_root, world, || {
+        world_generation::WorldGeneration::mint().map_err(mint_generation_error)
+    })
+}
+
+fn open_with_generation_minter<F>(
+    data_root: &Path,
+    world: &str,
+    mint_generation: F,
+) -> rusqlite::Result<Connection>
+where
+    F: FnOnce() -> rusqlite::Result<world_generation::MintedWorldGeneration>,
+{
     let dir = world_dir(data_root, world);
-    std::fs::create_dir_all(&dir).map_err(create_dir_error)?;
     let db = world_db(data_root, world);
     let db_existed = db.exists();
+    let generation = if db_existed {
+        None
+    } else {
+        Some(mint_generation()?)
+    };
+
+    std::fs::create_dir_all(&dir).map_err(create_dir_error)?;
     let c = Connection::open(db)?;
     c.busy_timeout(Duration::from_millis(5000))?;
     c.execute_batch(
@@ -91,9 +110,8 @@ pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
     if db_existed {
         world_schema::verify(&c)?;
     } else {
-        let generation =
-            world_generation::WorldGeneration::mint().map_err(mint_generation_error)?;
         let schema = world_schema::new_world(&c)?;
+        let generation = generation.ok_or_else(missing_minted_generation_error)?;
         world_schema::create(schema, generation)?;
     }
     Ok(c)
@@ -103,6 +121,13 @@ fn mint_generation_error(err: world_generation::MintWorldGenerationError) -> rus
     rusqlite::Error::SqliteFailure(
         ffi::Error::new(ffi::SQLITE_IOERR),
         Some(format!("mint world generation failed: {err}")),
+    )
+}
+
+fn missing_minted_generation_error() -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error::new(ffi::SQLITE_INTERNAL),
+        Some("new world schema creation reached without minted generation".to_owned()),
     )
 }
 
@@ -794,6 +819,25 @@ mod tests {
             crate::world_schema::generation(&c).unwrap(),
             crate::world_generation::WorldGeneration::new(stored).unwrap()
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn open_mint_failure_does_not_create_world_artifacts() {
+        let root = test_root("world-generation-mint-failure");
+        let _ = std::fs::remove_dir_all(&root);
+
+        let err = open_with_generation_minter(&root, "home/generated", || {
+            Err(rusqlite::Error::SqliteFailure(
+                ffi::Error::new(ffi::SQLITE_IOERR),
+                Some("forced mint failure".to_owned()),
+            ))
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("forced mint failure"));
+        assert!(!world_dir(&root, "home/generated").exists());
+        assert!(!world_db(&root, "home/generated").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -1,9 +1,9 @@
 //! World storage: one SQLite file per world.
 //!
-//! v5.0 schema (breaking from pre-v5 cores):
+//! v5.1 schema (breaking from pre-v5.1 cores):
 //!
 //! ```text
-//!     stage_meta(id, body, content_type)
+//!     stage_meta(id, generation, body, content_type)
 //!     meta_headers(name, value)
 //!     events(id, timestamp, event_type, target, body_sha256, size,
 //!            content_type, meta_sha256, hmac, prev_hmac)
@@ -25,7 +25,9 @@
 //! is the historical per-write view. The event chain stores structured
 //! audit facts, never JSON blobs.
 
-use crate::{audit, engine_types::AuditHmacKey, event::AuditEventKind, world_schema};
+use crate::{
+    audit, engine_types::AuditHmacKey, event::AuditEventKind, world_generation, world_schema,
+};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rusqlite::{ffi, params, Connection, OpenFlags, Transaction};
 use sha2::{Digest, Sha256};
@@ -72,7 +74,7 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(h.finalize())
 }
 
-/// Open or create the world's universe.db with the v5.0 schema.
+/// Open or create the world's universe.db with the v5.1 schema.
 pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
     let dir = world_dir(data_root, world);
     std::fs::create_dir_all(&dir).map_err(create_dir_error)?;
@@ -89,9 +91,19 @@ pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
     if db_existed {
         world_schema::verify(&c)?;
     } else {
-        world_schema::create(&c)?;
+        let generation =
+            world_generation::WorldGeneration::mint().map_err(mint_generation_error)?;
+        let schema = world_schema::new_world(&c)?;
+        world_schema::create(schema, generation)?;
     }
     Ok(c)
+}
+
+fn mint_generation_error(err: world_generation::MintWorldGenerationError) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error::new(ffi::SQLITE_IOERR),
+        Some(format!("mint world generation failed: {err}")),
+    )
 }
 
 fn create_dir_error(err: std::io::Error) -> rusqlite::Error {
@@ -124,6 +136,7 @@ pub fn open_existing(data_root: &Path, world: &str) -> rusqlite::Result<Option<C
         }
     };
     c.busy_timeout(Duration::from_millis(5000))?;
+    world_schema::verify(&c)?;
     Ok(Some(c))
 }
 
@@ -531,11 +544,15 @@ pub fn delete(data_root: &Path, world: &str) -> bool {
 }
 
 fn release_wal_files(data_root: &Path, world: &str) {
-    let db = world_db(data_root, world);
-    if let Ok(c) = Connection::open(&db) {
-        let _ = c.busy_timeout(Duration::from_millis(5000));
-        let _ = c.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
-        drop(c);
+    match open_checkpoint_conn(data_root, world) {
+        Ok(Some(c)) => {
+            if let Err(err) = c.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+                log_wal_release_error(world, "checkpoint", &err);
+            }
+            drop(c);
+        }
+        Ok(None) => {}
+        Err(err) => log_wal_release_error(world, "open", &err),
     }
     for suffix in ["-wal", "-shm"] {
         let _ = std::fs::remove_file(
@@ -545,6 +562,38 @@ fn release_wal_files(data_root: &Path, world: &str) {
         );
     }
     std::thread::sleep(Duration::from_millis(10));
+}
+
+fn open_checkpoint_conn(data_root: &Path, world: &str) -> rusqlite::Result<Option<Connection>> {
+    let path = world_db(data_root, world);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let c = match Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_WRITE) {
+        Ok(c) => c,
+        Err(e) => {
+            if !path.exists() {
+                return Ok(None);
+            }
+            return Err(e);
+        }
+    };
+    c.busy_timeout(Duration::from_millis(5000))?;
+    world_schema::verify(&c)?;
+    Ok(Some(c))
+}
+
+fn log_wal_release_error(world: &str, phase: &str, err: &rusqlite::Error) {
+    #[cfg(feature = "unstable-engine")]
+    tracing::warn!(
+        world,
+        phase,
+        error = %err,
+        "delete skipped wal checkpoint before physical remove"
+    );
+
+    #[cfg(not(feature = "unstable-engine"))]
+    eprintln!("elastik-core internal delete wal checkpoint {phase} failed for {world}: {err}");
 }
 
 /// List all sqlite-backed world keys by scanning the data dir.
@@ -643,6 +692,44 @@ mod tests {
         .unwrap();
     }
 
+    fn create_legacy_world_without_generation(data_root: &Path, world: &str) {
+        std::fs::create_dir_all(world_dir(data_root, world)).unwrap();
+        let c = Connection::open(world_db(data_root, world)).unwrap();
+        c.execute_batch(
+            r#"
+            CREATE TABLE stage_meta(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                body BLOB DEFAULT x'',
+                content_type TEXT DEFAULT 'application/octet-stream'
+            );
+            INSERT INTO stage_meta(id, body) VALUES(1, x'');
+            CREATE TABLE meta_headers(
+                name TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY(name)
+            );
+            CREATE TABLE events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                target TEXT DEFAULT '',
+                body_sha256 TEXT DEFAULT '',
+                size INTEGER DEFAULT 0,
+                content_type TEXT DEFAULT '',
+                meta_sha256 TEXT DEFAULT '',
+                hmac TEXT NOT NULL,
+                prev_hmac TEXT DEFAULT ''
+            );
+            CREATE TABLE event_headers(
+                event_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                value TEXT NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+    }
+
     #[test]
     fn disk_names_do_not_alias_literal_percent_with_encoded_slash() {
         assert_ne!(disk_name("home/a%2Fb"), disk_name("home/a/b"));
@@ -677,6 +764,66 @@ mod tests {
             err.sqlite_error_code(),
             Some(rusqlite::ffi::ErrorCode::DiskFull)
         );
+    }
+
+    #[test]
+    fn open_new_world_persists_generation() {
+        let root = test_root("world-generation");
+        let _ = std::fs::remove_dir_all(&root);
+        let stored = {
+            let c = open(&root, "home/generated").unwrap();
+            let generation = crate::world_schema::generation(&c).unwrap();
+            assert_eq!(generation.as_str().len(), 32);
+            assert!(generation
+                .as_str()
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)));
+            generation.as_str().to_owned()
+        };
+
+        let c = open(&root, "home/generated").unwrap();
+        assert_eq!(
+            crate::world_schema::generation(&c).unwrap().as_str(),
+            stored
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn open_existing_rejects_legacy_stage_meta_without_generation() {
+        let root = test_root("legacy-world-generation");
+        let _ = std::fs::remove_dir_all(&root);
+        create_legacy_world_without_generation(&root, "home/legacy");
+
+        let err = open_existing(&root, "home/legacy").unwrap_err();
+
+        assert!(err.to_string().contains("stage_meta.generation"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn checkpoint_open_does_not_create_missing_universe_db() {
+        let root = test_root("checkpoint-missing-db");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(world_dir(&root, "home/missing")).unwrap();
+
+        let conn = open_checkpoint_conn(&root, "home/missing").unwrap();
+
+        assert!(conn.is_none());
+        assert!(!world_db(&root, "home/missing").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn checkpoint_open_rejects_legacy_stage_meta_without_generation() {
+        let root = test_root("checkpoint-legacy-generation");
+        let _ = std::fs::remove_dir_all(&root);
+        create_legacy_world_without_generation(&root, "home/legacy");
+
+        let err = open_checkpoint_conn(&root, "home/legacy").unwrap_err();
+
+        assert!(err.to_string().contains("stage_meta.generation"));
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/core/src/world_schema.rs
+++ b/core/src/world_schema.rs
@@ -1,22 +1,58 @@
 //! SQLite schema helpers for one durable world database.
 
+use crate::world_generation::{MintedWorldGeneration, WorldGeneration};
 use rusqlite::{ffi, Connection, OptionalExtension};
 
-pub(crate) fn create(c: &Connection) -> rusqlite::Result<()> {
+pub(crate) struct NewWorldSchema<'c> {
+    c: &'c Connection,
+}
+
+pub(crate) fn new_world(c: &Connection) -> rusqlite::Result<NewWorldSchema<'_>> {
+    let existing = c
+        .query_row(
+            "SELECT name FROM sqlite_master \
+             WHERE type='table' AND name NOT LIKE 'sqlite_%' \
+             LIMIT 1",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()?;
+    if let Some(table) = existing {
+        return Err(schema_error(format!(
+            "new world schema already has table: {table}"
+        )));
+    }
+
+    Ok(NewWorldSchema { c })
+}
+
+pub(crate) fn create(
+    schema: NewWorldSchema<'_>,
+    generation: MintedWorldGeneration,
+) -> rusqlite::Result<()> {
+    let c = schema.c;
     c.execute_batch(
         r#"
-        CREATE TABLE IF NOT EXISTS stage_meta(
+        CREATE TABLE stage_meta(
             id INTEGER PRIMARY KEY CHECK(id=1),
+            generation TEXT NOT NULL,
             body BLOB DEFAULT x'',
             content_type TEXT DEFAULT 'application/octet-stream'
         );
-        INSERT OR IGNORE INTO stage_meta(id, body) VALUES(1, x'');
-        CREATE TABLE IF NOT EXISTS meta_headers(
+        "#,
+    )?;
+    c.execute(
+        "INSERT INTO stage_meta(id, generation, body) VALUES(1, ?1, x'')",
+        [generation.as_str()],
+    )?;
+    c.execute_batch(
+        r#"
+        CREATE TABLE meta_headers(
             name TEXT NOT NULL,
             value TEXT NOT NULL,
             PRIMARY KEY(name)
         );
-        CREATE TABLE IF NOT EXISTS events(
+        CREATE TABLE events(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             timestamp TEXT NOT NULL,
             event_type TEXT NOT NULL,
@@ -28,7 +64,7 @@ pub(crate) fn create(c: &Connection) -> rusqlite::Result<()> {
             hmac TEXT NOT NULL,
             prev_hmac TEXT DEFAULT ''
         );
-        CREATE TABLE IF NOT EXISTS event_headers(
+        CREATE TABLE event_headers(
             event_id INTEGER NOT NULL,
             name TEXT NOT NULL,
             value TEXT NOT NULL
@@ -51,9 +87,141 @@ pub(crate) fn verify(c: &Connection) -> rusqlite::Result<()> {
             return Err(schema_error(format!("missing required table: {table}")));
         }
     }
+    let _ = generation(c)?;
     Ok(())
+}
+
+pub(crate) fn generation(c: &Connection) -> rusqlite::Result<WorldGeneration> {
+    let mut columns = c.prepare("PRAGMA table_info(stage_meta)")?;
+    let rows = columns.query_map([], |r| r.get::<_, String>(1))?;
+    let mut has_generation = false;
+    for name in rows {
+        if name? == "generation" {
+            has_generation = true;
+            break;
+        }
+    }
+    if !has_generation {
+        return Err(schema_error(
+            "missing required column: stage_meta.generation".to_owned(),
+        ));
+    }
+
+    let generation = c
+        .query_row(
+            "SELECT CASE WHEN typeof(generation) = 'text' THEN generation END \
+             FROM stage_meta WHERE id=1",
+            [],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .ok_or_else(|| schema_error("missing required row: stage_meta id=1".to_owned()))?
+        .ok_or_else(|| schema_error("stage_meta.generation must be TEXT".to_owned()))?;
+
+    WorldGeneration::new(generation)
+        .map_err(|err| schema_error(format!("invalid stage_meta.generation: {err:?}")))
 }
 
 fn schema_error(msg: String) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), Some(msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world_generation::MintedWorldGeneration;
+
+    fn minted_generation() -> MintedWorldGeneration {
+        MintedWorldGeneration::test_only_from_entropy_bytes([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f,
+        ])
+    }
+
+    fn create_legacy_tables(c: &Connection) {
+        c.execute_batch(
+            r#"
+            CREATE TABLE stage_meta(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                body BLOB DEFAULT x'',
+                content_type TEXT DEFAULT 'application/octet-stream'
+            );
+            INSERT INTO stage_meta(id, body) VALUES(1, x'');
+            CREATE TABLE meta_headers(
+                name TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY(name)
+            );
+            CREATE TABLE events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                target TEXT DEFAULT '',
+                body_sha256 TEXT DEFAULT '',
+                size INTEGER DEFAULT 0,
+                content_type TEXT DEFAULT '',
+                meta_sha256 TEXT DEFAULT '',
+                hmac TEXT NOT NULL,
+                prev_hmac TEXT DEFAULT ''
+            );
+            CREATE TABLE event_headers(
+                event_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                value TEXT NOT NULL
+            );
+            "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn create_persists_generation() {
+        let c = Connection::open_in_memory().unwrap();
+
+        let schema = new_world(&c).unwrap();
+        create(schema, minted_generation()).unwrap();
+
+        let stored = self::generation(&c).unwrap();
+        assert_eq!(stored.as_str(), "000102030405060708090a0b0c0d0e0f");
+        verify(&c).unwrap();
+    }
+
+    #[test]
+    fn new_world_rejects_existing_schema() {
+        let c = Connection::open_in_memory().unwrap();
+        create_legacy_tables(&c);
+
+        let err = match new_world(&c) {
+            Ok(_) => panic!("existing schema must not mint a new-world proof"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("already has table"));
+    }
+
+    #[test]
+    fn verify_rejects_legacy_stage_meta_without_generation() {
+        let c = Connection::open_in_memory().unwrap();
+        create_legacy_tables(&c);
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err.to_string().contains("stage_meta.generation"));
+    }
+
+    #[test]
+    fn verify_rejects_invalid_generation_text() {
+        let c = Connection::open_in_memory().unwrap();
+        let schema = new_world(&c).unwrap();
+        create(schema, minted_generation()).unwrap();
+        c.execute(
+            "UPDATE stage_meta SET generation='000102030405060708090a0b0c0d0e0F'",
+            [],
+        )
+        .unwrap();
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err.to_string().contains("invalid stage_meta.generation"));
+    }
 }


### PR DESCRIPTION
## Summary

Persist a durable world incarnation generation in the SQLite schema before later Path 3 cursor/CAS work.

This layer changes:
- `core/src/world_generation.rs`
- `core/src/world_schema.rs`
- `core/src/world.rs`
- `core/src/read_cache.rs`

No CAS body table, timeline read-by-seq, subscribe payload, adapter API, or migration path is implemented here.

## Design Ledger

- Base / prior layer: `stack/18-generation-persistence` at `fc89b416eef7a58b981c12e477b661f2e4688b37` (#332).
- Head: `36584e6 world: close generation and read-cache QA gaps`.
- Path 3 plan citation: `design_notes/path3-precondition-challenge.md` defines fail-loud format markers and treats `gen` as storage-engine incarnation identity before cursor implementation.
- Stack depth: #333 is the fourth open cascade layer (`master -> #330 -> #331 -> #332 -> #333`). That is at the AGENTS hard cap; do not add #334 before draining.
- File-budget disclosure/sign-off: this layer touches pre-existing over-500 production files (`world.rs` and `read_cache.rs`). Raw diff is `+541/-37`; production-budget estimate is `473` changed lines and the rest is test code, which AGENTS excludes from the 500-line production budget.
- Storage-format break: v5.1 adds required `stage_meta.generation TEXT NOT NULL`. Pre-v5.1 durable world DBs now fail loud as schema corruption / missing `stage_meta.generation`. No migration, coercion, or compatibility fallback is added.

## Type-Seal Shape

- `NewWorldSchema` is a private-field proof that a just-opened DB has no existing user tables.
- `world_schema::create` requires `NewWorldSchema` and consumes `MintedWorldGeneration` by value, so the minted proof cannot be reused accidentally.
- Stored generation reads return parsed `WorldGeneration`, not minted proof.
- Raw generation strings stay private; persistence unwraps only through the `MintedWorldGeneration` `ToSql` implementation.
- New worlds mint generation before `create_dir_all` / `Connection::open`, so entropy failure leaves no world directory or empty `universe.db` behind.
- Read-cache opens verify schema before promotion.
- Cache hits re-verify schema before invoking read/audit closures, so an externally regressed cached DB cannot be trusted silently.
- Opening failure and panic cleanup become `Evicted` retry signals, not `Tombstone` cached absence, so concurrent readers cannot turn schema/open failure into a false 404.
- Delete-side WAL checkpoint uses a no-create read-write open plus schema verification before checkpoint; verification failure logs a warning and physical deletion continues, because checkpoint is best-effort cleanup, not a trusted read/write path.
- Test bypasses remain `#[cfg(test)]` only: deterministic minted generation and raw tracked-read wrapping.

## Review Ledger

Findings fixed during review:
- P3: `world_schema::create` originally accepted `&MintedWorldGeneration`; fixed to consume by value.
- P3: delete-side WAL release used `Connection::open` and could create an empty DB; fixed with `open_checkpoint_conn` using no-create flags and verification.
- P2: cached read slots verified only at open time; fixed by revalidating on every cache-hit use.
- P3: checkpoint verification errors were swallowed silently; fixed with diagnostic warning while preserving physical delete semantics.
- P1/P2: interrupted local head minted generation after opening/creating the DB; fixed by minting before filesystem/SQLite creation and adding `open_mint_failure_does_not_create_world_artifacts`.
- P2: `OpeningTransition::fail()` wrote `Tombstone`, letting waiters observe `Ok(None)` on schema/open failure; fixed by using `Evicted` retry state and adding `opening_failure_is_retry_signal_not_cached_absence`.
- P2: production `expect()` on the minted generation invariant violated AGENTS panic discipline; fixed by returning a typed `SQLITE_INTERNAL` error instead.

Independent QA after fixes:
- Lovelace the 2nd (Mencius + Noether + Popper): zero P0-P3 on generation persistence/type-seal shape.
- Jason the 2nd (Poincare + Harvey + Popper): zero P0-P3 on read-cache/tombstone/delete/fd lifecycle.
- Harvey the 2nd (Hypatia QA + Bacon + Sagan): found stale remote/body plus production `expect()`; `expect()` is fixed, branch/body are refreshed here. It also verified stack depth is at hard cap and type-seal shape has no active bypass.

Active skills used for this pass:
- `stacked-pr`
- `delegation-doctrine`
- `assign-scientist-reviewers`
- `monte-carlo-review`
- `precondition-problem`
- `rust-type-seal-enforcement`
- `http-type-seal-review`

## Validation

Local validation after final fix:
- `cargo fmt --manifest-path core/Cargo.toml -- --check` passed.
- `git diff --check origin/stack/18-generation-persistence...HEAD` passed.
- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings` passed.
- `cargo test --manifest-path core/Cargo.toml` passed: `122 passed, 2 ignored`; doctests `5 passed`.

Clean-merge validation from fresh worktree `AuditeDB-pr333-clean-review-adbf783`:
- Base: `origin/stack/18-generation-persistence` at `fc89b416eef7a58b981c12e477b661f2e4688b37`.
- `git merge --no-commit --no-ff stack/19-generation-persistence` merged cleanly.
- `git diff --cached --check` passed.
- `cargo fmt --manifest-path core/Cargo.toml -- --check` passed.
- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings` passed.
- `cargo test --manifest-path core/Cargo.toml` passed: `122 passed, 2 ignored`; doctests `5 passed`.

Pre-push hook passed after final fix:
- Rust format
- Rust clippy
- Rust core tests: `122 passed, 2 ignored`; doctests `5 passed`
- Rust bin tests: `108 passed`
- Version consistency: `8.3.0`
- Bundled SQLite version check: SQLite `3.53.1`
- `cargo audit` for core/bin/ffi lockfiles
- Python SDK smoke
- Header policy scanner and missing-baseline negative test
- JS syntax
- Whitespace check