### PR TITLE
core: record deleted subject identity

### DIFF
--- a/bin/src/server/coap_errors.rs
+++ b/bin/src/server/coap_errors.rs
@@ -5,6 +5,7 @@ use crate::engine::EngineError;
 pub(crate) fn read_error_to_coap(err: &EngineError) -> u8 {
     match err {
         EngineError::Auth(_) => 129,
+        EngineError::InvalidMetadata { .. } => 128,
         EngineError::InsufficientStorage => 167,
         EngineError::TransientStorage
         | EngineError::ShuttingDown
@@ -23,6 +24,7 @@ pub(crate) fn read_error_to_coap(err: &EngineError) -> u8 {
 pub(crate) fn read_error_body(err: &EngineError) -> &'static [u8] {
     match err {
         EngineError::Auth(_) => b"unauthorized\n",
+        EngineError::InvalidMetadata { .. } => b"invalid metadata\n",
         EngineError::InsufficientStorage => b"insufficient storage\n",
         EngineError::TransientStorage
         | EngineError::ShuttingDown
@@ -36,6 +38,7 @@ pub(crate) fn write_error_to_coap(err: &EngineError) -> u8 {
         EngineError::Auth(_) => 129,
         EngineError::PayloadTooLarge { .. } => 141,
         EngineError::PreconditionFailed { .. } => 140,
+        EngineError::InvalidMetadata { .. } => 128,
         EngineError::NotFound => 132,
         EngineError::QuotaExceeded { .. } | EngineError::InsufficientStorage => 167,
         EngineError::TransientStorage

--- a/bin/src/server/handler.rs
+++ b/bin/src/server/handler.rs
@@ -52,10 +52,10 @@ use crate::{
     engine_trace::EngineWriteTraceHooks,
     engine_types::{AccessTier, Representation, ValidatedWorldPath, WriteKind},
     server::{
-        content_range_value, decimal_header_value, http::semantics as hs, insufficient_storage,
-        not_found, payload_too_large, precondition_failed, server_error, storage_quota_exceeded,
-        storage_temporarily_unavailable, to_header_map, unauthorized, ErrorReason, Phase,
-        ServerState, TraceCtx, Verb,
+        bad_request, content_range_value, decimal_header_value, http::semantics as hs,
+        insufficient_storage, not_found, payload_too_large, precondition_failed, server_error,
+        storage_quota_exceeded, storage_temporarily_unavailable, to_header_map, unauthorized,
+        ErrorReason, Phase, ServerState, TraceCtx, Verb,
     },
 };
 
@@ -335,6 +335,10 @@ fn read_error_phase(err: EngineError) -> Phase {
             resp: server_error("unexpected read subscription limit".to_string()),
             reason: ErrorReason::StorageRead,
         },
+        EngineError::InvalidMetadata { message } => Phase::Error {
+            resp: bad_request(message),
+            reason: ErrorReason::PathInvalid(message),
+        },
         EngineError::InvalidWorldName
         | EngineError::NotFound
         | EngineError::AppendOnly
@@ -392,6 +396,10 @@ pub(crate) fn write_error_phase(err: EngineError) -> Phase {
         EngineError::InternalInvariant(message) => Phase::Error {
             resp: server_error(message.to_string()),
             reason: ErrorReason::StorageWriteAudit,
+        },
+        EngineError::InvalidMetadata { message } => Phase::Error {
+            resp: bad_request(message),
+            reason: ErrorReason::PathInvalid(message),
         },
         EngineError::ShuttingDown => Phase::Error {
             resp: storage_temporarily_unavailable(),

--- a/bin/src/server/handler/delete.rs
+++ b/bin/src/server/handler/delete.rs
@@ -23,8 +23,9 @@ use crate::{
     engine_trace::{DeleteMetadata, EngineDeleteTraceHooks},
     engine_types::{AccessTier, ValidatedWorldPath},
     server::{
-        http::semantics as hs, insufficient_storage, not_found, precondition_failed, server_error,
-        storage_temporarily_unavailable, unauthorized, ErrorReason, Phase, ServerState, TraceCtx,
+        bad_request, http::semantics as hs, insufficient_storage, not_found, precondition_failed,
+        server_error, storage_temporarily_unavailable, unauthorized, ErrorReason, Phase,
+        ServerState, TraceCtx,
     },
     AuthGate,
 };
@@ -219,6 +220,10 @@ fn delete_error_phase(err: EngineError, last_step: DeleteStep) -> Phase {
         EngineError::InsufficientStorage => insufficient_delete_error_phase(last_step),
         EngineError::Storage => storage_delete_error_phase(last_step),
         EngineError::InternalInvariant(message) => invariant_delete_error_phase(message, last_step),
+        EngineError::InvalidMetadata { message } => Phase::Error {
+            resp: bad_request(message),
+            reason: ErrorReason::PathInvalid(message),
+        },
         EngineError::InvalidWorldName
         | EngineError::PayloadTooLarge { .. }
         | EngineError::QuotaExceeded { .. }
@@ -324,9 +329,10 @@ mod tests {
         engine_types::{Preconditions, Representation},
         server::{
             handler::execute_put,
+            http::semantics::HeaderAllowlist,
             test_support::{
-                server_state_for_engine_for_tests, test_engine_for_server_with_auth_tokens,
-                world_db_path_for_server_tests,
+                server_state_for_engine_for_tests, server_state_with_headers_for_engine_for_tests,
+                test_engine_for_server_with_auth_tokens, world_db_path_for_server_tests,
             },
         },
     };
@@ -476,6 +482,51 @@ mod tests {
             .unwrap();
         assert_eq!(events, vec!["delete_intent", "delete_commit"]);
 
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_reserved_subject_metadata_even_if_header_is_allowlisted() {
+        let (engine, dir) = test_engine_for_server_with_auth_tokens("delete-reserved-header");
+        let state = server_state_with_headers_for_engine_for_tests(
+            engine.clone(),
+            crate::defaults::DEFAULT_MAX_WORLD_BYTES,
+            HeaderAllowlist::parse("auditedb-delete-subject-*"),
+            HeaderAllowlist::empty(),
+        );
+        let world = world_path("home/delete-reserved-header");
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"alive"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "auditedb-delete-subject-seq",
+            HeaderValue::from_static("fake"),
+        );
+        let (status, reason, body) = error_parts(
+            execute_delete(
+                headers,
+                AccessTier::Approve,
+                world.clone(),
+                &state,
+                &TraceCtx::disabled(),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(matches!(reason, ErrorReason::PathInvalid(_)));
+        assert_eq!(body, "bad request: reserved-delete-subject-header\n");
+        assert!(engine.read(&world, AccessTier::Read).unwrap().is_some());
+        assert!(!world_db_path_for_server_tests(&dir, "var/log/deletes").exists());
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/bin/src/server/proc.rs
+++ b/bin/src/server/proc.rs
@@ -335,6 +335,7 @@ fn proc_engine_error(scope: &'static str, err: EngineError) -> Response {
         EngineError::InsufficientStorage => insufficient_storage(),
         EngineError::Storage => server_error(format!("{scope} storage failure")),
         EngineError::InvalidWorldName => bad_request("invalid world path"),
+        EngineError::InvalidMetadata { message } => bad_request(message),
         EngineError::InternalInvariant(message) => {
             server_error(format!("{scope} internal invariant: {message}"))
         }

--- a/bin/src/server/test_support.rs
+++ b/bin/src/server/test_support.rs
@@ -32,11 +32,25 @@ pub(crate) fn server_state_with_max_world_bytes_for_engine_for_tests(
     engine: Engine,
     max_world_bytes: usize,
 ) -> ServerState {
-    ServerState::new(
+    server_state_with_headers_for_engine_for_tests(
         engine,
         max_world_bytes,
         HeaderAllowlist::empty(),
         HeaderAllowlist::empty(),
+    )
+}
+
+pub(crate) fn server_state_with_headers_for_engine_for_tests(
+    engine: Engine,
+    max_world_bytes: usize,
+    persist_header_allowlist: HeaderAllowlist,
+    persist_header_user_deny: HeaderAllowlist,
+) -> ServerState {
+    ServerState::new(
+        engine,
+        max_world_bytes,
+        persist_header_allowlist,
+        persist_header_user_deny,
     )
 }
 

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     engine_types::{AuditHmacKey, ValidatedWorldPath},
-    timeline::TimelineSeq,
+    timeline::{TimelineAddress, TimelineSeq},
     world,
     world_generation::WorldGeneration,
 };
@@ -27,7 +27,9 @@ pub(crate) use append::{
     AppendedBodyEvent,
 };
 pub(crate) use timeline_address::read_timeline_body_via_conn;
-pub(crate) use timeline_address::VerifiedBodyEvent;
+pub(crate) use timeline_address::{
+    verified_latest_body_head_via_conn, VerifiedBodyEvent, VerifiedBodyHead,
+};
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
@@ -36,6 +38,12 @@ const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256
            LEFT JOIN event_headers h ON h.event_id=e.id
            ORDER BY e.id ASC, h.name ASC, h.value ASC"#;
 pub(crate) const AUDIT_CHAIN_BROKEN_PREFIX: &str = "audit chain broken at event ";
+pub(crate) const DELETE_SUBJECT_WORLD: &str = "auditedb-delete-subject-world";
+pub(crate) const DELETE_SUBJECT_GENERATION: &str = "auditedb-delete-subject-generation";
+pub(crate) const DELETE_SUBJECT_SEQ: &str = "auditedb-delete-subject-seq";
+pub(crate) const DELETE_SUBJECT_BODY_SHA256: &str = "auditedb-delete-subject-body-sha256";
+pub(crate) const DELETE_SUBJECT_HMAC: &str = "auditedb-delete-subject-hmac";
+const DELETE_SUBJECT_RESERVED_PREFIX: &str = "auditedb-delete-subject-";
 
 pub struct VerifiedAuditTx<'tx, 'conn, 'key> {
     tx: &'tx Transaction<'conn>,
@@ -69,6 +77,97 @@ impl From<rusqlite::Error> for AuditError {
     fn from(value: rusqlite::Error) -> Self {
         Self::Storage(value)
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ReservedAuditHeader;
+
+#[derive(Clone)]
+pub(crate) struct VerifiedDeleteSubject {
+    address: TimelineAddress,
+    hmac: String,
+}
+
+impl VerifiedDeleteSubject {
+    pub(crate) fn from_body_head(head: VerifiedBodyHead) -> Self {
+        Self {
+            address: head.address().clone(),
+            hmac: head.hmac().to_owned(),
+        }
+    }
+
+    fn headers(&self) -> [(String, String); 5] {
+        [
+            (
+                DELETE_SUBJECT_WORLD.to_owned(),
+                self.address.world().as_str().to_owned(),
+            ),
+            (
+                DELETE_SUBJECT_GENERATION.to_owned(),
+                self.address.generation().as_str().to_owned(),
+            ),
+            (
+                DELETE_SUBJECT_SEQ.to_owned(),
+                self.address.seq().get().to_string(),
+            ),
+            (
+                DELETE_SUBJECT_BODY_SHA256.to_owned(),
+                self.address.body_sha256().as_str().to_owned(),
+            ),
+            (DELETE_SUBJECT_HMAC.to_owned(), self.hmac.clone()),
+        ]
+    }
+
+    pub(crate) fn body_sha256(&self) -> crate::timeline::BodySha256 {
+        self.address.body_sha256().clone()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AuditHeaders {
+    user: Vec<(String, String)>,
+    delete_subject: Option<VerifiedDeleteSubject>,
+}
+
+impl AuditHeaders {
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self {
+            user: Vec::new(),
+            delete_subject: None,
+        }
+    }
+
+    pub(crate) fn from_user(headers: Vec<(String, String)>) -> Result<Self, ReservedAuditHeader> {
+        if headers
+            .iter()
+            .any(|(name, _)| is_reserved_audit_header(name))
+        {
+            return Err(ReservedAuditHeader);
+        }
+        Ok(Self {
+            user: headers,
+            delete_subject: None,
+        })
+    }
+
+    pub(crate) fn with_delete_subject(mut self, subject: VerifiedDeleteSubject) -> Self {
+        self.delete_subject = Some(subject);
+        self
+    }
+
+    fn to_storage_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs = self.user.clone();
+        if let Some(subject) = &self.delete_subject {
+            pairs.extend(subject.headers());
+        }
+        pairs
+    }
+}
+
+fn is_reserved_audit_header(name: &str) -> bool {
+    name.to_ascii_lowercase()
+        .starts_with(DELETE_SUBJECT_RESERVED_PREFIX)
 }
 
 #[derive(Clone, Copy)]

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -97,7 +97,7 @@ pub(crate) fn append_with_conn_existing(
     body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
-    headers: &[(String, String)],
+    headers: &super::AuditHeaders,
     key: &AuditHmacKey,
 ) -> AuditResult<String> {
     append_with_conn_verified(
@@ -123,7 +123,7 @@ pub(crate) fn append_with_conn_genesis(
     body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
-    headers: &[(String, String)],
+    headers: &super::AuditHeaders,
     key: &AuditHmacKey,
 ) -> AuditResult<String> {
     append_with_conn_verified(
@@ -149,12 +149,13 @@ fn append_with_conn_verified(
     body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
-    headers: &[(String, String)],
+    headers: &super::AuditHeaders,
     key: &AuditHmacKey,
     empty_chain: EmptyChain,
 ) -> AuditResult<String> {
     let tx = conn.transaction()?;
     let audit_tx = super::verify_appendable_tx(&tx, ledger_world, key, empty_chain)?;
+    let headers = headers.to_storage_pairs();
     let row = append_tx_inner(
         &audit_tx,
         event_type.kind(),
@@ -162,7 +163,7 @@ fn append_with_conn_verified(
         body_sha256,
         size,
         content_type,
-        headers,
+        &headers,
     )?;
     tx.commit()?;
     Ok(row.hmac().to_owned())

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -139,7 +139,7 @@ pub(crate) fn verified_latest_body_head_via_conn(
     // The chain verification and "latest body row" lookup share one SQLite
     // snapshot. Otherwise delete could anchor the ledger to a row that was not
     // part of the verified chain it just observed.
-    super::require_intact(super::verify_world_connection(&tx, world, key)?)?;
+    super::require_intact(super::verify_world_tx(&tx, world, key)?)?;
     if let Some(break_report) = super::live_body::verify_tx(&tx)? {
         return Err(super::AuditError::ChainBroken(break_report));
     }

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -54,6 +54,25 @@ impl VerifiedBodyEvent {
     }
 }
 
+pub(crate) struct VerifiedBodyHead {
+    address: TimelineAddress,
+    hmac: String,
+}
+
+impl VerifiedBodyHead {
+    fn new(address: TimelineAddress, hmac: String) -> Self {
+        Self { address, hmac }
+    }
+
+    pub(crate) fn address(&self) -> &TimelineAddress {
+        &self.address
+    }
+
+    pub(crate) fn hmac(&self) -> &str {
+        &self.hmac
+    }
+}
+
 struct TimelineEventSnapshot {
     event_type: String,
     target: String,
@@ -108,6 +127,64 @@ pub(crate) fn verified_timeline_address_via_conn(
     let lookup = TimelineAddressLookup::Body(TimelineAddress::from_verified_body_event(event));
     tx.commit()?;
     Ok(lookup)
+}
+
+pub(crate) fn verified_latest_body_head_via_conn(
+    tracked: &mut TrackedReadConnection,
+    world: &ValidatedWorldPath,
+    key: &AuditHmacKey,
+) -> super::AuditResult<Option<VerifiedBodyHead>> {
+    let conn = tracked.as_mut_conn();
+    let tx = conn.transaction()?;
+    // The chain verification and "latest body row" lookup share one SQLite
+    // snapshot. Otherwise delete could anchor the ledger to a row that was not
+    // part of the verified chain it just observed.
+    super::require_intact(super::verify_world_connection(&tx, world, key)?)?;
+    if let Some(break_report) = super::live_body::verify_tx(&tx)? {
+        return Err(super::AuditError::ChainBroken(break_report));
+    }
+
+    let Some((seq, event_type, target, body_sha256, hmac)) = tx
+        .query_row(
+            "SELECT id, event_type, target, body_sha256, hmac
+             FROM events
+             WHERE event_type IN ('put', 'append')
+             ORDER BY id DESC
+             LIMIT 1",
+            [],
+            |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()?
+    else {
+        tx.commit()?;
+        return Ok(None);
+    };
+
+    let kind = AuditEventKind::from_storage(&event_type)
+        .ok_or_else(|| corrupt("events.event_type is not a known audit event"))?;
+    if !kind.class().body_bearing {
+        return Err(corrupt("latest body query returned a metadata event").into());
+    }
+    if target != world.as_str() {
+        return Err(corrupt("events.target does not match requested world").into());
+    }
+    let seq = TimelineSeq::new(seq).map_err(|_| corrupt("events.id is not positive"))?;
+    let body_sha256 = BodySha256::new(body_sha256)
+        .map_err(|err| corrupt(&format!("events.body_sha256 is invalid: {err:?}")))?;
+    let gen = world_schema::generation(&tx)?;
+    let event = VerifiedBodyEvent::new(world.clone(), gen, seq, body_sha256);
+    let address = TimelineAddress::from_verified_body_event(event);
+    let head = VerifiedBodyHead::new(address, super::hmac_label(&hmac));
+    tx.commit()?;
+    Ok(Some(head))
 }
 
 pub(crate) fn read_timeline_body_via_conn(

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -632,7 +632,7 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, DeleteError::ReservedMetadataHeader));
-        assert!(core.read_world(subject.as_str()).unwrap().is_some());
+        assert!(core.read_world(&subject).unwrap().is_some());
         assert!(!crate::world::world_db(&dir, "var/log/deletes").exists());
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -514,9 +514,9 @@ mod tests {
 
         let (core, dir) = test_core("delete-ledger-subject-address");
         let subject = ValidatedWorldPath::new("home/delete-ledger-subject-address").unwrap();
-        core.write_world(subject.as_str(), b"old", "text/plain", &[])
+        core.test_only_write_world(subject.as_str(), b"old", "text/plain", &[])
             .unwrap();
-        core.write_world(subject.as_str(), b"final", "text/plain", &[])
+        core.test_only_write_world(subject.as_str(), b"final", "text/plain", &[])
             .unwrap();
 
         let subject_conn =
@@ -614,7 +614,7 @@ mod tests {
         let (core, dir) = test_core("delete-ledger-reserved-subject-header");
         let subject =
             ValidatedWorldPath::new("home/delete-ledger-reserved-subject-header").unwrap();
-        core.write_world(subject.as_str(), b"body", "text/plain", &[])
+        core.test_only_write_world(subject.as_str(), b"body", "text/plain", &[])
             .unwrap();
 
         let permit = authorize_delete(&subject, auth::Tier::Approve).unwrap();
@@ -644,7 +644,7 @@ mod tests {
 
         let (core, dir) = test_core("delete-ledger-recreate-generation");
         let subject = ValidatedWorldPath::new("home/delete-ledger-recreate-generation").unwrap();
-        core.write_world(subject.as_str(), b"first", "text/plain", &[])
+        core.test_only_write_world(subject.as_str(), b"first", "text/plain", &[])
             .unwrap();
         let first_conn = Connection::open(crate::world::world_db(&dir, subject.as_str())).unwrap();
         let first_generation = world_schema::generation(&first_conn).unwrap();
@@ -664,7 +664,7 @@ mod tests {
         .await
         .unwrap();
 
-        core.write_world(subject.as_str(), b"second", "text/plain", &[])
+        core.test_only_write_world(subject.as_str(), b"second", "text/plain", &[])
             .unwrap();
         let second_conn = Connection::open(crate::world::world_db(&dir, subject.as_str())).unwrap();
         let second_generation = world_schema::generation(&second_conn).unwrap();

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -8,6 +8,7 @@
 use std::sync::atomic::Ordering;
 
 use crate::{
+    audit::{AuditHeaders, VerifiedDeleteSubject},
     auth, can_delete,
     engine::EngineError,
     engine_types::{ChangeVerb, Preconditions, ValidatedWorldPath},
@@ -34,10 +35,18 @@ pub(crate) struct DeletePermit {
 pub(crate) enum DeleteError {
     Auth(AuthGate),
     AppendOnlyLedger,
+    ReservedMetadataHeader,
     PreconditionFailed {
         message: &'static str,
     },
     NotFound,
+    SubjectAudit {
+        world: ValidatedWorldPath,
+        err: crate::audit::AuditError,
+    },
+    SubjectMissingHead {
+        world: ValidatedWorldPath,
+    },
     TransientStorage {
         #[allow(dead_code)]
         scope: &'static str,
@@ -100,10 +109,17 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     req: DeleteRequest,
     hooks: &H,
 ) -> Result<(), DeleteError> {
+    let DeleteRequest {
+        preconditions,
+        content_type,
+        headers,
+    } = req;
     let world_name = permit.world.as_str();
     let _write_guard = core.acquire_world_lock(world_name).await;
     hooks.lock_acquired(world_name);
-    check_preconditions(core, &permit.world, &req.preconditions.into())?;
+    check_preconditions(core, &permit.world, &preconditions.into())?;
+    let user_headers =
+        AuditHeaders::from_user(headers).map_err(|_| DeleteError::ReservedMetadataHeader)?;
 
     let Some(stage) = core
         .read_world(world_name)
@@ -127,7 +143,15 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     } else {
         stage.body.len()
     };
-    let body_sha256_before = BodySha256::for_body(&stage.body);
+    let subject = capture_delete_subject_proof(core, &permit.world)?;
+    let body_sha256_before = subject
+        .as_ref()
+        .map(VerifiedDeleteSubject::body_sha256)
+        .unwrap_or_else(|| BodySha256::for_body(&stage.body));
+    let ledger_headers = match subject {
+        Some(subject) => user_headers.with_delete_subject(subject),
+        None => user_headers,
+    };
 
     if let Err(err) = core
         .append_to_ledger(AuditAppendJob {
@@ -136,8 +160,8 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
             target: world_name.to_owned(),
             body_sha256: body_sha256_before.clone(),
             size: 0,
-            content_type: req.content_type.clone(),
-            headers: req.headers.clone(),
+            content_type: content_type.clone(),
+            headers: ledger_headers.clone(),
             key: ledger_hmac_key(core),
         })
         .await
@@ -187,8 +211,8 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
             target: world_name.to_owned(),
             body_sha256: body_sha256_before.clone(),
             size: 0,
-            content_type: req.content_type.clone(),
-            headers: req.headers.clone(),
+            content_type: content_type.clone(),
+            headers: ledger_headers.clone(),
             key: ledger_hmac_key(core),
         })
         .await
@@ -207,8 +231,8 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
                 target: world_name.to_owned(),
                 body_sha256: body_sha256_before,
                 size: 0,
-                content_type: req.content_type,
-                headers: req.headers,
+                content_type,
+                headers: ledger_headers,
                 key: ledger_hmac_key(core),
             })
             .await
@@ -234,6 +258,27 @@ fn ledger_hmac_key(core: &Core) -> crate::engine_types::AuditHmacKey {
     core.hmac_key.clone_secret()
 }
 
+fn capture_delete_subject_proof(
+    core: &Core,
+    world: &ValidatedWorldPath,
+) -> Result<Option<VerifiedDeleteSubject>, DeleteError> {
+    if store::is_memory_world(world.as_str()) {
+        return Ok(None);
+    }
+    let Some(head) = core
+        .latest_body_head(world)
+        .map_err(|err| DeleteError::SubjectAudit {
+            world: world.clone(),
+            err,
+        })?
+    else {
+        return Err(DeleteError::SubjectMissingHead {
+            world: world.clone(),
+        });
+    };
+    Ok(Some(VerifiedDeleteSubject::from_body_head(head)))
+}
+
 fn storage_len_missing_error() -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
         ffi::Error {
@@ -241,6 +286,16 @@ fn storage_len_missing_error() -> rusqlite::Error {
             extended_code: ffi::SQLITE_CORRUPT,
         },
         Some("persistent world vanished while computing storage_len".to_owned()),
+    )
+}
+
+fn subject_head_missing_error() -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error {
+            code: ffi::ErrorCode::DatabaseCorrupt,
+            extended_code: ffi::SQLITE_CORRUPT,
+        },
+        Some("persistent world has no audited body head".to_owned()),
     )
 }
 
@@ -319,8 +374,21 @@ impl From<DeleteError> for EngineError {
         match value {
             DeleteError::Auth(gate) => Self::Auth(gate),
             DeleteError::AppendOnlyLedger => Self::AppendOnly,
+            DeleteError::ReservedMetadataHeader => Self::InvalidMetadata {
+                message: "reserved-delete-subject-header",
+            },
             DeleteError::PreconditionFailed { message } => Self::PreconditionFailed { message },
             DeleteError::NotFound => Self::NotFound,
+            DeleteError::SubjectAudit { world, err } => subject_audit_error_to_engine(&world, err),
+            DeleteError::SubjectMissingHead { world } => {
+                crate::engine_ops::log_storage_error(
+                    "subject audit",
+                    &subject_head_missing_error(),
+                    "delete",
+                    Some(world.as_str()),
+                );
+                Self::Storage
+            }
             DeleteError::TransientStorage { scope, world, err } => {
                 crate::engine_ops::log_storage_error(scope, &err, "delete", Some(world.as_str()));
                 Self::TransientStorage
@@ -339,11 +407,35 @@ impl From<DeleteError> for EngineError {
     }
 }
 
+fn subject_audit_error_to_engine(
+    world: &crate::engine_types::ValidatedWorldPath,
+    err: crate::audit::AuditError,
+) -> EngineError {
+    match err {
+        crate::audit::AuditError::ChainBroken(_) => EngineError::Storage,
+        crate::audit::AuditError::Storage(err) => {
+            crate::engine_ops::log_storage_error(
+                "subject audit",
+                &err,
+                "delete",
+                Some(world.as_str()),
+            );
+            match crate::classify_storage_failure(&err) {
+                StorageFailureClass::InsufficientStorage => EngineError::InsufficientStorage,
+                StorageFailureClass::Transient => EngineError::TransientStorage,
+                StorageFailureClass::Other => EngineError::Storage,
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::engine_types::ValidatedWorldPath;
     use crate::test_support::test_core;
+    use crate::world_schema;
+    use rusqlite::Connection;
 
     #[test]
     fn delete_permit_requires_approve_and_binds_world() {
@@ -412,6 +504,185 @@ mod tests {
         assert_eq!(cas_rows, 0);
         assert_eq!(first_retained_seq, None);
         assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 0);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn delete_ledger_records_subject_final_address() {
+        struct NoopTrace;
+        impl DeleteTraceHooks for NoopTrace {}
+
+        let (core, dir) = test_core("delete-ledger-subject-address");
+        let subject = ValidatedWorldPath::new("home/delete-ledger-subject-address").unwrap();
+        core.write_world(subject.as_str(), b"old", "text/plain", &[])
+            .unwrap();
+        core.write_world(subject.as_str(), b"final", "text/plain", &[])
+            .unwrap();
+
+        let subject_conn =
+            Connection::open(crate::world::world_db(&dir, subject.as_str())).unwrap();
+        let subject_generation = world_schema::generation(&subject_conn).unwrap();
+        let (subject_seq, subject_hmac): (i64, String) = subject_conn
+            .query_row(
+                "SELECT id, hmac FROM events ORDER BY id DESC LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        drop(subject_conn);
+
+        let permit = authorize_delete(&subject, auth::Tier::Approve).unwrap();
+        delete(
+            &core,
+            &permit,
+            DeleteRequest {
+                preconditions: Preconditions::none(),
+                content_type: "text/plain".to_owned(),
+                headers: vec![("x-meta-operator".to_owned(), "alice".to_owned())],
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+
+        let ledger = Connection::open(crate::world::world_db(&dir, "var/log/deletes")).unwrap();
+        let events: Vec<(i64, String)> = {
+            let mut stmt = ledger
+                .prepare("SELECT id, event_type FROM events ORDER BY id")
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        assert_eq!(
+            events,
+            vec![
+                (1, "delete_intent".to_owned()),
+                (2, "delete_commit".to_owned())
+            ]
+        );
+
+        let expected = [
+            (
+                crate::audit::DELETE_SUBJECT_WORLD,
+                subject.as_str().to_owned(),
+            ),
+            (
+                crate::audit::DELETE_SUBJECT_GENERATION,
+                subject_generation.as_str().to_owned(),
+            ),
+            (crate::audit::DELETE_SUBJECT_SEQ, subject_seq.to_string()),
+            (
+                crate::audit::DELETE_SUBJECT_BODY_SHA256,
+                BodySha256::for_body(b"final").as_str().to_owned(),
+            ),
+            (
+                crate::audit::DELETE_SUBJECT_HMAC,
+                format!("hmac-{subject_hmac}"),
+            ),
+        ];
+        for event_id in [1_i64, 2] {
+            for (name, value) in expected.iter() {
+                let stored: String = ledger
+                    .query_row(
+                        "SELECT value FROM event_headers WHERE event_id=?1 AND name=?2",
+                        rusqlite::params![event_id, name],
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(stored, *value);
+            }
+            let operator: String = ledger
+                .query_row(
+                    "SELECT value FROM event_headers WHERE event_id=?1 AND name='x-meta-operator'",
+                    [event_id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(operator, "alice");
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_reserved_subject_metadata_headers() {
+        struct NoopTrace;
+        impl DeleteTraceHooks for NoopTrace {}
+
+        let (core, dir) = test_core("delete-ledger-reserved-subject-header");
+        let subject =
+            ValidatedWorldPath::new("home/delete-ledger-reserved-subject-header").unwrap();
+        core.write_world(subject.as_str(), b"body", "text/plain", &[])
+            .unwrap();
+
+        let permit = authorize_delete(&subject, auth::Tier::Approve).unwrap();
+        let err = delete(
+            &core,
+            &permit,
+            DeleteRequest {
+                preconditions: Preconditions::none(),
+                content_type: "text/plain".to_owned(),
+                headers: vec![("AuditeDB-Delete-Subject-Seq".to_owned(), "fake".to_owned())],
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, DeleteError::ReservedMetadataHeader));
+        assert!(core.read_world(subject.as_str()).unwrap().is_some());
+        assert!(!crate::world::world_db(&dir, "var/log/deletes").exists());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn delete_ledger_subject_generation_distinguishes_recreated_world() {
+        struct NoopTrace;
+        impl DeleteTraceHooks for NoopTrace {}
+
+        let (core, dir) = test_core("delete-ledger-recreate-generation");
+        let subject = ValidatedWorldPath::new("home/delete-ledger-recreate-generation").unwrap();
+        core.write_world(subject.as_str(), b"first", "text/plain", &[])
+            .unwrap();
+        let first_conn = Connection::open(crate::world::world_db(&dir, subject.as_str())).unwrap();
+        let first_generation = world_schema::generation(&first_conn).unwrap();
+        drop(first_conn);
+
+        let permit = authorize_delete(&subject, auth::Tier::Approve).unwrap();
+        delete(
+            &core,
+            &permit,
+            DeleteRequest {
+                preconditions: Preconditions::none(),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+
+        core.write_world(subject.as_str(), b"second", "text/plain", &[])
+            .unwrap();
+        let second_conn = Connection::open(crate::world::world_db(&dir, subject.as_str())).unwrap();
+        let second_generation = world_schema::generation(&second_conn).unwrap();
+        drop(second_conn);
+        assert_ne!(first_generation, second_generation);
+
+        let ledger = Connection::open(crate::world::world_db(&dir, "var/log/deletes")).unwrap();
+        let stored_generation: String = ledger
+            .query_row(
+                "SELECT value FROM event_headers
+                 WHERE event_id=1 AND name=?1",
+                [crate::audit::DELETE_SUBJECT_GENERATION],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(stored_generation, first_generation.as_str());
+        assert_ne!(stored_generation, second_generation.as_str());
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -155,6 +155,11 @@ pub enum EngineError {
     Auth(AuthGate),
     /// The supplied world name failed canonical-path validation.
     InvalidWorldName,
+    /// The supplied representation metadata failed engine-level validation.
+    InvalidMetadata {
+        /// Static reason string (`reserved-delete-subject-header`, ...).
+        message: &'static str,
+    },
     /// The world does not exist.
     NotFound,
     /// The target world is append-only and refuses delete/overwrite (for

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -609,6 +609,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn engine_delete_ledger_subject_generation_survives_recreate() {
+        let (engine, root) = test_engine("delete-recreate");
+        let world = ValidatedWorldPath::new("home/delete-recreate").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"first"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let first_conn = rusqlite::Connection::open(crate::world::world_db(
+            engine.core().data.as_path(),
+            world.as_str(),
+        ))
+        .unwrap();
+        let first_generation = crate::world_schema::generation(&first_conn).unwrap();
+        drop(first_conn);
+
+        engine
+            .delete(&world, Preconditions::none(), AccessTier::Approve)
+            .await
+            .unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"second"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let second_conn = rusqlite::Connection::open(crate::world::world_db(
+            engine.core().data.as_path(),
+            world.as_str(),
+        ))
+        .unwrap();
+        let second_generation = crate::world_schema::generation(&second_conn).unwrap();
+        drop(second_conn);
+        assert_ne!(first_generation, second_generation);
+
+        let ledger =
+            rusqlite::Connection::open(crate::world::world_db(&root, "var/log/deletes")).unwrap();
+        let stored_generation: String = ledger
+            .query_row(
+                "SELECT value FROM event_headers
+                 WHERE event_id=1 AND name=?1",
+                [crate::audit::DELETE_SUBJECT_GENERATION],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_generation, first_generation.as_str());
+        assert_ne!(stored_generation, second_generation.as_str());
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn engine_read_timeline_body_returns_historical_body() {
         let (engine, root) = test_engine("timeline-public-read");
         let world = ValidatedWorldPath::new("home/timeline-public-read").unwrap();

--- a/core/src/engine_trace.rs
+++ b/core/src/engine_trace.rs
@@ -87,6 +87,11 @@ pub trait EngineDeleteTraceHooks {
 /// [`DeleteMetadata::default`] to record empty metadata. The plain
 /// [`crate::Engine::delete`] convenience method always records empty
 /// metadata.
+///
+/// Header names beginning with `auditedb-delete-subject-` are reserved for the
+/// engine's internal subject-coordinate proof in the delete ledger. Supplying
+/// one of those names to [`crate::Engine::delete_traced`] fails with
+/// [`EngineError::InvalidMetadata`].
 #[derive(Clone, Default)]
 #[non_exhaustive]
 pub struct DeleteMetadata {
@@ -244,7 +249,9 @@ impl Engine {
     /// `audit_intent_failed` callback fires before the
     /// [`EngineError::Storage`] / [`EngineError::TransientStorage`] /
     /// [`EngineError::InsufficientStorage`] / [`EngineError::InternalInvariant`]
-    /// result is returned when the audit-intent write itself fails.
+    /// result is returned when the audit-intent write itself fails. Returns
+    /// [`EngineError::InvalidMetadata`] if `metadata.headers` uses a reserved
+    /// delete-subject header name.
     pub async fn delete_traced<H: EngineDeleteTraceHooks + ?Sized>(
         &self,
         world: &ValidatedWorldPath,

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -24,7 +24,7 @@ use std::sync::Mutex as StdMutex;
 
 use rusqlite::Connection;
 
-use crate::audit;
+use crate::audit::{self, AuditHeaders};
 use crate::engine_types::{AuditHmacKey, ValidatedWorldPath};
 use crate::event::EventMetadataKind;
 use crate::timeline::BodySha256;
@@ -39,7 +39,7 @@ pub(crate) struct AuditAppendJob {
     pub(crate) body_sha256: BodySha256,
     pub(crate) size: i64,
     pub(crate) content_type: String,
-    pub(crate) headers: Vec<(String, String)>,
+    pub(crate) headers: AuditHeaders,
     pub(crate) key: AuditHmacKey,
 }
 
@@ -154,7 +154,7 @@ mod tests {
                     body_sha256: BodySha256::for_body(b"body"),
                     size: 0,
                     content_type: "application/octet-stream".to_owned(),
-                    headers: Vec::new(),
+                    headers: AuditHeaders::empty(),
                     key: test_key(),
                 },
             )

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -497,6 +497,24 @@ impl ReadCache {
         })
     }
 
+    /// Delete-side subject anchoring. Reads the latest body-bearing audit row
+    /// through the same SlotState protocol as ordinary reads, so delete's
+    /// later tombstone drain cannot race a bare fd.
+    pub(crate) fn cached_latest_body_head(
+        &self,
+        data: &std::path::Path,
+        world: &crate::engine_types::ValidatedWorldPath,
+        key: &crate::engine_types::AuditHmacKey,
+    ) -> rusqlite::Result<Option<crate::audit::AuditResult<Option<crate::audit::VerifiedBodyHead>>>>
+    {
+        let key = key.clone_secret();
+        self.with_tracked_conn(data, world.as_str(), move |conn| {
+            Ok(crate::audit::verified_latest_body_head_via_conn(
+                conn, world, &key,
+            ))
+        })
+    }
+
     /// Run a closure with a `&mut TrackedReadConnection` obtained
     /// through the SlotState protocol. Three-phase split:
     ///   1. Cache hit (any state, regardless of cap)

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -510,7 +510,7 @@ impl ReadCache {
     ) -> rusqlite::Result<Option<crate::audit::AuditResult<Option<crate::audit::VerifiedBodyHead>>>>
     {
         let key = key.clone_secret();
-        self.with_tracked_conn(data, world.as_str(), move |conn| {
+        self.with_tracked_conn(data, world, move |conn| {
             Ok(crate::audit::verified_latest_body_head_via_conn(
                 conn, world, &key,
             ))

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -264,6 +264,27 @@ impl Core {
         }
     }
 
+    /// Delete-side final subject anchor through the read-cache SlotState
+    /// protocol. Durable delete uses this before installing a tombstone so the
+    /// delete ledger can identify the exact body event being removed.
+    pub(crate) fn latest_body_head(
+        &self,
+        world: &ValidatedWorldPath,
+    ) -> audit::AuditResult<Option<audit::VerifiedBodyHead>> {
+        debug_assert!(
+            !store::is_memory_world(world.as_str()),
+            "latest_body_head only applies to durable worlds"
+        );
+        let head = self
+            .read_cache
+            .cached_latest_body_head(&self.data, world, &self.hmac_key)
+            .map_err(audit::AuditError::from)?;
+        match head {
+            Some(result) => result,
+            None => Ok(None),
+        }
+    }
+
     /// Test-only fixture: seed a world directly without going through
     /// auth/preconditions/audit. Production writes go through `world_ops`
     /// (durable: `world::write_with_audit_checked` + `reserve_storage`;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -724,6 +724,48 @@ mod tests {
     }
 
     #[test]
+    fn delete_with_metadata_rejects_reserved_delete_subject_headers() {
+        let engine = test_engine("delete-meta-reserved");
+        let none = FfiPreconditions {
+            if_match: Vec::new(),
+            if_none_match: Vec::new(),
+        };
+        engine
+            .replace(
+                "home/delete-meta-reserved".to_owned(),
+                small_representation(b"delete me"),
+                none.clone(),
+                FfiAccessTier::Write,
+            )
+            .expect("replace succeeds");
+
+        let err = engine
+            .delete_with_metadata(
+                "home/delete-meta-reserved".to_owned(),
+                FfiDeleteMetadata {
+                    content_type: "text/plain".to_owned(),
+                    headers: vec![FfiHeader {
+                        name: "auditedb-delete-subject-seq".to_owned(),
+                        value: "fake".to_owned(),
+                    }],
+                },
+                none,
+                FfiAccessTier::Approve,
+            )
+            .expect_err("reserved header should be rejected");
+
+        assert!(matches!(
+            err,
+            FfiError::InvalidMetadata { ref message }
+                if message == "reserved-delete-subject-header"
+        ));
+        assert!(engine
+            .read("home/delete-meta-reserved".to_owned(), FfiAccessTier::Read)
+            .expect("read after rejected delete")
+            .is_some());
+    }
+
+    #[test]
     fn engine_verbs_reject_noncanonical_worlds() {
         let engine = test_engine("invalid-world");
         let err = engine
@@ -984,6 +1026,16 @@ mod tests {
         assert!(matches!(transient, FfiError::TransientStorage));
         assert!(!transient.to_string().contains("Some("));
         assert!(!transient.to_string().contains("sqlite"));
+
+        let invalid_metadata: FfiError = EngineError::InvalidMetadata {
+            message: "reserved-delete-subject-header",
+        }
+        .into();
+        assert!(matches!(
+            invalid_metadata,
+            FfiError::InvalidMetadata { ref message }
+                if message == "reserved-delete-subject-header"
+        ));
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -281,6 +281,9 @@ pub enum FfiError {
         gate: FfiAuthGate,
     },
     InvalidWorldName,
+    InvalidMetadata {
+        message: String,
+    },
     NotFound,
     AppendOnly,
     PayloadTooLarge {
@@ -604,6 +607,9 @@ impl From<EngineError> for FfiError {
         match value {
             EngineError::Auth(gate) => Self::Auth { gate: gate.into() },
             EngineError::InvalidWorldName => Self::InvalidWorldName,
+            EngineError::InvalidMetadata { message } => Self::InvalidMetadata {
+                message: message.to_owned(),
+            },
             EngineError::NotFound => Self::NotFound,
             EngineError::AppendOnly => Self::AppendOnly,
             EngineError::PayloadTooLarge { max } => Self::PayloadTooLarge { max: max as u64 },
@@ -643,6 +649,7 @@ impl fmt::Display for FfiError {
             | Self::RuntimeInitFailed { message }
             | Self::BuildDataRootIo { message }
             | Self::PreconditionFailed { message }
+            | Self::InvalidMetadata { message }
             | Self::InternalInvariant { message } => f.write_str(message),
             Self::UnknownBuildError { detail } | Self::UnknownEngineError { detail } => {
                 f.write_str(detail)


### PR DESCRIPTION
## Summary

- record the deleted subject's verified final coordinate in `var/log/deletes` intent/commit rows
- route delete subject capture through read-cache, audit-chain verification, and live-body verification before minting a proof
- keep delete subject metadata sealed through `AuditHeaders`/`VerifiedDeleteSubject` until audit append lowers it into HMAC-covered event headers
- reject user-supplied `auditedb-delete-subject-*` metadata across core, HTTP, CoAP, and FFI as `InvalidMetadata`

## Why

Delete replay cannot rely on the deleted world file. A delete ledger row that only names a path is ambiguous after delete/recreate. This layer records `{world, generation, seq, body_sha256, hmac}` for the exact audited body event being removed.

## Review Notes

Subagent review caught and this PR fixes:

- subject proof must verify the live body matches the audited head in the same SQLite snapshot
- subject proof must not degrade to raw header strings before the audit append sink
- reserved delete-subject metadata needs real API-level rejection tests
- ABA generation coverage should include the public `Engine::{replace, delete}` path

## Validation

- `python core/no_json.py core/src`
- `cargo fmt --check` (core)
- `cargo fmt --manifest-path bin/Cargo.toml -- --check`
- `cargo fmt --manifest-path ffi/Cargo.toml -- --check`
- `cargo test --lib` (core: 179 passed, 2 ignored)
- `cargo test --manifest-path bin/Cargo.toml` (109 passed)
- `cargo test --manifest-path ffi/Cargo.toml` (23 passed)
- `cargo clippy --all-targets -- -D warnings` (core)
- `cargo clippy --manifest-path bin/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path ffi/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --lib` (core)
- `git diff --check`
- pre-push hook full fast gate passed, including version consistency, cargo audit, SDK smoke, header policy scan, JS syntax, whitespace
