### PR TITLE
core: expose sealed timeline read contract

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -220,6 +220,12 @@ pub use engine_types::{
 };
 #[cfg(feature = "unstable-engine")]
 pub use path::{validate_world_name, NAMESPACE_PREFIXES};
+#[cfg(feature = "unstable-engine")]
+pub use timeline::{
+    BodySha256, TimelineAddress, TimelineBody, TimelineCorruption, TimelineRead, TimelineSeq,
+};
+#[cfg(feature = "unstable-engine")]
+pub use world_generation::WorldGeneration;
 
 // ─── helpers ────────────────────────────────────────────────────────
 

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -1,8 +1,13 @@
 //! Core timeline address contract for Path 3.
 //!
-//! This module intentionally defines only the typed contract. It does not read
-//! SQLite, retain CAS bodies, render HTTP, expose FFI, or implement migration.
-//! Later layers wire storage into these types.
+//! A timeline address names one durable body event in one durable world
+//! generation. It is not just a row number: the address also carries the world
+//! path and the SHA-256 of the body the audit row promised.
+//!
+//! Public callers may inspect timeline addresses and read outcomes, but they
+//! cannot mint addresses directly. Production addresses are created only after
+//! audit verification proves that an event row belongs to the requested world
+//! and generation.
 
 #![cfg_attr(not(test), allow(dead_code))]
 
@@ -13,8 +18,25 @@ use std::num::NonZeroI64;
 /// FIPS 180-4 defines SHA-256 output as 256 bits; hex renders 4 bits per char.
 const BODY_SHA256_HEX_LEN: usize = 64;
 
