### PR TITLE
core: dereference timeline bodies from retained cas

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -454,6 +454,8 @@ fn hmac_field(mac: &mut Hmac<Sha256>, label: &[u8], value: &str) {
     mac.update(b"\0");
 }
 
+// Invariant: HMAC accepts any key length; AuditHmacKey enforces Elastik's key policy.
+#[allow(clippy::expect_used)]
 fn event_hmac(key: &AuditHmacKey, input: EventHmacInput<'_>) -> String {
     let mut mac = Hmac::<Sha256>::new_from_slice(key.as_slice()).expect("hmac key");
     hmac_field(&mut mac, b"prev", input.prev);

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -118,7 +118,7 @@ pub(crate) fn read_timeline_body_via_conn(
     let conn = tracked.as_mut_conn();
     let tx = conn.transaction()?;
     let actual_gen = world_schema::generation(&tx)?;
-    super::require_intact(super::verify_world_connection(&tx, address.world(), key)?)?;
+    super::require_intact(super::verify_world_tx(&tx, address.world(), key)?)?;
 
     let read = if &actual_gen != address.gen() {
         TimelineRead::GenMismatch {

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -1,12 +1,16 @@
 #![cfg_attr(not(test), allow(dead_code))]
 
+use bytes::Bytes;
 use rusqlite::{ffi, params, OptionalExtension};
 
 use crate::{
-    engine_types::{AuditHmacKey, ValidatedWorldPath},
+    engine_types::{AuditHmacKey, Representation, ValidatedWorldPath},
     event::AuditEventKind,
     read_cache::TrackedReadConnection,
-    timeline::{BodySha256, TimelineAddress, TimelineAddressLookup, TimelineSeq},
+    timeline::{
+        BodySha256, TimelineAddress, TimelineAddressLookup, TimelineCorruption, TimelineRead,
+        TimelineSeq,
+    },
     world_generation::WorldGeneration,
     world_schema,
 };
@@ -48,6 +52,15 @@ impl VerifiedBodyEvent {
     pub(crate) fn body_sha256(&self) -> &BodySha256 {
         &self.body_sha256
     }
+}
+
+struct TimelineEventSnapshot {
+    event_type: String,
+    target: String,
+    body_sha256: String,
+    size: i64,
+    content_type: String,
+    headers: Vec<(String, String)>,
 }
 
 pub(crate) fn verified_timeline_address_via_conn(
@@ -95,6 +108,147 @@ pub(crate) fn verified_timeline_address_via_conn(
     let lookup = TimelineAddressLookup::Body(TimelineAddress::from_verified_body_event(event));
     tx.commit()?;
     Ok(lookup)
+}
+
+pub(crate) fn read_timeline_body_via_conn(
+    tracked: &mut TrackedReadConnection,
+    address: &TimelineAddress,
+    key: &AuditHmacKey,
+) -> super::AuditResult<TimelineRead> {
+    let conn = tracked.as_mut_conn();
+    let tx = conn.transaction()?;
+    let actual_gen = world_schema::generation(&tx)?;
+    super::require_intact(super::verify_world_connection(&tx, address.world(), key)?)?;
+
+    let read = if &actual_gen != address.gen() {
+        TimelineRead::GenMismatch {
+            requested: address.clone(),
+            actual: actual_gen,
+        }
+    } else {
+        match load_event_snapshot(&tx, address.seq())? {
+            Some(row) => timeline_read_from_snapshot(&tx, address, row)?,
+            None => TimelineRead::MissingRow {
+                address: address.clone(),
+            },
+        }
+    };
+    tx.commit()?;
+    Ok(read)
+}
+
+fn load_event_snapshot(
+    tx: &rusqlite::Transaction<'_>,
+    seq: TimelineSeq,
+) -> rusqlite::Result<Option<TimelineEventSnapshot>> {
+    let Some((event_type, target, body_sha256, size, content_type)) = tx
+        .query_row(
+            "SELECT event_type, target, body_sha256, size, content_type FROM events WHERE id=?1",
+            params![seq.get()],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                    r.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()?
+    else {
+        return Ok(None);
+    };
+
+    let mut headers = Vec::new();
+    {
+        let mut stmt = tx.prepare(
+            "SELECT name, value FROM event_headers WHERE event_id=?1 ORDER BY name, value",
+        )?;
+        let rows = stmt.query_map(params![seq.get()], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })?;
+        for pair in rows {
+            headers.push(pair?);
+        }
+    }
+
+    Ok(Some(TimelineEventSnapshot {
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+    }))
+}
+
+fn timeline_read_from_snapshot(
+    tx: &rusqlite::Transaction<'_>,
+    address: &TimelineAddress,
+    row: TimelineEventSnapshot,
+) -> rusqlite::Result<TimelineRead> {
+    let Some(kind) = AuditEventKind::from_storage(&row.event_type) else {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::InvalidEventShape,
+        ));
+    };
+    if !kind.class().body_bearing {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::MissingBodyForPresentRow,
+        ));
+    }
+    if row.target != address.world().as_str() {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::InvalidEventShape,
+        ));
+    }
+    let Ok(body_sha256) = BodySha256::new(row.body_sha256) else {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::InvalidEventShape,
+        ));
+    };
+    if &body_sha256 != address.body_sha256() {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::InvalidEventShape,
+        ));
+    }
+
+    let Some(body) = tx
+        .query_row(
+            "SELECT body FROM cas_bodies WHERE body_sha256=?1",
+            params![address.body_sha256().as_str()],
+            |r| r.get::<_, Vec<u8>>(0),
+        )
+        .optional()?
+    else {
+        return Ok(TimelineRead::Expired {
+            address: address.clone(),
+        });
+    };
+    if i64::try_from(body.len()).ok() != Some(row.size) {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::InvalidEventShape,
+        ));
+    }
+
+    Ok(TimelineRead::body(
+        address.clone(),
+        Representation::new(Bytes::from(body), row.content_type, row.headers),
+    ))
+}
+
+fn timeline_corrupt(address: &TimelineAddress, reason: TimelineCorruption) -> TimelineRead {
+    TimelineRead::Corrupt {
+        address: address.clone(),
+        reason,
+    }
 }
 
 fn corrupt(message: &str) -> rusqlite::Error {
@@ -307,6 +461,197 @@ mod tests {
             TimelineAddressLookup::MissingRow | TimelineAddressLookup::NoBody => {
                 panic!("expected body timeline address")
             }
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn read_timeline_body_uses_retained_cas_not_current_body() {
+        let root = temp_root("read-historical-body");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/read-history").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(
+                    Bytes::from_static(b"old"),
+                    "text/plain",
+                    vec![("x-meta-version".to_owned(), "old".to_owned())],
+                ),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(
+                    Bytes::from_static(b"new"),
+                    "text/plain",
+                    vec![("x-meta-version".to_owned(), "new".to_owned())],
+                ),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+        let TimelineAddressLookup::Body(address) = verified_timeline_address_via_conn(
+            &mut tracked,
+            &world,
+            TimelineSeq::new(1).unwrap(),
+            &engine.core().hmac_key,
+        )
+        .unwrap() else {
+            panic!("expected body timeline address");
+        };
+
+        let read =
+            read_timeline_body_via_conn(&mut tracked, &address, &engine.core().hmac_key).unwrap();
+
+        match read {
+            TimelineRead::Body(body) => {
+                assert_eq!(body.address(), &address);
+                assert_eq!(body.representation().body, Bytes::from_static(b"old"));
+                assert_eq!(body.representation().content_type, "text/plain");
+                assert_eq!(
+                    body.representation().headers,
+                    vec![("x-meta-version".to_owned(), "old".to_owned())]
+                );
+            }
+            _ => panic!("expected retained historical body"),
+        }
+
+        assert_eq!(
+            engine
+                .read(&world, AccessTier::Read)
+                .unwrap()
+                .unwrap()
+                .representation
+                .body,
+            Bytes::from_static(b"new")
+        );
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn read_timeline_body_reports_generation_mismatch_without_current_read() {
+        let root = temp_root("read-generation-mismatch");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/read-gen-mismatch").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"old"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+        let TimelineAddressLookup::Body(address) = verified_timeline_address_via_conn(
+            &mut tracked,
+            &world,
+            TimelineSeq::new(1).unwrap(),
+            &engine.core().hmac_key,
+        )
+        .unwrap() else {
+            panic!("expected body timeline address");
+        };
+        drop(tracked);
+
+        engine
+            .delete(&world, Preconditions::none(), AccessTier::Approve)
+            .await
+            .unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"new"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        let new_gen = world_schema::generation(&conn).unwrap();
+        assert_ne!(&new_gen, address.gen());
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+        let read =
+            read_timeline_body_via_conn(&mut tracked, &address, &engine.core().hmac_key).unwrap();
+
+        match read {
+            TimelineRead::GenMismatch { requested, actual } => {
+                assert_eq!(requested, address);
+                assert_eq!(actual, new_gen);
+            }
+            _ => panic!("expected generation mismatch"),
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn read_timeline_body_reports_missing_row_for_same_generation_gap() {
+        let root = temp_root("read-missing-row");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/read-missing-row").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let conn =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, world.as_str()))
+                .unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+        let address = TimelineAddress::test_only_new(
+            world.clone(),
+            gen,
+            TimelineSeq::new(99).unwrap(),
+            BodySha256::for_body(b"value"),
+        );
+
+        match read_timeline_body_via_conn(&mut tracked, &address, &engine.core().hmac_key).unwrap()
+        {
+            TimelineRead::MissingRow { address: got } => assert_eq!(got, address),
+            _ => panic!("expected missing row"),
         }
 
         drop(engine);

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -213,10 +213,10 @@ fn timeline_read_from_snapshot(
         ));
     };
     if &body_sha256 != address.body_sha256() {
-        return Ok(timeline_corrupt(
-            address,
-            TimelineCorruption::InvalidEventShape,
-        ));
+        return Ok(TimelineRead::AddressMismatch {
+            requested: address.clone(),
+            actual: body_sha256,
+        });
     }
 
     let Some(body) = tx
@@ -227,9 +227,7 @@ fn timeline_read_from_snapshot(
         )
         .optional()?
     else {
-        return Ok(TimelineRead::Expired {
-            address: address.clone(),
-        });
+        return missing_timeline_body_read(tx, address);
     };
     if i64::try_from(body.len()).ok() != Some(row.size) {
         return Ok(timeline_corrupt(
@@ -249,6 +247,33 @@ fn timeline_corrupt(address: &TimelineAddress, reason: TimelineCorruption) -> Ti
         address: address.clone(),
         reason,
     }
+}
+
+fn missing_timeline_body_read(
+    tx: &rusqlite::Transaction<'_>,
+    address: &TimelineAddress,
+) -> rusqlite::Result<TimelineRead> {
+    let first_retained_seq = first_retained_seq(tx)?;
+    if first_retained_seq.is_some_and(|seq| address.seq() >= seq) {
+        return Ok(timeline_corrupt(
+            address,
+            TimelineCorruption::MissingBodyForPresentRow,
+        ));
+    }
+
+    Ok(TimelineRead::NeverRetained {
+        address: address.clone(),
+    })
+}
+
+fn first_retained_seq(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<Option<TimelineSeq>> {
+    tx.query_row(
+        "SELECT first_retained_seq FROM cas_state WHERE id=1",
+        [],
+        |r| r.get::<_, Option<i64>>(0),
+    )?
+    .map(|seq| TimelineSeq::new(seq).map_err(|_| corrupt("cas_state.first_retained_seq invalid")))
+    .transpose()
 }
 
 fn corrupt(message: &str) -> rusqlite::Error {
@@ -546,6 +571,94 @@ mod tests {
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn timeline_snapshot_reports_address_hash_mismatch_without_cas_lookup() {
+        let key = key();
+        let world = ValidatedWorldPath::new("home/address-mismatch").unwrap();
+        let mut conn = single_event_conn(
+            &world,
+            "put",
+            BodySha256::for_body(b"stored").as_str(),
+            &key,
+        );
+        conn.execute("UPDATE cas_state SET first_retained_seq=1 WHERE id=1", [])
+            .unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        let address = TimelineAddress::test_only_new(
+            world,
+            gen,
+            TimelineSeq::new(1).unwrap(),
+            BodySha256::for_body(b"requested"),
+        );
+
+        let tx = conn.transaction().unwrap();
+        let row = load_event_snapshot(&tx, address.seq()).unwrap().unwrap();
+
+        match timeline_read_from_snapshot(&tx, &address, row).unwrap() {
+            TimelineRead::AddressMismatch { requested, actual } => {
+                assert_eq!(requested, address);
+                assert_eq!(actual, BodySha256::for_body(b"stored"));
+            }
+            _ => panic!("expected address mismatch"),
+        }
+    }
+
+    #[test]
+    fn timeline_snapshot_reports_never_retained_before_retention_floor() {
+        let key = key();
+        let world = ValidatedWorldPath::new("home/never-retained").unwrap();
+        let mut conn =
+            single_event_conn(&world, "put", BodySha256::for_body(b"value").as_str(), &key);
+        conn.execute("UPDATE cas_state SET first_retained_seq=2 WHERE id=1", [])
+            .unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        let address = TimelineAddress::test_only_new(
+            world,
+            gen,
+            TimelineSeq::new(1).unwrap(),
+            BodySha256::for_body(b"value"),
+        );
+
+        let tx = conn.transaction().unwrap();
+        let row = load_event_snapshot(&tx, address.seq()).unwrap().unwrap();
+
+        match timeline_read_from_snapshot(&tx, &address, row).unwrap() {
+            TimelineRead::NeverRetained { address: got } => assert_eq!(got, address),
+            _ => panic!("expected never-retained timeline read"),
+        }
+    }
+
+    #[test]
+    fn timeline_snapshot_reports_corrupt_missing_retained_body() {
+        let key = key();
+        let world = ValidatedWorldPath::new("home/missing-retained").unwrap();
+        let mut conn =
+            single_event_conn(&world, "put", BodySha256::for_body(b"value").as_str(), &key);
+        conn.execute("UPDATE cas_state SET first_retained_seq=1 WHERE id=1", [])
+            .unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        let address = TimelineAddress::test_only_new(
+            world,
+            gen,
+            TimelineSeq::new(1).unwrap(),
+            BodySha256::for_body(b"value"),
+        );
+
+        let tx = conn.transaction().unwrap();
+        let row = load_event_snapshot(&tx, address.seq()).unwrap().unwrap();
+
+        match timeline_read_from_snapshot(&tx, &address, row).unwrap() {
+            TimelineRead::Corrupt {
+                address: got,
+                reason,
+            } => {
+                assert_eq!(got, address);
+                assert_eq!(reason, TimelineCorruption::MissingBodyForPresentRow);
+            }
+            _ => panic!("expected corrupt missing retained body"),
+        }
     }
 
     #[tokio::test]

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -60,6 +60,9 @@ pub(crate) enum TimelineCorruption {
 
 pub(crate) enum TimelineRead {
     Body(TimelineBody),
+    NeverRetained {
+        address: TimelineAddress,
+    },
     Expired {
         address: TimelineAddress,
     },
@@ -71,6 +74,13 @@ pub(crate) enum TimelineRead {
         actual: WorldGeneration,
     },
     MissingRow {
+        address: TimelineAddress,
+    },
+    AddressMismatch {
+        requested: TimelineAddress,
+        actual: BodySha256,
+    },
+    Unproven {
         address: TimelineAddress,
     },
     Corrupt {
@@ -391,6 +401,9 @@ mod tests {
         let actual = WorldGeneration::new("fedcba9876543210fedcba9876543210").unwrap();
 
         let reads = [
+            TimelineRead::NeverRetained {
+                address: address(1),
+            },
             TimelineRead::Expired {
                 address: address(2),
             },
@@ -404,10 +417,18 @@ mod tests {
                 requested: address(5),
                 actual: actual.clone(),
             },
+            TimelineRead::AddressMismatch {
+                requested: address(6),
+                actual: BodySha256::for_body(b"actual"),
+            },
+            TimelineRead::Unproven {
+                address: address(7),
+            },
         ];
 
         for read in reads {
             match read {
+                TimelineRead::NeverRetained { address } => assert_eq!(address.seq().get(), 1),
                 TimelineRead::Expired { address } => assert_eq!(address.seq().get(), 2),
                 TimelineRead::Gone { address } => assert_eq!(address.seq().get(), 3),
                 TimelineRead::MissingRow { address } => assert_eq!(address.seq().get(), 4),
@@ -418,6 +439,11 @@ mod tests {
                     assert_eq!(requested.seq().get(), 5);
                     assert_eq!(got, actual);
                 }
+                TimelineRead::AddressMismatch { requested, actual } => {
+                    assert_eq!(requested.seq().get(), 6);
+                    assert_eq!(actual, BodySha256::for_body(b"actual"));
+                }
+                TimelineRead::Unproven { address } => assert_eq!(address.seq().get(), 7),
                 TimelineRead::Body(_) | TimelineRead::Corrupt { .. } => {
                     panic!("unexpected read mode")
                 }

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -128,6 +128,16 @@ impl TimelineAddress {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_only_new(
+        world: ValidatedWorldPath,
+        gen: WorldGeneration,
+        seq: TimelineSeq,
+        body_sha256: BodySha256,
+    ) -> Self {
+        Self::new(world, gen, seq, body_sha256)
+    }
+
     pub(crate) fn from_verified_body_event(event: crate::audit::VerifiedBodyEvent) -> Self {
         Self::new(
             event.world().clone(),


### PR DESCRIPTION
## Summary

- Add the private core primitive for `read(TimelineAddress)` over retained CAS bodies.
- Require `TrackedReadConnection`, `TimelineAddress`, and `AuditHmacKey` before a timeline body can be dereferenced.
- Verify the audit chain and world generation in the same SQLite transaction before reading the event row/body.
- Return typed timeline outcomes instead of silently falling back to current body:
  - `Body` from `cas_bodies`.
  - `GenMismatch` for delete/recreate incarnation mismatch.
  - `MissingRow` for a same-generation sequence gap.
  - `Expired` for missing retained CAS body.
  - `Corrupt` for invalid row shape/hash/target.

This layer is intentionally private and unwired except tests. Public/adapter wiring is deferred to the next stacked layer so the CAS dereference contract can be reviewed by itself.

## Type-Seal Shape

- `read_timeline_body_via_conn` requires `&mut TrackedReadConnection`; callers cannot pass a bare `rusqlite::Connection`.
- `TimelineAddress` remains opaque; the only new constructor is `TimelineAddress::test_only_new` under plain `#[cfg(test)]`.
- The helper reads body bytes from `cas_bodies` by `body_sha256`, never from `stage_meta.body`.
- `TimelineRead::body` rehashes the returned bytes and converts a mismatch to `Corrupt`.

## Validation

Local and pre-push:

- `cargo test audit::timeline_address -- --nocapture`: 9 passed.
- `cargo test --lib` in `core`: 166 passed, 2 ignored.
- `cargo clippy --all-targets -- -D warnings` in `core`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

Pre-push hook also passed:

- Rust format.
- Rust clippy.
- Rust tests: core 166 passed, 2 ignored; doc-tests 5 passed; bin 108 passed.
- Version consistency: 8.3.0.
- Bundled SQLite check: libsqlite3-sys 0.38.0 bundles SQLite 3.53.1.
- `cargo audit` for core/bin/ffi locks.
- Python SDK smoke.
- Header policy scanner and missing-baseline negative test.
- JS syntax.
- Whitespace check.

## Review Ledger

Final subagent reviews were clean P0-P2:

- Mencius: type-seal integrity, no bare connection/current-body bypass.
- Popper: falsified the B-signal/C-current counterexample; no path returns current C.
- QA-Enforcement: scope/process clean; diff limited to core timeline/audit, no adapter drift.

P3/process note from QA: helper is private/unwired by design; this PR body records that explicitly.
