### PR TITLE
world: add inert CAS schema

### DIFF
--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -1,6 +1,6 @@
 //! World storage: one SQLite file per world.
 //!
-//! v5.1 schema (breaking from pre-v5.1 cores):
+//! v5.2 schema (breaking from pre-v5.2 cores):
 //!
 //! ```text
 //!     stage_meta(id, generation, body, content_type)
@@ -8,11 +8,14 @@
 //!     events(id, timestamp, event_type, target, body_sha256, size,
 //!            content_type, meta_sha256, hmac, prev_hmac)
 //!     event_headers(event_id, name, value)
+//!     cas_bodies(body_sha256, body)
+//!     cas_state(id=1, first_retained_seq)
 //! ```
 //!
 //! Renames vs pre-v5: `stage_html` -> `body`. Drops: `pending_js`,
-//! `js_result`, `state`. No migrator. World dirs from older binaries
-//! fail SELECT body; wipe `data/` to upgrade.
+//! `js_result`, `state`. v5.2 adds the inert CAS tables. No migrator:
+//! world dirs from older binaries fail loudly on the first missing or stale
+//! schema surface; wipe `data/` to upgrade.
 //!
 //! `state` is gone on purpose. The old `pending|active|disabled`
 //! triple was a hook for an in-core plugin runtime that no longer
@@ -74,7 +77,7 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(h.finalize())
 }
 
-/// Open or create the world's universe.db with the v5.1 schema.
+/// Open or create the world's universe.db with the v5.2 schema.
 pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
     let dir = world_dir(data_root, world);
     std::fs::create_dir_all(&dir).map_err(create_dir_error)?;

--- a/core/src/world_schema.rs
+++ b/core/src/world_schema.rs
@@ -3,6 +3,28 @@
 use crate::world_generation::{MintedWorldGeneration, WorldGeneration};
 use rusqlite::{ffi, Connection, OptionalExtension};
 
+const CAS_BODIES_TABLE_SQL: &str = r#"
+CREATE TABLE cas_bodies(
+    body_sha256 TEXT NOT NULL PRIMARY KEY
+        CHECK(typeof(body_sha256)='text')
+        CHECK(length(body_sha256)=64)
+        CHECK(body_sha256 NOT GLOB '*[^0-9a-f]*'),
+    body BLOB NOT NULL
+        CHECK(typeof(body)='blob')
+) WITHOUT ROWID
+"#;
+
+const CAS_STATE_TABLE_SQL: &str = r#"
+CREATE TABLE cas_state(
+    id INTEGER PRIMARY KEY CHECK(id=1),
+    first_retained_seq INTEGER
+        CHECK(
+            first_retained_seq IS NULL OR
+            (typeof(first_retained_seq)='integer' AND first_retained_seq > 0)
+        )
+)
+"#;
+
 pub(crate) struct NewWorldSchema<'c> {
     c: &'c Connection,
 }
@@ -41,6 +63,12 @@ pub(crate) fn create(
         );
         "#,
     )?;