+/// Opaque address of one audited body value.
+///
+/// The fields are private on purpose. A caller can receive, clone, compare, and
+/// inspect a `TimelineAddress`, but cannot construct or recombine the
+/// `{ world, generation, seq, body_sha256 }` coordinate outside verified audit
+/// minting.
+///
+/// ```compile_fail
+/// fn recombine(address: elastik_core::TimelineAddress) -> elastik_core::TimelineAddress {
+///     let world = address.world().clone();
+///     let generation = address.generation().clone();
+///     let seq = address.seq();
+///     let body_sha256 = address.body_sha256().clone();
+///
+///     elastik_core::TimelineAddress::new(world, generation, seq, body_sha256)
+/// }
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct TimelineAddress {
+pub struct TimelineAddress {
     world: ValidatedWorldPath,
     gen: WorldGeneration,
     seq: TimelineSeq,
@@ -29,13 +51,16 @@ pub(crate) struct MintedTimelineAddress {
     body_sha256: BodySha256,
 }
 
+/// Positive audit-event sequence number inside one durable world generation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct TimelineSeq(NonZeroI64);
+pub struct TimelineSeq(NonZeroI64);
 
+/// SHA-256 digest of a body value, rendered as 64 lowercase hex characters.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct BodySha256(String);
+pub struct BodySha256(String);
 
-pub(crate) struct TimelineBody {
+/// Body value resolved from a timeline address.
+pub struct TimelineBody {
     address: TimelineAddress,
     representation: Representation,
 }
@@ -51,30 +76,56 @@ pub(crate) enum InvalidBodySha256 {
     NotLowerHex,
 }
 
+/// Corruption detected while resolving a timeline address.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum TimelineCorruption {
+#[non_exhaustive]
+pub enum TimelineCorruption {
+    /// A body event row exists but its retained CAS body is missing in a state
+    /// where retention metadata said it should still exist.
     MissingBodyForPresentRow,
+    /// The returned bytes did not hash to the address's promised SHA-256.
     BodyHashMismatch,
+    /// The event row shape is not a valid body event for this address.
     InvalidEventShape,
 }
 
-pub(crate) enum TimelineRead {
+/// Result of resolving a timeline address.
+///
+/// `Body` is the only successful byte-bearing outcome. The other variants tell
+/// callers why the exact historical value is not available without falling back
+/// to the current live body.
+#[non_exhaustive]
+pub enum TimelineRead {
+    /// The addressed historical body was found.
     Body(TimelineBody),
+    /// The audit row exists, but the retained CAS body has aged out.
     Expired {
+        /// Address that could not be materialized.
         address: TimelineAddress,
     },
+    /// The addressed durable world no longer exists.
     Gone {
+        /// Address that could not be materialized.
         address: TimelineAddress,
     },
+    /// The path was deleted and recreated; the address belongs to an older
+    /// generation than the current world.
     GenMismatch {
+        /// Address requested by the caller.
         requested: TimelineAddress,
+        /// Current generation stored in the world's SQLite file.
         actual: WorldGeneration,
     },
+    /// No event row with the address's sequence exists in this generation.
     MissingRow {
+        /// Address that could not be materialized.
         address: TimelineAddress,
     },
+    /// The addressed row or retained body failed integrity checks.
     Corrupt {
+        /// Address that failed verification.
         address: TimelineAddress,
+        /// Integrity failure category.
         reason: TimelineCorruption,
     },
 }
@@ -87,11 +138,13 @@ pub(crate) enum TimelineAddressLookup {
 }
 
 impl TimelineBody {
-    pub(crate) fn address(&self) -> &TimelineAddress {
+    /// Returns the address that produced this historical body.
+    pub fn address(&self) -> &TimelineAddress {
         &self.address
     }
 
-    pub(crate) fn representation(&self) -> &Representation {
+    /// Returns the body bytes, content type, and metadata snapshot.
+    pub fn representation(&self) -> &Representation {
         &self.representation
     }
 }
@@ -147,19 +200,27 @@ impl TimelineAddress {
         )
     }
 
-    pub(crate) fn world(&self) -> &ValidatedWorldPath {
+    /// Returns the canonical world path this address belongs to.
+    pub fn world(&self) -> &ValidatedWorldPath {
         &self.world
+    }
+
+    /// Returns the durable-world generation this address belongs to.
+    pub fn generation(&self) -> &WorldGeneration {
+        &self.gen
     }
 
     pub(crate) fn gen(&self) -> &WorldGeneration {
         &self.gen
     }
 
-    pub(crate) fn seq(&self) -> TimelineSeq {
+    /// Returns the audited event sequence number inside this generation.
+    pub fn seq(&self) -> TimelineSeq {
         self.seq
     }
 
-    pub(crate) fn body_sha256(&self) -> &BodySha256 {
+    /// Returns the body digest promised by the audited event row.
+    pub fn body_sha256(&self) -> &BodySha256 {
         &self.body_sha256
     }
 }
@@ -204,7 +265,8 @@ impl TimelineSeq {
             .ok_or(InvalidTimelineSeq::NonPositive)
     }
 
-    pub(crate) fn get(self) -> i64 {
+    /// Returns the positive SQLite row id used as the timeline sequence.
+    pub fn get(self) -> i64 {
         self.0.get()
     }
 }
@@ -225,7 +287,8 @@ impl BodySha256 {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    /// Returns the 64-character lowercase hexadecimal digest.
+    pub fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/core/src/world_generation.rs
+++ b/core/src/world_generation.rs
@@ -8,8 +8,14 @@ use std::fmt;
 /// 32 lowercase hexadecimal characters.
 const WORLD_GEN_HEX_LEN: usize = 32;
 
+/// Durable-world incarnation identity.
+///
+/// A world generation changes when a durable world is physically deleted and
+/// later recreated at the same path. Timeline addresses include the generation
+/// so an old address cannot silently resolve against the new world's audit
+/// rows.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct WorldGeneration(String);
+pub struct WorldGeneration(String);
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct MintedWorldGeneration(WorldGeneration);
@@ -43,7 +49,8 @@ impl WorldGeneration {
         Ok(Self(raw))
     }
 
-    pub(crate) fn as_str(&self) -> &str {
+    /// Returns the lowercase hexadecimal generation identifier.
+    pub fn as_str(&self) -> &str {
         &self.0
     }
 }


### PR DESCRIPTION
## Summary

Expose the Path 3 timeline read vocabulary through the unstable Engine public surface without exposing any minting path.

This layer makes `TimelineAddress`, `TimelineRead`, `TimelineBody`, `TimelineSeq`, `BodySha256`, `TimelineCorruption`, and `WorldGeneration` nameable/inspectable by embedders. Fields and raw constructors remain private or `pub(crate)`.

## Stack

- Base: `stack/22r22-timeline-read-cache` (#338), commit `439ae35`
- Head: `stack/22r23-public-timeline-contract`, commit `baf53f4`
- Plan section: public sealed timeline read contract vocabulary before wiring a public Engine resolver

## Scope

Production diff: 3 files, +94/-18.

- `core/src/lib.rs`: re-export timeline contract types behind `unstable-engine`.
- `core/src/timeline.rs`: make output contract types public, keep minting private, add rustdoc.
- `core/src/world_generation.rs`: make generation identity inspectable, keep construction/minting crate-internal.

No SQLite read logic, HTTP, FFI, SDK, migration, retention policy, or SSE wiring in this layer.

## Type-Seal Contract

External safe Rust callers can receive an address and inspect:

- world
- generation
- sequence
- body SHA-256

They cannot construct or recombine a `TimelineAddress`. The compile-fail doctest proves an external caller with already-obtained components still fails specifically on private `TimelineAddress::new` (`E0624`).

## Validation

- `cargo test --lib` from `core`: 167 passed, 2 ignored
- `cargo test --doc -- --show-output` from `core`: 6 passed, including isolated `TimelineAddress::new` compile-fail
- `cargo clippy --all-targets -- -D warnings` from `core`: pass
- `cargo fmt --check`: pass
- `git diff --check`: pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --lib`: pass
- Push pre-push hook: pass, including core/bin tests, version consistency, bundled SQLite check, cargo audit over core/bin/ffi locks, SDK smoke, header policy scanner, JS syntax, whitespace

## Review Ledger

Fresh final gate after the last doc-only change:

- McClintock the 3rd / QA + type-seal micro-review: 0 confirmed P0-P2. Confirmed public types remain sealed, doctest isolates private `TimelineAddress::new`, and `TimelineSeq` docs do not imply caller minting.

Earlier rounds before fixes:

- Carson the 3rd / Mencius type-seal review: 0 P0-P2, requested external compile-fail seal proof as P3.
- Halley the 3rd / Popper falsification: 0 P0-P2, requested compile-fail proof and noted `Gone` is contract-only until later storage evidence.
- Goodall the 3rd / QA enforcement: 0 P0-P2, requested PR-body caveat for `Gone` vs current `Option` internals.
- Bernoulli the 3rd / type-seal review: P2 on broad compile-fail doctest. Fixed by rewriting the doctest to use already-obtained address components and fail only on private `TimelineAddress::new`.
- Averroes the 3rd / Popper: 0 P0-P2 before the final doctest rewrite; invalidated and superseded.
- James the 3rd / QA: 0 P0-P2 before final doc-only fix; invalidated and superseded.
- Newton the 3rd / final type-seal review: 0 P0-P2 before `TimelineSeq` doc polish; invalidated and superseded.
- Pasteur the 3rd / final QA review: 0 P0-P2, P3 for missing `TimelineSeq` type doc. Fixed.
- Planck the 3rd: closed while running after doc-only diff invalidated the round.

## Caveat For Later Layers

`TimelineRead::Gone` is part of the public read-outcome vocabulary in this layer. The current internal read-cache bridge still returns outer `Ok(None)` for tombstone/missing-world before a public resolver exists. The future public Engine resolver should map missing durable world for an otherwise valid timeline address to `Gone`, not expose `Option<TimelineRead>` as the public outcome.