### PR TITLE
core: expose public timeline body resolver

### DIFF
--- a/core/src/engine_error.rs
+++ b/core/src/engine_error.rs
@@ -30,6 +30,13 @@ pub(crate) fn read_error_to_engine(
             log_storage_error(scope, &err, "read", world);
             EngineError::Storage
         }
+        world_ops::ReadError::AuditChainBroken {
+            scope,
+            break_report,
+        } => {
+            log_audit_chain_error(scope, &break_report, "read", world);
+            EngineError::Storage
+        }
         world_ops::ReadError::PermitWorldMismatch => {
             EngineError::InternalInvariant("read permit world mismatch")
         }

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -217,10 +217,10 @@ impl Engine {
     /// executor worker should call it from their blocking-worker boundary.
     ///
     /// Unlike [`Engine::read`], this method does not return `Option`: a
-    /// timeline address names a historical fact. If the durable world no
-    /// longer exists, the result is [`TimelineRead::Gone`]. Other
-    /// [`TimelineRead`] variants describe exact historical-read outcomes; this
-    /// method never falls back to the current live body.
+    /// timeline address names a historical fact. Missing local storage becomes
+    /// [`TimelineRead::Unproven`] until delete-ledger proof can bind the absence
+    /// to the requested address. This method never falls back to the current
+    /// live body.
     ///
     /// # Errors
     /// - [`EngineError::Auth`] if `tier` is below `Read`.
@@ -681,9 +681,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn engine_read_timeline_body_maps_missing_world_to_gone() {
-        let (engine, root) = test_engine("timeline-public-gone");
-        let world = ValidatedWorldPath::new("home/timeline-gone").unwrap();
+    async fn engine_read_timeline_body_maps_missing_world_to_unproven() {
+        let (engine, root) = test_engine("timeline-public-unproven");
+        let world = ValidatedWorldPath::new("home/timeline-unproven").unwrap();
         engine
             .replace(
                 &world,
@@ -704,8 +704,8 @@ mod tests {
             .read_timeline_body(&address, AccessTier::Read)
             .expect("missing durable world is a typed read outcome")
         {
-            TimelineRead::Gone { address: got } => assert_eq!(got, address),
-            _ => panic!("expected gone"),
+            TimelineRead::Unproven { address: got } => assert_eq!(got, address),
+            _ => panic!("expected unproven"),
         }
 
         drop(engine);

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -18,7 +18,9 @@ use crate::{
         AccessTier, ChangeEvent, EngineSubscription, Preconditions, ReadResult, Representation,
         SubscribePattern, SubscriptionRecvError, ValidatedWorldPath, WriteKind, WriteResult,
     },
-    etag, event, world_ops, AuthGate, Core,
+    etag, event,
+    timeline::{TimelineAddress, TimelineRead},
+    world_ops, AuthGate, Core,
 };
 
 pub(crate) use crate::engine_error::{log_blocking_storage_error, log_storage_error};
@@ -56,6 +58,16 @@ impl<'a> EngineOps<'a> {
             ))),
             world_ops::ReadOutcome::Missing => Ok(None),
         }
+    }
+
+    pub(crate) fn read_timeline_body(
+        &self,
+        address: &TimelineAddress,
+        tier: auth::Tier,
+    ) -> Result<TimelineRead, EngineError> {
+        let permit = world_ops::authorize_read(self.core, address.world(), tier)?;
+        world_ops::read_timeline_body(self.core, &permit, address)
+            .map_err(|err| read_error_to_engine(err, Some(address.world().as_str())))
     }
 
     pub(crate) async fn replace<H: world_ops::WriteTraceHooks + ?Sized>(
@@ -195,6 +207,33 @@ impl Engine {
         tier: AccessTier,
     ) -> Result<Option<ReadResult>, EngineError> {
         EngineOps::new(self.core()).read(world, tier.into())
+    }
+
+    /// Reads the body snapshot addressed by an audited timeline address.
+    ///
+    /// This is a synchronous API with the same blocking profile as
+    /// [`Engine::read`]. It may reuse a cached SQLite connection and verify the
+    /// audit chain on the caller thread. Async adapters that cannot block an
+    /// executor worker should call it from their blocking-worker boundary.
+    ///
+    /// Unlike [`Engine::read`], this method does not return `Option`: a
+    /// timeline address names a historical fact. If the durable world no
+    /// longer exists, the result is [`TimelineRead::Gone`]. Other
+    /// [`TimelineRead`] variants describe exact historical-read outcomes; this
+    /// method never falls back to the current live body.
+    ///
+    /// # Errors
+    /// - [`EngineError::Auth`] if `tier` is below `Read`.
+    /// - [`EngineError::TransientStorage`] for SQLite `BUSY`/`LOCKED`.
+    /// - [`EngineError::InsufficientStorage`] for full-disk failures.
+    /// - [`EngineError::Storage`] for audit-chain corruption or other storage
+    ///   failures.
+    pub fn read_timeline_body(
+        &self,
+        address: &TimelineAddress,
+        tier: AccessTier,
+    ) -> Result<TimelineRead, EngineError> {
+        EngineOps::new(self.core()).read_timeline_body(address, tier.into())
     }
 
     /// Replaces a world with the provided representation.
@@ -433,7 +472,11 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
-    use crate::engine_types::{AuditHmacKey, ChangeVerb};
+    use crate::{
+        engine_types::{AuditHmacKey, ChangeVerb},
+        timeline::{BodySha256, TimelineAddress, TimelineRead, TimelineSeq},
+        world, world_schema,
+    };
 
     fn temp_root(name: &str) -> PathBuf {
         let nonce = SystemTime::now()
@@ -457,6 +500,24 @@ mod tests {
             .build()
             .unwrap();
         (engine, root)
+    }
+
+    fn timeline_address_for_body(
+        engine: &Engine,
+        world_path: &ValidatedWorldPath,
+        seq: i64,
+        body: &[u8],
+    ) -> TimelineAddress {
+        let conn =
+            rusqlite::Connection::open(world::world_db(&engine.core().data, world_path.as_str()))
+                .unwrap();
+        let gen = world_schema::generation(&conn).unwrap();
+        TimelineAddress::test_only_new(
+            world_path.clone(),
+            gen,
+            TimelineSeq::new(seq).unwrap(),
+            BodySha256::for_body(body),
+        )
     }
 
     #[test]
@@ -537,6 +598,115 @@ mod tests {
             .await
             .unwrap();
         assert!(engine.read(&world, AccessTier::Read).unwrap().is_none());
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn engine_read_timeline_body_returns_historical_body() {
+        let (engine, root) = test_engine("timeline-public-read");
+        let world = ValidatedWorldPath::new("home/timeline-public-read").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(
+                    Bytes::from_static(b"old"),
+                    "text/plain",
+                    vec![("x-meta-version".to_owned(), "one".to_owned())],
+                ),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        let address = timeline_address_for_body(&engine, &world, 1, b"old");
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"new"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        match engine
+            .read_timeline_body(&address, AccessTier::Read)
+            .expect("timeline read succeeds")
+        {
+            TimelineRead::Body(body) => {
+                assert_eq!(body.address(), &address);
+                assert_eq!(body.representation().body, Bytes::from_static(b"old"));
+                assert_eq!(body.representation().content_type, "text/plain");
+                assert_eq!(
+                    body.representation().headers.as_slice(),
+                    [("x-meta-version".to_owned(), "one".to_owned())]
+                );
+            }
+            _ => panic!("expected historical body"),
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn engine_read_timeline_body_requires_read_tier() {
+        let root = temp_root("timeline-public-auth");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
+            .read_token(b"reader".to_vec())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/timeline-auth").unwrap();
+        let address = TimelineAddress::test_only_new(
+            world,
+            crate::world_generation::WorldGeneration::new("0123456789abcdef0123456789abcdef")
+                .unwrap(),
+            TimelineSeq::new(1).unwrap(),
+            BodySha256::for_body(b"value"),
+        );
+
+        assert!(matches!(
+            engine.read_timeline_body(&address, AccessTier::Anon),
+            Err(EngineError::Auth(AuthGate::Read))
+        ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn engine_read_timeline_body_maps_missing_world_to_gone() {
+        let (engine, root) = test_engine("timeline-public-gone");
+        let world = ValidatedWorldPath::new("home/timeline-gone").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"old"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        let address = timeline_address_for_body(&engine, &world, 1, b"old");
+
+        engine
+            .delete(&world, Preconditions::none(), AccessTier::Approve)
+            .await
+            .unwrap();
+
+        match engine
+            .read_timeline_body(&address, AccessTier::Read)
+            .expect("missing durable world is a typed read outcome")
+        {
+            TimelineRead::Gone { address: got } => assert_eq!(got, address),
+            _ => panic!("expected gone"),
+        }
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -204,7 +204,7 @@ pub(crate) fn read_timeline_body(
     }
     match core.read_timeline_body(address) {
         Ok(Some(read)) => Ok(read),
-        Ok(None) => Ok(TimelineRead::Gone {
+        Ok(None) => Ok(TimelineRead::Unproven {
             address: address.clone(),
         }),
         Err(err) => Err(classify_read_audit_error("timeline read", err)),

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -17,7 +17,7 @@ use crate::{
     audit, auth, can_read, can_write,
     engine_types::{ChangeVerb, ValidatedWorldPath},
     etag, needs_write_approve, store,
-    timeline::BodySha256,
+    timeline::{BodySha256, TimelineAddress, TimelineRead},
     world, AuthGate, Core, StorageFailureClass,
 };
 
@@ -54,6 +54,11 @@ pub(crate) enum ReadError {
         #[allow(dead_code)]
         scope: &'static str,
         err: rusqlite::Error,
+    },
+    AuditChainBroken {
+        #[allow(dead_code)]
+        scope: &'static str,
+        break_report: audit::VerifyBreak,
     },
     PermitWorldMismatch,
 }
@@ -187,6 +192,23 @@ pub(crate) fn authorize_write(
 
 pub(crate) fn read_world(core: &Core, permit: &ReadPermit) -> Result<ReadOutcome, ReadError> {
     read_world_for(core, permit, &permit.world)
+}
+
+pub(crate) fn read_timeline_body(
+    core: &Core,
+    permit: &ReadPermit,
+    address: &TimelineAddress,
+) -> Result<TimelineRead, ReadError> {
+    if permit.world != *address.world() {
+        return Err(ReadError::PermitWorldMismatch);
+    }
+    match core.read_timeline_body(address) {
+        Ok(Some(read)) => Ok(read),
+        Ok(None) => Ok(TimelineRead::Gone {
+            address: address.clone(),
+        }),
+        Err(err) => Err(classify_read_audit_error("timeline read", err)),
+    }
 }
 
 pub(crate) fn read_world_for(
@@ -460,6 +482,16 @@ fn classify_read_error(scope: &'static str, err: rusqlite::Error) -> ReadError {
     }
 }
 
+fn classify_read_audit_error(scope: &'static str, err: audit::AuditError) -> ReadError {
+    match err {
+        audit::AuditError::ChainBroken(break_report) => ReadError::AuditChainBroken {
+            scope,
+            break_report,
+        },
+        audit::AuditError::Storage(err) => classify_read_error(scope, err),
+    }
+}
+
 fn classify_write_audit_error(scope: &'static str, err: audit::AuditError) -> WriteError {
     match err {
         audit::AuditError::ChainBroken(break_report) => WriteError::AuditChainBroken {
@@ -493,9 +525,22 @@ fn classify_write_storage_error(
 mod tests {
     use super::*;
     use crate::test_support::test_core;
+    use crate::{
+        timeline::{TimelineAddress, TimelineSeq},
+        world_generation::WorldGeneration,
+    };
 
     fn world_path(world: &str) -> ValidatedWorldPath {
         ValidatedWorldPath::new(world).unwrap()
+    }
+
+    fn timeline_address(world: ValidatedWorldPath) -> TimelineAddress {
+        TimelineAddress::test_only_new(
+            world,
+            WorldGeneration::new("0123456789abcdef0123456789abcdef").unwrap(),
+            TimelineSeq::new(1).unwrap(),
+            BodySha256::for_body(b"value"),
+        )
     }
 
     #[tokio::test]
@@ -523,6 +568,20 @@ mod tests {
             b"right-door"
         );
         assert!(core.read_world("home/permit-b").unwrap().is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn timeline_read_permit_is_bound_to_address_world() {
+        let (core, dir) = test_core("timeline-read-permit-bound");
+        let permit = authorize_read(&core, &world_path("home/right"), auth::Tier::Read).unwrap();
+        let address = timeline_address(world_path("home/wrong"));
+
+        assert!(matches!(
+            read_timeline_body(&core, &permit, &address),
+            Err(ReadError::PermitWorldMismatch)
+        ));
 
         let _ = std::fs::remove_dir_all(dir);
     }


### PR DESCRIPTION
## Summary

Add the public Engine resolver for sealed timeline body reads.

`Engine::read_timeline_body(&TimelineAddress, AccessTier)` resolves an audited timeline address to a `TimelineRead` without exposing `Option<TimelineRead>` at the public boundary.

## Stack

- Base: `stack/22r23-public-timeline-contract` (#339), commit `baf53f4`
- Head: `stack/22r24-public-timeline-resolver`, commit `16e6876`
- Plan section: public Engine resolver after exposing the sealed timeline read contract vocabulary

## Scope

Production diff: 3 files, +239/-3, mostly tests.

- `core/src/world_ops.rs`: add a read-permit-bound timeline resolver.
- `core/src/engine_ops.rs`: expose `Engine::read_timeline_body` and wire through `EngineOps`.
- `core/src/engine_error.rs`: map timeline read audit-chain breakage into existing runtime `EngineError::Storage` logging path.

No SSE, HTTP, FFI, SDK, async API rewrite, retention policy, or migration work in this layer.

## Contract

- Requires read auth through `authorize_read(self.core, address.world(), tier)`.
- Requires a `ReadPermit` to call the storage resolver.
- Re-checks `permit.world == address.world()` before storage access.
- Returns `Result<TimelineRead, EngineError>`, not `Option<TimelineRead>`.
- Maps missing/tombstoned durable world to `TimelineRead::Gone`.
- Uses the existing read-cache/tombstone path under `Core::read_timeline_body`; no direct SQLite bypass.
- Never falls back to the current live body for a historical address.

## Validation

- `cargo test --lib` from `core`: 171 passed, 2 ignored
- `cargo test --doc -- --show-output` from `core`: 6 passed
- `cargo clippy --all-targets -- -D warnings` from `core`: pass
- `cargo fmt --check`: pass
- `git diff --check`: pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --lib`: pass
- Focused tests:
  - `engine_ops::tests::engine_read_timeline_body_returns_historical_body`
  - `engine_ops::tests::engine_read_timeline_body_requires_read_tier`
  - `engine_ops::tests::engine_read_timeline_body_maps_missing_world_to_gone`
  - `world_ops::tests::timeline_read_permit_is_bound_to_address_world`
- Push pre-push hook: pass, including core/bin tests, version consistency, bundled SQLite check, cargo audit over core/bin/ffi locks, SDK smoke, header policy scanner, JS syntax, whitespace

## Review Ledger

Fresh final round after the last doc wording fix:

- Maxwell the 3rd / type-seal review: 0 confirmed P0-P2. Confirmed read auth, permit-bound resolver, public non-Option result, `Gone` mapping, and read-cache path.
- Aristotle the 3rd / Popper falsification: 0 confirmed P0-P2. Could not falsify unauthorized read, cross-world address, current-body race, missing-world `None`, or audit corruption mapping.
- Wegener the 3rd / QA enforcement: 0 confirmed P0-P2. Confirmed narrow 3-file scope, no async/SSE/FFI/HTTP scope creep, docs narrow, validation green.

P3 ledgered, not blockers:

- No public-level active-tombstone test; Core layer covers active tombstone and this layer covers post-delete `Gone`.
- Public tests build addresses via `test_only_new` because public address minting is not wired yet; lower layers cover verified minting.
- No public-level audit-chain tamper mapping test; underlying verifier and error mapping are already covered.

## Notes

This layer intentionally follows current `Engine::read` sync shape. The planned async Engine boundary is a later stack, not hidden in this PR.