+    c.execute_batch(CAS_BODIES_TABLE_SQL)?;
+    c.execute_batch(CAS_STATE_TABLE_SQL)?;
+    c.execute(
+        "INSERT INTO cas_state(id, first_retained_seq) VALUES(1, NULL)",
+        [],
+    )?;
     c.execute(
         "INSERT INTO stage_meta(id, generation, body) VALUES(1, ?1, x'')",
         [generation.as_str()],
@@ -75,19 +103,13 @@ pub(crate) fn create(
 
 pub(crate) fn verify(c: &Connection) -> rusqlite::Result<()> {
     for table in ["stage_meta", "meta_headers", "events", "event_headers"] {
-        let exists = c
-            .query_row(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
-                [table],
-                |r| r.get::<_, i64>(0),
-            )
-            .optional()?
-            .is_some();
-        if !exists {
-            return Err(schema_error(format!("missing required table: {table}")));
-        }
+        require_table(c, table)?;
     }
     let _ = generation(c)?;
+    verify_exact_table(c, "cas_bodies", CAS_BODIES_TABLE_SQL)?;
+    verify_exact_table(c, "cas_state", CAS_STATE_TABLE_SQL)?;
+    verify_cas_body_rows(c)?;
+    verify_cas_state_row(c)?;
     Ok(())
 }
 
@@ -124,6 +146,169 @@ pub(crate) fn generation(c: &Connection) -> rusqlite::Result<WorldGeneration> {
 
 fn schema_error(msg: String) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), Some(msg))
+}
+
+fn require_table(c: &Connection, table: &str) -> rusqlite::Result<()> {
+    let exists = c
+        .query_row(
+            "SELECT 1 FROM sqlite_schema WHERE type='table' AND name=?1",
+            [table],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?
+        .is_some();
+    if exists {
+        Ok(())
+    } else {
+        Err(schema_error(format!("missing required table: {table}")))
+    }
+}
+
+fn verify_exact_table(c: &Connection, table: &str, expected_sql: &str) -> rusqlite::Result<()> {
+    let sql = c
+        .query_row(
+            "SELECT sql FROM sqlite_schema WHERE type='table' AND name=?1",
+            [table],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten()
+        .ok_or_else(|| schema_error(format!("missing required table: {table}")))?;
+
+    if normalized_schema_sql(&sql) == normalized_schema_sql(expected_sql) {
+        Ok(())
+    } else {
+        Err(schema_error(format!(
+            "schema mismatch for required table: {table}"
+        )))
+    }
+}
+
+fn normalized_schema_sql(sql: &str) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = sql.chars().collect();
+    let mut idx = 0;
+    let mut in_string = false;
+
+    while idx < chars.len() {
+        let ch = chars[idx];
+        if in_string {
+            out.push(ch);
+            if ch == '\'' {
+                if matches!(chars.get(idx + 1), Some('\'')) {
+                    idx += 1;
+                    out.push(chars[idx]);
+                } else {
+                    in_string = false;
+                }
+            }
+            idx += 1;
+            continue;
+        }
+
+        if ch == '\'' {
+            in_string = true;
+            out.push(ch);
+            idx += 1;
+        } else if ch.is_ascii_whitespace() {
+            while idx < chars.len() && chars[idx].is_ascii_whitespace() {
+                idx += 1;
+            }
+            if let (Some(prev), Some(next)) = (out.chars().last(), chars.get(idx)) {
+                if is_sql_word_char(prev) && is_sql_word_char(*next) {
+                    out.push(' ');
+                }
+            }
+        } else {
+            out.push(ch);
+            idx += 1;
+        }
+    }
+
+    out.trim_end_matches(';').to_owned()
+}
+
+fn is_sql_word_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn verify_cas_body_rows(c: &Connection) -> rusqlite::Result<()> {
+    let mut stmt = c.prepare(
+        "SELECT body_sha256, typeof(body_sha256), typeof(body), length(body) FROM cas_bodies",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<i64>>(3)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (hash, hash_type, body_type, body_len) = row?;
+        if hash_type != "text" || !is_lower_hex_sha256(&hash) {
+            return Err(schema_error(
+                "cas_bodies.body_sha256 must be 64-byte lower hex TEXT".to_owned(),
+            ));
+        }
+        if body_type != "blob" || body_len.is_none() {
+            return Err(schema_error("cas_bodies.body must be BLOB".to_owned()));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_lower_hex_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn verify_cas_state_row(c: &Connection) -> rusqlite::Result<()> {
+    let mut stmt =
+        c.prepare("SELECT id, typeof(first_retained_seq), first_retained_seq FROM cas_state")?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0;
+
+    while let Some(row) = rows.next()? {
+        count += 1;
+        let id: i64 = row.get(0)?;
+        if id != 1 {
+            return Err(schema_error(
+                "invalid row: cas_state.id must be 1".to_owned(),
+            ));
+        }
+
+        let value_type: String = row.get(1)?;
+        if value_type == "null" {
+            continue;
+        }
+        if value_type != "integer" {
+            return Err(schema_error(
+                "cas_state.first_retained_seq must be INTEGER or NULL".to_owned(),
+            ));
+        }
+
+        let seq: i64 = row.get(2)?;
+        if seq <= 0 {
+            return Err(schema_error(
+                "cas_state.first_retained_seq must be positive".to_owned(),
+            ));
+        }
+    }
+
+    match count {
+        1 => Ok(()),
+        0 => Err(schema_error(
+            "missing required row: cas_state id=1".to_owned(),
+        )),
+        _ => Err(schema_error(
+            "cas_state must contain exactly one row".to_owned(),
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -174,16 +359,137 @@ mod tests {
         .unwrap();
     }
 
+    fn create_pre_cas_tables(c: &Connection) {
+        create_legacy_tables(c);
+        c.execute("ALTER TABLE stage_meta ADD COLUMN generation TEXT", [])
+            .unwrap();
+        c.execute(
+            "UPDATE stage_meta SET generation='000102030405060708090a0b0c0d0e0f'",
+            [],
+        )
+        .unwrap();
+    }
+
+    fn create_valid_schema(c: &Connection) {
+        let schema = new_world(c).unwrap();
+        create(schema, minted_generation()).unwrap();
+    }
+
+    fn assert_schema_mismatch(c: &Connection) {
+        assert!(verify(c)
+            .unwrap_err()
+            .to_string()
+            .contains("schema mismatch"));
+    }
+
     #[test]
     fn create_persists_generation() {
         let c = Connection::open_in_memory().unwrap();
 
-        let schema = new_world(&c).unwrap();
-        create(schema, minted_generation()).unwrap();
+        create_valid_schema(&c);
 
         let stored = self::generation(&c).unwrap();
         assert_eq!(stored.as_str(), "000102030405060708090a0b0c0d0e0f");
         verify(&c).unwrap();
+    }
+
+    #[test]
+    fn create_initializes_empty_cas_schema() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+
+        let cas_rows: i64 = c
+            .query_row("SELECT count(*) FROM cas_bodies", [], |r| r.get(0))
+            .unwrap();
+        let state_rows: i64 = c
+            .query_row("SELECT count(*) FROM cas_state WHERE id=1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let first_retained_type: String = c
+            .query_row(
+                "SELECT typeof(first_retained_seq) FROM cas_state",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(cas_rows, 0);
+        assert_eq!(state_rows, 1);
+        assert_eq!(first_retained_type, "null");
+        verify(&c).unwrap();
+    }
+
+    #[test]
+    fn cas_bodies_rejects_invalid_rows() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        let hash = "a".repeat(64);
+
+        c.execute(
+            "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+            rusqlite::params![hash, b"body".as_slice()],
+        )
+        .unwrap();
+
+        assert!(c
+            .execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+                rusqlite::params![hash, b"duplicate".as_slice()],
+            )
+            .is_err());
+        assert!(c
+            .execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+                rusqlite::params!["a".repeat(63), b"short-hash".as_slice()],
+            )
+            .is_err());
+        assert!(c
+            .execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+                rusqlite::params!["A".repeat(64), b"upper-hash".as_slice()],
+            )
+            .is_err());
+        assert!(c
+            .execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+                rusqlite::params!["g".repeat(64), b"non-hex-hash".as_slice()],
+            )
+            .is_err());
+        assert!(c
+            .execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(x'aaaaaaaa', ?1)",
+                rusqlite::params![b"blob-hash".as_slice()],
+            )
+            .is_err());
+        assert!(c
+            .execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, 'text body')",
+                rusqlite::params!["b".repeat(64)],
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn cas_state_rejects_invalid_rows() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+
+        assert!(c
+            .execute(
+                "INSERT INTO cas_state(id, first_retained_seq) VALUES(2, NULL)",
+                [],
+            )
+            .is_err());
+        assert!(c
+            .execute("UPDATE cas_state SET first_retained_seq=0 WHERE id=1", [])
+            .is_err());
+        assert!(c
+            .execute(
+                "UPDATE cas_state SET first_retained_seq='text' WHERE id=1",
+                [],
+            )
+            .is_err());
     }
 
     #[test]
@@ -210,10 +516,21 @@ mod tests {
     }
 
     #[test]
+    fn verify_rejects_pre_cas_schema_with_generation() {
+        let c = Connection::open_in_memory().unwrap();
+        create_pre_cas_tables(&c);
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("missing required table: cas_bodies"));
+    }
+
+    #[test]
     fn verify_rejects_invalid_generation_text() {
         let c = Connection::open_in_memory().unwrap();
-        let schema = new_world(&c).unwrap();
-        create(schema, minted_generation()).unwrap();
+        create_valid_schema(&c);
         c.execute(
             "UPDATE stage_meta SET generation='000102030405060708090a0b0c0d0e0F'",
             [],
@@ -223,5 +540,162 @@ mod tests {
         let err = verify(&c).unwrap_err();
 
         assert!(err.to_string().contains("invalid stage_meta.generation"));
+    }
+
+    #[test]
+    fn verify_rejects_missing_cas_state_row() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute("DELETE FROM cas_state", []).unwrap();
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err.to_string().contains("cas_state id=1"));
+    }
+
+    #[test]
+    fn verify_rejects_non_integer_cas_state_floor() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute("PRAGMA ignore_check_constraints=ON", []).unwrap();
+        c.execute(
+            "UPDATE cas_state SET first_retained_seq='not-an-integer' WHERE id=1",
+            [],
+        )
+        .unwrap();
+        c.execute("PRAGMA ignore_check_constraints=OFF", [])
+            .unwrap();
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err.to_string().contains("first_retained_seq"));
+    }
+
+    #[test]
+    fn verify_rejects_corrupt_persisted_cas_body_rows() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute("PRAGMA ignore_check_constraints=ON", []).unwrap();
+        c.execute(
+            "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, 'text body')",
+            rusqlite::params!["g".repeat(64)],
+        )
+        .unwrap();
+        c.execute("PRAGMA ignore_check_constraints=OFF", [])
+            .unwrap();
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err.to_string().contains("cas_bodies.body_sha256"));
+    }
+
+    #[test]
+    fn verify_rejects_spoofed_cas_body_check() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute_batch(
+            r#"
+            DROP TABLE cas_bodies;
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY
+                    CHECK(typeof(body_sha256)='text' OR 1)
+                    CHECK(length(body_sha256)=64)
+                    CHECK(body_sha256 NOT GLOB '*[^0-9a-f]*'),
+                body BLOB NOT NULL
+                    CHECK(typeof(body)='blob')
+            ) WITHOUT ROWID;
+            "#,
+        )
+        .unwrap();
+
+        assert_schema_mismatch(&c);
+    }
+
+    #[test]
+    fn verify_rejects_spoofed_cas_body_literal_whitespace() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute_batch(
+            r#"
+            DROP TABLE cas_bodies;
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY
+                    CHECK(typeof(body_sha256)='text')
+                    CHECK(length(body_sha256)=64)
+                    CHECK(body_sha256 NOT GLOB '*[^0-9 a-f]*'),
+                body BLOB NOT NULL
+                    CHECK(typeof(body)='blob')
+            ) WITHOUT ROWID;
+            "#,
+        )
+        .unwrap();
+
+        c.execute(
+            "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+            rusqlite::params![format!("{} ", "a".repeat(63)), b"weak".as_slice()],
+        )
+        .unwrap();
+        assert_schema_mismatch(&c);
+    }
+
+    #[test]
+    fn verify_rejects_spoofed_cas_state_primary_key_spacing() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute_batch(
+            r#"
+            DROP TABLE cas_state;
+            CREATE TABLE cas_state(
+                id INTEGERPRIMARY KEY CHECK(id=1),
+                first_retained_seq INTEGER
+                    CHECK(
+                        first_retained_seq IS NULL OR
+                        (typeof(first_retained_seq)='integer' AND first_retained_seq > 0)
+                    )
+            );
+            INSERT INTO cas_state(id, first_retained_seq) VALUES(1, NULL);
+            "#,
+        )
+        .unwrap();
+
+        let pk: i64 = c
+            .query_row("PRAGMA table_info(cas_state)", [], |r| r.get(5))
+            .unwrap();
+        assert_eq!(pk, 0);
+        assert_schema_mismatch(&c);
+    }
+
+    #[test]
+    fn verify_rejects_cas_column_shape_changes() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute("ALTER TABLE cas_state ADD COLUMN note TEXT", [])
+            .unwrap();
+
+        assert_schema_mismatch(&c);
+
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute("ALTER TABLE cas_bodies ADD COLUMN content_type TEXT", [])
+            .unwrap();
+
+        assert_schema_mismatch(&c);
+
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute_batch(
+            r#"
+            DROP TABLE cas_bodies;
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY
+                    CHECK(typeof(body_sha256)='text')
+                    CHECK(length(body_sha256)=64)
+                    CHECK(body_sha256 NOT GLOB '*[^0-9a-f]*')
+            ) WITHOUT ROWID;
+            "#,
+        )
+        .unwrap();
+
+        assert_schema_mismatch(&c);
     }
 }


