### PR TITLE
core: route timeline reads through read cache

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -25,6 +25,7 @@ use append::test_only_append_tx_inner as append_tx_inner;
 pub(crate) use append::{
     append_retained_body_tx_row, append_with_conn_existing, append_with_conn_genesis,
 };
+pub(crate) use timeline_address::read_timeline_body_via_conn;
 pub(crate) use timeline_address::VerifiedBodyEvent;
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -129,6 +129,9 @@ fn open_verified_read_conn(path: &std::path::Path) -> rusqlite::Result<Connectio
 /// See AGENTS.md section "Physics, not policy."
 pub(crate) struct TrackedReadConnection(Connection);
 
+#[cfg_attr(not(test), allow(dead_code))]
+type TimelineReadResult = crate::audit::AuditResult<crate::timeline::TimelineRead>;
+
 impl TrackedReadConnection {
     /// Module-private constructor. The only call site in the crate
     /// is `OpeningTransition::promote`. Intentionally not exposed
@@ -471,6 +474,26 @@ impl ReadCache {
         let key = key.clone_secret();
         self.with_tracked_conn(data, world, move |conn| {
             crate::audit::verify_chain_via_conn(conn, world, &key)
+        })
+    }
+
+    /// Historical body read through the cached read path. Same SlotState
+    /// protocol as ordinary cached reads: delete drains in-flight timeline
+    /// reads before unlinking the world database, and a tombstone produces
+    /// `Ok(None)` rather than opening a new fd.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn cached_read_timeline_body(
+        &self,
+        data: &std::path::Path,
+        address: &crate::timeline::TimelineAddress,
+        key: &crate::engine_types::AuditHmacKey,
+    ) -> rusqlite::Result<Option<TimelineReadResult>> {
+        let world = address.world().as_str();
+        let key = key.clone_secret();
+        self.with_tracked_conn(data, world, move |conn| {
+            Ok(crate::audit::read_timeline_body_via_conn(
+                conn, address, &key,
+            ))
         })
     }
 

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -490,7 +490,7 @@ impl ReadCache {
         address: &crate::timeline::TimelineAddress,
         key: &crate::engine_types::AuditHmacKey,
     ) -> rusqlite::Result<Option<TimelineReadResult>> {
-        let world = address.world().as_str();
+        let world = address.world();
         let key = key.clone_secret();
         self.with_tracked_conn(data, world, move |conn| {
             Ok(crate::audit::read_timeline_body_via_conn(

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -30,6 +30,7 @@ use crate::engine_types::{AuditHmacKey, ValidatedWorldPath};
 use crate::ledger::LedgerWriter;
 pub(crate) use crate::ledger::{AuditAppendJob, BlockingSqliteError};
 use crate::read_cache::ReadCache;
+use crate::timeline::{TimelineAddress, TimelineRead};
 use crate::world::Stage;
 use crate::{audit, auth, event, store, world};
 
@@ -240,6 +241,29 @@ impl Core {
             .cached_verify_chain(&self.data, world, &self.hmac_key)
     }
 
+    /// Historical body read through the read-cache SlotState protocol.
+    /// Durable timeline reads are fd-lifetime sensitive for the same reason
+    /// ordinary reads and audit verifies are: delete must drain the cached
+    /// connection before removing the world database.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn read_timeline_body(
+        &self,
+        address: &TimelineAddress,
+    ) -> audit::AuditResult<Option<TimelineRead>> {
+        debug_assert!(
+            !store::is_memory_world(address.world().as_str()),
+            "read_timeline_body only applies to durable worlds"
+        );
+        let read = self
+            .read_cache
+            .cached_read_timeline_body(&self.data, address, &self.hmac_key)
+            .map_err(audit::AuditError::from)?;
+        match read {
+            Some(result) => result.map(Some),
+            None => Ok(None),
+        }
+    }
+
     /// Test-only fixture: seed a world directly without going through
     /// auth/preconditions/audit. Production writes go through `world_ops`
     /// (durable: `world::write_with_audit_checked` + `reserve_storage`;
@@ -410,7 +434,13 @@ impl Core {
 
 #[cfg(test)]
 mod tests {
-    use crate::engine_types::AuditHmacKey;
+    use bytes::Bytes;
+
+    use crate::{
+        engine_types::{AuditHmacKey, ValidatedWorldPath},
+        timeline::{BodySha256, TimelineAddress, TimelineRead, TimelineSeq},
+        world, world_schema,
+    };
 
     #[test]
     fn core_hmac_key_is_stored_as_audit_hmac_key() {
@@ -418,6 +448,69 @@ mod tests {
 
         fn assert_audit_hmac_key(_: &AuditHmacKey) {}
         assert_audit_hmac_key(&core.hmac_key);
+
+        drop(core);
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn core_timeline_body_read_uses_read_cache_tombstone_protocol() {
+        let (core, dir) = crate::test_support::test_core("core-timeline-read-cache");
+        let world = ValidatedWorldPath::new("home/timeline-cache").unwrap();
+
+        world::write_with_audit_checked(
+            &core.data,
+            &world,
+            b"old",
+            "text/plain",
+            &[("x-meta-version".to_owned(), "old".to_owned())],
+            &core.hmac_key,
+        )
+        .unwrap();
+        world::write_with_audit_checked(
+            &core.data,
+            &world,
+            b"new",
+            "application/octet-stream",
+            &[("x-meta-version".to_owned(), "new".to_owned())],
+            &core.hmac_key,
+        )
+        .unwrap();
+
+        let conn = rusqlite::Connection::open(world::world_db(&core.data, world.as_str())).unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        drop(conn);
+        let address = TimelineAddress::test_only_new(
+            world.clone(),
+            gen,
+            TimelineSeq::new(1).unwrap(),
+            BodySha256::for_body(b"old"),
+        );
+
+        match core.read_timeline_body(&address).unwrap().unwrap() {
+            TimelineRead::Body(body) => {
+                assert_eq!(body.representation().body, Bytes::from_static(b"old"));
+                assert_eq!(
+                    body.representation().headers,
+                    vec![("x-meta-version".to_owned(), "old".to_owned())]
+                );
+            }
+            _ => panic!("expected retained historical body"),
+        }
+
+        core.install_tombstone(world.as_str()).await;
+        assert!(
+            core.read_timeline_body(&address).unwrap().is_none(),
+            "timeline reads must route through the read-cache tombstone gate"
+        );
+
+        core.clear_tombstone(world.as_str());
+        match core.read_timeline_body(&address).unwrap().unwrap() {
+            TimelineRead::Body(body) => {
+                assert_eq!(body.representation().body, Bytes::from_static(b"old"));
+            }
+            _ => panic!("expected retained historical body after tombstone clear"),
+        }
 
         drop(core);
         std::fs::remove_dir_all(dir).ok();

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -539,13 +539,13 @@ mod tests {
             _ => panic!("expected retained historical body"),
         }
 
-        core.install_tombstone(world.as_str()).await;
+        core.install_tombstone(&world).await;
         assert!(
             core.read_timeline_body(&address).unwrap().is_none(),
             "timeline reads must route through the read-cache tombstone gate"
         );
 
-        core.clear_tombstone(world.as_str());
+        core.clear_tombstone(&world);
         match core.read_timeline_body(&address).unwrap().unwrap() {
             TimelineRead::Body(body) => {
                 assert_eq!(body.representation().body, Bytes::from_static(b"old"));


### PR DESCRIPTION
## Summary

- Route private timeline body reads through the existing read-cache SlotState protocol.
- Add `ReadCache::cached_read_timeline_body` and private `Core::read_timeline_body` wrapper.
- Preserve tombstone/drain semantics: delete can short-circuit in-flight timeline reads with `Ok(None)` before unlinking a world database.
- Keep public `Engine`/adapter wiring out of this layer.

## Type-Seal Shape

Call path:

```text
Core::read_timeline_body
  -> ReadCache::cached_read_timeline_body
  -> ReadCache::with_tracked_conn
  -> audit::read_timeline_body_via_conn
```

The timeline SQL primitive still requires `&mut TrackedReadConnection`, `&TimelineAddress`, and `&AuditHmacKey`. This layer does not add any bare `rusqlite::Connection` read path.

## Transitional Dead Code

This PR intentionally lands the private Core/ReadCache wrapper before public API wiring. Three `#[cfg_attr(not(test), allow(dead_code))]` markers are scoped to that transitional surface:

- `TimelineReadResult` alias.
- `ReadCache::cached_read_timeline_body`.
- `Core::read_timeline_body`.

The next public wiring layer should remove this pressure by adding real production callers.

## Validation

Local and pre-push:

- `cargo test state::tests::core_timeline_body_read_uses_read_cache_tombstone_protocol -- --nocapture`: passed.
- `cargo test read_timeline_body -- --nocapture`: 3 passed.
- `cargo test --lib` in `core`: 167 passed, 2 ignored.
- `cargo clippy --all-targets -- -D warnings` in `core`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

Pre-push hook also passed:

- Rust format.
- Rust clippy.
- Rust tests: core 167 passed, 2 ignored; doc-tests 5 passed; bin 108 passed.
- Version consistency: 8.3.0.
- Bundled SQLite check: libsqlite3-sys 0.38.0 bundles SQLite 3.53.1.
- `cargo audit` for core/bin/ffi locks.
- Python SDK smoke.
- Header policy scanner and missing-baseline negative test.
- JS syntax.
- Whitespace check.

## Review Ledger

Final subagent reviews were clean P0-P2:

- Mencius: type-seal/fd-lifetime integrity clean; wrapper uses `with_tracked_conn` and no bare SQLite bypass.
- Popper: no counterexample where tombstone is bypassed, audit errors are flattened, or wrong world/address is read.
- QA-Enforcement: scope clean; only `core/src/audit.rs`, `core/src/read_cache.rs`, and `core/src/state.rs` changed; transitional dead-code markers are scoped and recorded here.
