### PR TITLE
core: extract timeline addresses from audit rows

### DIFF
--- a/bin/src/server/handler/tests.rs
+++ b/bin/src/server/handler/tests.rs
@@ -702,7 +702,7 @@ async fn post_audit_uses_existing_representation_metadata() {
 
 #[tokio::test]
 async fn durable_storage_quota_returns_507_without_writing() {
-    let (engine, dir) = test_engine_for_server_with_storage_quota("storage-quota", 4);
+    let (engine, dir) = test_engine_for_server_with_storage_quota("storage-quota", 8);
     let headers = HeaderMap::new();
 
     let first = unwrap_response(
@@ -730,9 +730,9 @@ async fn durable_storage_quota_returns_507_without_writing() {
         .await,
     );
     assert_eq!(over.status(), StatusCode::INSUFFICIENT_STORAGE);
-    assert_eq!(over.headers().get("x-storage-usage").unwrap(), "4");
-    assert_eq!(over.headers().get("x-storage-quota").unwrap(), "4");
-    assert_eq!(over.headers().get("x-storage-needed").unwrap(), "1");
+    assert_eq!(over.headers().get("x-storage-usage").unwrap(), "8");
+    assert_eq!(over.headers().get("x-storage-quota").unwrap(), "8");
+    assert_eq!(over.headers().get("x-storage-needed").unwrap(), "2");
     assert!(engine
         .read(&world_path("home/b"), AccessTier::Read)
         .unwrap()
@@ -750,9 +750,9 @@ async fn durable_storage_quota_returns_507_without_writing() {
         .await,
     );
     assert_eq!(append.status(), StatusCode::INSUFFICIENT_STORAGE);
-    assert_eq!(append.headers().get("x-storage-usage").unwrap(), "4");
-    assert_eq!(append.headers().get("x-storage-quota").unwrap(), "4");
-    assert_eq!(append.headers().get("x-storage-needed").unwrap(), "1");
+    assert_eq!(append.headers().get("x-storage-usage").unwrap(), "8");
+    assert_eq!(append.headers().get("x-storage-quota").unwrap(), "8");
+    assert_eq!(append.headers().get("x-storage-needed").unwrap(), "6");
     assert_eq!(
         engine
             .read(&world_path("home/a"), AccessTier::Read)
@@ -813,8 +813,11 @@ async fn concurrent_puts_to_distinct_worlds_do_not_overshoot_quota() {
     }
 
     let used = engine.df(AccessTier::Read).unwrap().storage_used;
-    let counted = accepted * body_len;
-    assert_eq!(used, counted, "counter must equal sum of accepted bodies");
+    let counted = accepted * body_len * 2;
+    assert_eq!(
+        used, counted,
+        "counter must equal accepted live bodies plus retained CAS bodies"
+    );
     assert![
         used <= quota,
         "counter must never exceed quota: {used} > {quota}"

--- a/bin/src/server/proc.rs
+++ b/bin/src/server/proc.rs
@@ -717,7 +717,7 @@ mod tests {
 
     #[tokio::test]
     async fn proc_du_and_df_report_resource_usage() {
-        let (engine, dir) = test_engine_for_server_with_storage_quota("proc-du-df", 10);
+        let (engine, dir) = test_engine_for_server_with_storage_quota("proc-du-df", 16);
         engine
             .replace(
                 &world_path("home/hello"),
@@ -742,19 +742,19 @@ mod tests {
         let du = proc_du(State(state.clone()), Method::GET, headers.clone()).await;
         assert_eq!(du.status(), StatusCode::OK);
         let du_body = response_text(du).await;
-        assert!(du_body.contains("home/hello\t5\n"));
+        assert!(du_body.contains("home/hello\t10\n"));
         assert!(du_body.contains("tmp/scratch\t4\n"));
 
         let df = proc_df(State(state.clone()), Method::GET, headers.clone()).await;
         assert_eq!(df.status(), StatusCode::OK);
         let df_body = response_text(df).await;
-        assert!(df_body.contains("storage\t5\t10\t5\n"));
+        assert!(df_body.contains("storage\t10\t16\t6\n"));
         assert!(df_body.contains("memory\t4\t268435456\t268435452\n"));
         assert!(df_body.contains("worlds\t2\tunlimited\tunlimited\n"));
 
         let head = proc_du(State(state), Method::HEAD, headers).await;
         assert_eq!(head.status(), StatusCode::OK);
-        assert_eq!(head.headers().get(header::CONTENT_LENGTH).unwrap(), "27");
+        assert_eq!(head.headers().get(header::CONTENT_LENGTH).unwrap(), "28");
         assert_eq!(response_text(head).await, "");
 
         let _ = std::fs::remove_dir_all(dir);

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -11,18 +11,21 @@ use crate::{
     engine_types::{AuditHmacKey, ValidatedWorldPath},
     timeline::TimelineSeq,
     world,
+    world_generation::WorldGeneration,
 };
 use std::{collections::HashSet, fmt, path::Path};
 
 mod append;
 mod live_body;
 mod retention;
+mod timeline_address;
 
 #[cfg(test)]
 use append::test_only_append_tx_inner as append_tx_inner;
 pub(crate) use append::{
     append_retained_body_tx_row, append_with_conn_existing, append_with_conn_genesis,
 };
+pub(crate) use timeline_address::VerifiedBodyEvent;
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
@@ -135,15 +138,17 @@ fn verify_appendable_tx<'tx, 'conn, 'key>(
     key: &'key AuditHmacKey,
     empty_chain: EmptyChain,
 ) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
+    let generation = crate::world_schema::generation(tx)?;
     let retention = retention::load(tx)?;
     let mut stmt = tx.prepare(AUDIT_SELECT)?;
     let allow_empty = matches!(empty_chain, EmptyChain::Allow);
     require_intact(verify_statement(
         &mut stmt,
-        key.as_slice(),
+        key,
         allow_empty,
         &retention,
         Some(world_name.as_str()),
+        &generation,
     )?)?;
     if let Some(break_report) = live_body::verify_tx(tx)? {
         return Err(AuditError::ChainBroken(break_report));
@@ -176,27 +181,17 @@ struct EventHmacInput<'a> {
     prev: &'a str,
     event_type: &'a str,
     target: &'a str,
+    generation: &'a WorldGeneration,
     body_sha256: &'a str,
     size: i64,
     content_type: &'a str,
     meta_sha256: &'a str,
 }
 
-/// O(1) chain-head read through the SlotState-tracked read path: the
-/// newest event's `(id, hmac)` without re-walking the chain.
-///
-/// This is the unit of external anchoring (the O(1) subset of what
-/// `verify_chain_via_conn` reports as `latest`): a host that remembers the
-/// returned stamp can later prove tail truncation or rollback whenever the
-/// observed head is behind the anchored seq -- which in-file verification
-/// structurally cannot. (A rolled-back or replaced chain re-grown past the
-/// anchor needs the at-seq divergence check, a later PR.) Returns
-/// `Ok(None)` for an empty chain (bootstrap-shape DB) -- nothing to anchor
-/// yet.
-///
-/// Same type gate as `verify_chain_via_conn`: no bare-connection path, so
-/// a delete on the same world drains in-flight head reads via the usual
-/// SlotState write guard.
+/// O(1) chain-head read through the SlotState-tracked read path: newest
+/// `(id, hmac)` without re-walking the chain. `Ok(None)` means an empty
+/// bootstrap-shape DB. Same type gate as `verify_chain_via_conn`, so delete
+/// drains in-flight head reads through SlotState.
 pub fn chain_head_via_conn(
     tracked: &mut crate::read_cache::TrackedReadConnection,
 ) -> rusqlite::Result<Option<(i64, String)>> {
@@ -205,22 +200,15 @@ pub fn chain_head_via_conn(
         .query_row(
             "SELECT id, hmac FROM events ORDER BY id DESC LIMIT 1",
             [],
-            // hmac_label: same `hmac-` rendering as VerifyOk's
-            // genesis/latest, so a stamp compares byte-for-byte with
-            // what verify reports and what subscribers witness.
+            // Same `hmac-` rendering as VerifyOk.
             |r| Ok((r.get::<_, i64>(0)?, hmac_label(&r.get::<_, String>(1)?))),
         )
         .optional()
 }
 
-/// Verify the audit chain through a `TrackedReadConnection` (the
-/// SlotState-tracked read path). Mirrors `world::read_with_hmac_via_conn`
-/// -- the cache layer drives the slot-before-open dance and hands us
-/// the connection through the type gate. The bare per-operation
-/// `verify_chain(data, world, key)` path is gone (Bug 58); admin
-/// audit-verify surfaces now go through `Core::cached_verify_chain`,
-/// so a delete on the same world drains in-flight verifies via the
-/// usual SlotState write guard.
+/// Verify through the SlotState-tracked read path. There is no bare
+/// per-operation verify path, so delete drains in-flight verifies through the
+/// same guard as ordinary cached reads.
 pub fn verify_chain_via_conn(
     tracked: &mut crate::read_cache::TrackedReadConnection,
     world_name: &str,
@@ -241,9 +229,10 @@ pub fn verify_chain_via_conn(
 
 #[cfg(test)]
 fn verify_connection(c: &Connection, key: &AuditHmacKey) -> rusqlite::Result<VerifyReport> {
+    let generation = crate::world_schema::generation(c)?;
     let retention = retention::load(c)?;
     let mut stmt = c.prepare(AUDIT_SELECT)?;
-    verify_statement(&mut stmt, key.as_slice(), false, &retention, None)
+    verify_statement(&mut stmt, key, false, &retention, None, &generation)
 }
 
 fn verify_world_connection(
@@ -251,23 +240,26 @@ fn verify_world_connection(
     world_name: &ValidatedWorldPath,
     key: &AuditHmacKey,
 ) -> rusqlite::Result<VerifyReport> {
+    let generation = crate::world_schema::generation(c)?;
     let retention = retention::load(c)?;
     let mut stmt = c.prepare(AUDIT_SELECT)?;
     verify_statement(
         &mut stmt,
-        key.as_slice(),
+        key,
         false,
         &retention,
         Some(world_name.as_str()),
+        &generation,
     )
 }
 
 fn verify_statement(
     stmt: &mut Statement<'_>,
-    key: &[u8],
+    key: &AuditHmacKey,
     allow_empty: bool,
     retention: &retention::CasRetentionState,
     expected_target: Option<&str>,
+    generation: &WorldGeneration,
 ) -> rusqlite::Result<VerifyReport> {
     let mut state = VerifyAccumulator {
         prev: String::new(),
@@ -302,6 +294,7 @@ fn verify_statement(
                 retention,
                 &mut state,
                 expected_target,
+                generation,
             ) {
                 return Ok(VerifyReport::Broken(break_report));
             }
@@ -325,6 +318,7 @@ fn verify_statement(
             retention,
             &mut state,
             expected_target,
+            generation,
         ) {
             return Ok(VerifyReport::Broken(break_report));
         }
@@ -366,10 +360,11 @@ fn require_intact(report: VerifyReport) -> AuditResult<()> {
 fn verify_event(
     row: &EventRow,
     headers: &[(String, String)],
-    key: &[u8],
+    key: &AuditHmacKey,
     retention: &retention::CasRetentionState,
     state: &mut VerifyAccumulator,
     expected_target: Option<&str>,
+    generation: &WorldGeneration,
 ) -> Option<VerifyBreak> {
     let idx = state.events;
     if matches!(row.event_type.as_str(), "put" | "append")
@@ -402,6 +397,7 @@ fn verify_event(
             prev: &state.prev,
             event_type: &row.event_type,
             target: &row.target,
+            generation,
             body_sha256: &row.body_sha256,
             size: row.size,
             content_type: &row.content_type,
@@ -449,11 +445,12 @@ fn hmac_field(mac: &mut Hmac<Sha256>, label: &[u8], value: &str) {
     mac.update(b"\0");
 }
 
-fn event_hmac(key: &[u8], input: EventHmacInput<'_>) -> String {
-    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("hmac key");
+fn event_hmac(key: &AuditHmacKey, input: EventHmacInput<'_>) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key.as_slice()).expect("hmac key");
     hmac_field(&mut mac, b"prev", input.prev);
     hmac_field(&mut mac, b"type", input.event_type);
     hmac_field(&mut mac, b"target", input.target);
+    hmac_field(&mut mac, b"gen", input.generation.as_str());
     hmac_field(&mut mac, b"body-sha256", input.body_sha256);
     hmac_field(&mut mac, b"size", &input.size.to_string());
     hmac_field(&mut mac, b"content-type", input.content_type);
@@ -524,6 +521,8 @@ mod tests {
                 name TEXT NOT NULL,
                 value TEXT NOT NULL
             );
+            CREATE VIEW stage_meta AS
+            SELECT 1 AS id, '0123456789abcdef0123456789abcdef' AS generation;
             CREATE TABLE cas_bodies(
                 body_sha256 TEXT NOT NULL PRIMARY KEY,
                 body BLOB NOT NULL
@@ -566,12 +565,14 @@ mod tests {
 
     fn hmac_for_fields(event_type: &str, target: &str) -> String {
         let key = test_key();
+        let generation = WorldGeneration::new("0123456789abcdef0123456789abcdef").unwrap();
         event_hmac(
-            key.as_slice(),
+            &key,
             EventHmacInput {
                 prev: "",
                 event_type,
                 target,
+                generation: &generation,
                 body_sha256: "abc",
                 size: 3,
                 content_type: "text/plain",
@@ -981,6 +982,8 @@ mod tests {
                 name TEXT NOT NULL,
                 value TEXT NOT NULL
             );
+            CREATE VIEW stage_meta AS
+            SELECT 1 AS id, '0123456789abcdef0123456789abcdef' AS generation;
             CREATE TABLE cas_bodies(
                 body_sha256 TEXT NOT NULL PRIMARY KEY,
                 body BLOB NOT NULL

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -25,9 +25,9 @@ use append::test_only_append_tx_inner as append_tx_inner;
 pub(crate) use append::{
     append_retained_body_tx_row, append_with_conn_existing, append_with_conn_genesis,
 };
-pub(crate) use timeline_address::VerifiedBodyEvent;
 #[cfg(test)]
 use rusqlite::Connection;
+pub(crate) use timeline_address::VerifiedBodyEvent;
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -147,6 +147,7 @@ fn append_tx_inner(
     );
     let canonical = canonical_headers(headers);
     let meta_sha256 = super::meta_sha256_canonical(content_type, &canonical);
+    let generation = crate::world_schema::generation(tx)?;
     let prev = tx
         .query_row(
             "SELECT hmac FROM events ORDER BY id DESC LIMIT 1",
@@ -156,11 +157,12 @@ fn append_tx_inner(
         .optional()?
         .unwrap_or_default();
     let h = event_hmac(
-        audit_tx.key.as_slice(),
+        audit_tx.key,
         EventHmacInput {
             prev: &prev,
             event_type: event_type.as_str(),
             target,
+            generation: &generation,
             body_sha256: body_sha256.as_str(),
             size,
             content_type,

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -61,7 +61,7 @@ pub(crate) fn verified_timeline_address_via_conn(
     // Verification and row extraction must share one SQLite snapshot; otherwise
     // a concurrent writer could append a row after verification but before the
     // address lookup.
-    super::require_intact(super::verify_world_connection(&tx, world, key)?)?;
+    super::require_intact(super::verify_world_tx(&tx, world, key)?)?;
 
     let Some(row) = tx
         .query_row(

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -1,0 +1,504 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use rusqlite::{ffi, params, OptionalExtension};
+
+use crate::{
+    engine_types::{AuditHmacKey, ValidatedWorldPath},
+    event::AuditEventKind,
+    read_cache::TrackedReadConnection,
+    timeline::{BodySha256, TimelineAddress, TimelineAddressLookup, TimelineSeq},
+    world_generation::WorldGeneration,
+    world_schema,
+};
+
+pub(crate) struct VerifiedBodyEvent {
+    world: ValidatedWorldPath,
+    gen: WorldGeneration,
+    seq: TimelineSeq,
+    body_sha256: BodySha256,
+}
+
+impl VerifiedBodyEvent {
+    fn new(
+        world: ValidatedWorldPath,
+        gen: WorldGeneration,
+        seq: TimelineSeq,
+        body_sha256: BodySha256,
+    ) -> Self {
+        Self {
+            world,
+            gen,
+            seq,
+            body_sha256,
+        }
+    }
+
+    pub(crate) fn world(&self) -> &ValidatedWorldPath {
+        &self.world
+    }
+
+    pub(crate) fn gen(&self) -> &WorldGeneration {
+        &self.gen
+    }
+
+    pub(crate) fn seq(&self) -> TimelineSeq {
+        self.seq
+    }
+
+    pub(crate) fn body_sha256(&self) -> &BodySha256 {
+        &self.body_sha256
+    }
+}
+
+pub(crate) fn verified_timeline_address_via_conn(
+    tracked: &mut TrackedReadConnection,
+    world: &ValidatedWorldPath,
+    seq: TimelineSeq,
+    key: &AuditHmacKey,
+) -> super::AuditResult<TimelineAddressLookup> {
+    let conn = tracked.as_mut_conn();
+    let tx = conn.transaction()?;
+    // Verification and row extraction must share one SQLite snapshot; otherwise
+    // a concurrent writer could append a row after verification but before the
+    // address lookup.
+    super::require_intact(super::verify_world_connection(&tx, world, key)?)?;
+
+    let Some(row) = tx
+        .query_row(
+            "SELECT event_type, target, body_sha256 FROM events WHERE id=?1",
+            params![seq.get()],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?
+    else {
+        return Ok(TimelineAddressLookup::MissingRow);
+    };
+
+    let kind = AuditEventKind::from_storage(&row.0)
+        .ok_or_else(|| corrupt("events.event_type is not a known audit event"))?;
+    if !kind.class().body_bearing {
+        return Ok(TimelineAddressLookup::NoBody);
+    }
+    if row.1 != world.as_str() {
+        return Err(corrupt("events.target does not match requested world").into());
+    }
+    let body_sha256 = BodySha256::new(row.2)
+        .map_err(|err| corrupt(&format!("events.body_sha256 is invalid: {err:?}")))?;
+    let gen = world_schema::generation(&tx)?;
+    let event = VerifiedBodyEvent::new(world.clone(), gen, seq, body_sha256);
+    let lookup = TimelineAddressLookup::Body(TimelineAddress::from_verified_body_event(event));
+    tx.commit()?;
+    Ok(lookup)
+}
+
+fn corrupt(message: &str) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error::new(ffi::SQLITE_CORRUPT),
+        Some(message.to_owned()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+    use crate::{
+        engine::Engine,
+        engine_types::{AccessTier, AuditHmacKey, Preconditions, Representation},
+    };
+    use bytes::Bytes;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "elastik-audit-timeline-address-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        root
+    }
+
+    fn key() -> AuditHmacKey {
+        AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
+    fn resign_event(
+        conn: &rusqlite::Connection,
+        id: i64,
+        event_type: &str,
+        body_sha256: &str,
+        key: &AuditHmacKey,
+    ) {
+        let generation = world_schema::generation(conn).unwrap();
+        let (target, size, content_type, meta_sha256, prev_hmac): (
+            String,
+            i64,
+            String,
+            String,
+            String,
+        ) = conn
+            .query_row(
+                "SELECT target, size, content_type, meta_sha256, prev_hmac FROM events WHERE id=?1",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .unwrap();
+        let hmac = super::super::event_hmac(
+            key,
+            super::super::EventHmacInput {
+                prev: &prev_hmac,
+                event_type,
+                target: &target,
+                generation: &generation,
+                body_sha256,
+                size,
+                content_type: &content_type,
+                meta_sha256: &meta_sha256,
+            },
+        );
+        conn.execute(
+            "UPDATE events SET event_type=?1, body_sha256=?2, hmac=?3 WHERE id=?4",
+            rusqlite::params![event_type, body_sha256, hmac, id],
+        )
+        .unwrap();
+    }
+
+    fn assert_corrupt_error(result: super::super::AuditResult<TimelineAddressLookup>, text: &str) {
+        match result {
+            Err(super::super::AuditError::Storage(rusqlite::Error::SqliteFailure(
+                err,
+                Some(message),
+            ))) => {
+                assert_eq!(err.extended_code, rusqlite::ffi::SQLITE_CORRUPT);
+                assert!(message.contains(text), "{message}");
+            }
+            other => panic!("expected SQLITE_CORRUPT containing {text:?}, got {other:?}"),
+        }
+    }
+
+    fn single_event_conn(
+        world: &ValidatedWorldPath,
+        event_type: &str,
+        body_sha256: &str,
+        key: &AuditHmacKey,
+    ) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                target TEXT NOT NULL,
+                body_sha256 TEXT NOT NULL,
+                size INTEGER NOT NULL,
+                content_type TEXT NOT NULL,
+                meta_sha256 TEXT NOT NULL,
+                hmac TEXT NOT NULL,
+                prev_hmac TEXT NOT NULL
+            );
+            CREATE TABLE event_headers(
+                event_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                value TEXT NOT NULL
+            );
+            CREATE VIEW stage_meta AS
+            SELECT 1 AS id, '0123456789abcdef0123456789abcdef' AS generation;
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY,
+                body BLOB NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE cas_state(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                first_retained_seq INTEGER
+            );
+            INSERT INTO cas_state(id, first_retained_seq) VALUES(1, NULL);
+            "#,
+        )
+        .unwrap();
+        let generation = world_schema::generation(&conn).unwrap();
+        let meta_sha256 = super::super::meta_sha256_canonical("application/octet-stream", &[]);
+        let hmac = super::super::event_hmac(
+            key,
+            super::super::EventHmacInput {
+                prev: "",
+                event_type,
+                target: world.as_str(),
+                generation: &generation,
+                body_sha256,
+                size: 0,
+                content_type: "application/octet-stream",
+                meta_sha256: &meta_sha256,
+            },
+        );
+        conn.execute(
+            r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
+                                  content_type, meta_sha256, hmac, prev_hmac)
+               VALUES(datetime('now'), ?1, ?2, ?3, 0, 'application/octet-stream', ?4, ?5, '')"#,
+            rusqlite::params![event_type, world.as_str(), body_sha256, meta_sha256, hmac],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[tokio::test]
+    async fn verified_timeline_address_uses_event_row_not_current_body() {
+        let root = temp_root("historical-row");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/history").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"old"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"new"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        let lookup = verified_timeline_address_via_conn(
+            &mut tracked,
+            &world,
+            TimelineSeq::new(1).unwrap(),
+            &engine.core().hmac_key,
+        )
+        .unwrap();
+
+        match lookup {
+            TimelineAddressLookup::Body(address) => {
+                assert_eq!(address.world(), &world);
+                assert_eq!(address.gen(), &gen);
+                assert_eq!(address.seq().get(), 1);
+                assert_eq!(address.body_sha256(), &BodySha256::for_body(b"old"));
+            }
+            TimelineAddressLookup::MissingRow | TimelineAddressLookup::NoBody => {
+                panic!("expected body timeline address")
+            }
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn verified_timeline_address_rejects_generation_tampering() {
+        let root = temp_root("generation-tamper");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/generation-tamper").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        conn.execute(
+            "UPDATE stage_meta SET generation='fedcba9876543210fedcba9876543210' WHERE id=1",
+            [],
+        )
+        .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        assert!(matches!(
+            verified_timeline_address_via_conn(
+                &mut tracked,
+                &world,
+                TimelineSeq::new(1).unwrap(),
+                &engine.core().hmac_key,
+            ),
+            Err(super::super::AuditError::ChainBroken(_))
+        ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn verified_timeline_address_rejects_unknown_event_type_as_corrupt() {
+        let key = key();
+        let ledger = ValidatedWorldPath::new("var/log/deletes").unwrap();
+        let conn = single_event_conn(&ledger, "custom", "", &key);
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        assert_corrupt_error(
+            verified_timeline_address_via_conn(
+                &mut tracked,
+                &ledger,
+                TimelineSeq::new(1).unwrap(),
+                &key,
+            ),
+            "events.event_type",
+        );
+    }
+
+    #[tokio::test]
+    async fn verified_timeline_address_rejects_invalid_body_hash_before_minting() {
+        let root = temp_root("invalid-body-hash");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/invalid-body-hash").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        resign_event(&conn, 1, "put", "not-a-valid-hash", &engine.core().hmac_key);
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        match verified_timeline_address_via_conn(
+            &mut tracked,
+            &world,
+            TimelineSeq::new(1).unwrap(),
+            &engine.core().hmac_key,
+        ) {
+            Err(super::super::AuditError::ChainBroken(report)) => {
+                assert_eq!(report.expected, "valid body_sha256");
+                assert_eq!(report.actual, "body-sha256-not-a-valid-hash");
+            }
+            other => panic!("expected invalid body hash to break verification, got {other:?}"),
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn verified_timeline_address_reports_missing_rows() {
+        let root = temp_root("missing-row");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/missing-row").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        assert!(matches!(
+            verified_timeline_address_via_conn(
+                &mut tracked,
+                &world,
+                TimelineSeq::new(99).unwrap(),
+                &engine.core().hmac_key,
+            )
+            .unwrap(),
+            TimelineAddressLookup::MissingRow
+        ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn verified_timeline_address_reports_metadata_events_as_no_body() {
+        let root = temp_root("no-body");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let subject = ValidatedWorldPath::new("home/deleted").unwrap();
+        engine
+            .replace(
+                &subject,
+                Representation::new(Bytes::from_static(b"deleted"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        engine
+            .delete(&subject, Preconditions::none(), AccessTier::Approve)
+            .await
+            .unwrap();
+
+        let ledger = ValidatedWorldPath::new("var/log/deletes").unwrap();
+        let conn = rusqlite::Connection::open(crate::world::world_db(
+            &engine.core().data,
+            ledger.as_str(),
+        ))
+        .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        assert!(matches!(
+            verified_timeline_address_via_conn(
+                &mut tracked,
+                &ledger,
+                TimelineSeq::new(1).unwrap(),
+                &engine.core().hmac_key,
+            )
+            .unwrap(),
+            TimelineAddressLookup::NoBody
+        ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -39,6 +39,18 @@ pub(crate) struct AuditEventClass {
 }
 
 impl AuditEventKind {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn from_storage(raw: &str) -> Option<Self> {
+        match raw {
+            "put" => Some(Self::Put),
+            "append" => Some(Self::Append),
+            "delete_intent" => Some(Self::DeleteIntent),
+            "delete_commit" => Some(Self::DeleteCommit),
+            "delete_commit_failed" => Some(Self::DeleteCommitFailed),
+            _ => None,
+        }
+    }
+
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Put => "put",
@@ -167,5 +179,19 @@ mod tests {
             AuditEventKind::DeleteCommitFailed.as_str(),
             "delete_commit_failed"
         );
+    }
+
+    #[test]
+    fn audit_event_kind_parses_storage_strings() {
+        for kind in [
+            AuditEventKind::Put,
+            AuditEventKind::Append,
+            AuditEventKind::DeleteIntent,
+            AuditEventKind::DeleteCommit,
+            AuditEventKind::DeleteCommitFailed,
+        ] {
+            assert_eq!(AuditEventKind::from_storage(kind.as_str()), Some(kind));
+        }
+        assert_eq!(AuditEventKind::from_storage("custom"), None);
     }
 }

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -79,6 +79,13 @@ pub(crate) enum TimelineRead {
     },
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TimelineAddressLookup {
+    Body(TimelineAddress),
+    MissingRow,
+    NoBody,
+}
+
 impl TimelineBody {
     pub(crate) fn address(&self) -> &TimelineAddress {
         &self.address
@@ -119,6 +126,15 @@ impl TimelineAddress {
             seq,
             body_sha256,
         }
+    }
+
+    pub(crate) fn from_verified_body_event(event: crate::audit::VerifiedBodyEvent) -> Self {
+        Self::new(
+            event.world().clone(),
+            event.gen().clone(),
+            event.seq(),
+            event.body_sha256().clone(),
+        )
     }
 
     pub(crate) fn world(&self) -> &ValidatedWorldPath {
@@ -391,6 +407,25 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn timeline_address_lookup_distinguishes_missing_and_non_body_events() {
+        match TimelineAddressLookup::Body(address(8)) {
+            TimelineAddressLookup::Body(address) => assert_eq!(address.seq().get(), 8),
+            TimelineAddressLookup::MissingRow | TimelineAddressLookup::NoBody => {
+                panic!("expected body address")
+            }
+        }
+
+        assert!(matches!(
+            TimelineAddressLookup::MissingRow,
+            TimelineAddressLookup::MissingRow
+        ));
+        assert!(matches!(
+            TimelineAddressLookup::NoBody,
+            TimelineAddressLookup::NoBody
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bind audit HMAC input to `WorldGeneration` so a body hash cannot be replayed under the wrong world instance.
- Add verified timeline-address extraction from audit event rows through `TrackedReadConnection`, `ValidatedWorldPath`, `TimelineSeq`, and `AuditHmacKey`.
- Introduce `VerifiedBodyEvent` as the minting gate for `TimelineAddress`; metadata/non-body events return `NoBody`, missing rows return `MissingRow`, and corrupt rows fail before an address is minted.
- Align bin quota/proc tests with retained-CAS accounting so the pre-push hook stays honest.

## Type-Seal Shape

The protected path now requires:

- `TrackedReadConnection` for read-cache fd lifecycle discipline.
- `ValidatedWorldPath` for canonical world binding.
- `TimelineSeq` for positive SQLite event row ids.
- `AuditHmacKey` for key-length proof and HMAC sink access.
- `WorldGeneration` in the signed HMAC material.
- `VerifiedBodyEvent` before constructing a `TimelineAddress`.

`AuditHmacKey::as_slice()` remains at the HMAC primitive sink; callers do not get a raw key API for timeline extraction.

## Validation

Local before push:

- `cargo test --manifest-path bin/Cargo.toml`: 108 passed.
- `cargo test --lib` in `core`: 163 passed, 2 ignored.
- `cargo clippy --manifest-path bin/Cargo.toml --all-targets -- -D warnings`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

Pre-push hook also passed:

- Rust format.
- Rust clippy.
- Rust tests: core 163 passed, 2 ignored; doc-tests 5 passed; bin 108 passed.
- Version consistency: 8.3.0.
- Bundled SQLite check: libsqlite3-sys 0.38.0 bundles SQLite 3.53.1.
- `cargo audit` for core/bin/ffi locks.
- Python SDK smoke.
- Header policy scanner and missing-baseline negative test.
- JS syntax.
- Whitespace check.

## Review Ledger

Final subagent review rounds were clean P0-P2:

- Noether: invariant check for retained-CAS quota accounting and timeline minting.
- Popper: attempted counterexamples for quota/proc expectations and event-row address extraction.
- QA-Enforcement: scoped-diff and process check, no production drift in the bin hook-unblocker commit.
- Mencius/Jason earlier checked the type-seal shape for audit/timeline extraction.

## Line Budget

Core layer review snapshot:

- Raw diff: about +605/-35.
- Production diff: about +167/-34.
- Test diff: about +438/-1.

Hook-unblocker commit:

- Tests only: 2 files, +16/-13.