### PR DESCRIPTION
## What changed

Adds the inert CAS schema foothold from `design_notes/PLAN-cas-body-schema.md` section 7:

- creates `cas_bodies(body_sha256, body)` for future content-addressed bodies
- creates singleton `cas_state(id = 1, first_retained_seq)` for future local retention floor state
- verifies exact CAS table shape on existing worlds
- scans persisted CAS rows for fail-loud shape/type corruption
- updates durable world schema docs from v5.1 to v5.2

This layer is intentionally schema-only.

## Stack position

Base layer: #334, `stack/20-cas-schema-plan` at `388aa1350cd4de2e29012653c7a9c3272f615654`.

Current layer: `stack/21-cas-schema` at `89da540ea02b7be678dc8b00189f0b9b1345cfcd`.

Repair update: this branch was top-down merged with the current #334 head so #335 no longer builds on stale `stack/20-cas-schema-plan` state. Adjacent diff remains `2 files changed, 496 insertions(+), 19 deletions(-)`.

Stack-depth waiver: this PR is beyond the normal AGENTS.md 3-4 cascade-depth cap. It is opened under the user's explicit infinite-stack sign-off: `我sign off允许你做∞堆叠`.

Process note: this refresh does not repair the later hidden-base gap between #335 and #336. Work above #357/r42 remains frozen until that stack topology is repaired or the lower stack is drained.

## Scope boundaries

Included:

- inert CAS table DDL
- new-world initialization
- existing-world schema verification
- row-level corruption checks for shape/type constraints
- focused regression tests for SQL normalisation and schema spoofing

Not included in this layer:

- write-side CAS storage
- `read(TimelineAddress)`
- adapter, SDK, FFI, HTTP, MQTT, or SSE API changes
- ETag/listen semantics
- retention/pruning policy
- foreign keys
- migration or backfill

## Diff disclosure

Adjacent diff against current #334:

`2 files changed, 496 insertions(+), 19 deletions(-)`

- `core/src/world.rs`: `+7/-4`
- `core/src/world_schema.rs`: `+489/-15`

## Review ledger

Earlier review rounds found and this PR fixes:

- quoted SQL literal whitespace spoof in schema comparison
- SQL token-boundary spoof such as `INTEGERPRIMARY KEY`
- v5.2 documentation drift
- missing tests for lowercase non-hex hashes, missing CAS columns, and extra CAS columns
- persisted `cas_bodies` row corruption that bypasses CHECK constraints with `PRAGMA ignore_check_constraints=ON`

Final review round before the base refresh:

- Dalton / Popper: zero P0-P2. P3 ledgered: this layer does not prove `sha256(body) == body_sha256`. That equality belongs to future write/read CAS semantics per the plan, not to this inert schema layer.
- Ohm / Noether-Poincare: zero P0-P3.
- Beauvoir / Hypatia QA: zero P0-P2. Prior P3 was that the waiver was not inspectable before PR creation; this body records it.

Base-refresh QA:

- Main-agent local verification confirmed the refreshed adjacent diff is still the same two schema files.
- Current broader stack topology still has a P0 hidden-base gap above this PR; that is explicitly not hidden by this body.

Active skills for the refresh:

- `http-type-seal-review`
- `rust-type-seal-enforcement`
- `assign-scientist-reviewers`
- `precondition-problem`
- `monte-carlo-review`
- `stacked-pr`
- `delegation-doctrine`

## Validation

Local after base refresh:

- `git diff --check origin/stack/20-cas-schema-plan...HEAD`: passed
- `cargo fmt --manifest-path core/Cargo.toml -- --check`: passed
- `cargo test --manifest-path core/Cargo.toml --lib`: passed, `133 passed`, `2 ignored`
- `cargo test --manifest-path core/Cargo.toml --doc`: passed, `5 passed`
- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`: passed

Pre-push hook after base refresh:

- Rust format: passed
- Rust clippy: passed
- Rust tests: passed, core `133 passed`, `2 ignored`; doctests `5 passed`; bin `108 passed`
- version consistency: passed, `8.3.0`
- bundled SQLite check: passed, `3.53.1`
- cargo audit for core/bin/ffi locks: passed
- Python SDK smoke: passed
- header policy scanner and negative test: passed
- JS syntax: passed
- whitespace check: passed

GitHub checks for `89da540` are passing.

`pre-push: all Elastik local gates passed`

