### PR TITLE
bin: expose timeline addresses in listen events

### DIFF
--- a/bin/src/server/http/README.md
+++ b/bin/src/server/http/README.md
@@ -70,6 +70,29 @@ them before calling Engine methods.
 Bare HTTP paths such as `/foo` are adapter-side conveniences and map to
 `home/foo` before validation. The Engine library itself rejects bare names.
 
+## `/listen/*`
+
+`GET /listen/<pattern>` opens a Server-Sent Events stream. Each event is a
+control-plane notification: it says which world changed, but it never embeds
+the world's body.
+
+```text
+event: put
+id: 42
+data: path: /home/task/a
+data: method: PUT
+data: etag: hmac-...
+data: timeline-world: home/task/a
+data: timeline-generation: ...
+data: timeline-seq: 1
+data: timeline-body-sha256: ...
+```
+
+`timeline-*` fields appear for durable body writes when the Engine has a
+timeline address for that exact world. They identify the historical write; they
+are not a body payload. A later `GET /home/task/a` reads the current value and
+may observe a newer write than the event that woke the client.
+
 ## `/proc/*`
 
 The binary exposes text-shaped `/proc/*` endpoints over HTTP. These are adapter

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -237,7 +237,7 @@ mod tests {
             .subscribe(
                 &SubscribePattern::new("home/task/*"),
                 AccessTier::Read,
-                None,
+                SubscriptionResume::none(),
             )
             .expect("test subscription should be accepted");
         let world = ValidatedWorldPath::new("home/task/source").unwrap();

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -19,9 +19,9 @@ pub(crate) const ALLOW: &str = "GET, OPTIONS";
 // SSE event tap. Curl-first:
 //   curl -N http://127.0.0.1:3105/listen/home/task/*
 //
-// The stream is control-plane only. It says which world changed; it
-// never embeds the world's body, so stored Content-Type semantics stay
-// entirely on GET/HEAD.
+// The stream is control-plane only. Durable body writes carry a timeline
+// address; they still never embed the world's body, so stored Content-Type
+// semantics stay outside the SSE event.
 pub(crate) async fn handler(
     State(state): State<ServerState>,
     method: Method,
@@ -104,6 +104,25 @@ fn sse_change_event(change: EngineChangeEvent) -> Event {
         data.push_str("\netag: ");
         data.push_str(&change.etag);
     }
+    if let Some(address) = change.timeline_address.as_ref() {
+        if address.world() == &change.path {
+            data.push_str("\ntimeline-world: ");
+            data.push_str(address.world().as_str());
+            data.push_str("\ntimeline-generation: ");
+            data.push_str(address.generation().as_str());
+            data.push_str("\ntimeline-seq: ");
+            data.push_str(&address.seq().get().to_string());
+            data.push_str("\ntimeline-body-sha256: ");
+            data.push_str(address.body_sha256().as_str());
+        } else {
+            #[cfg(feature = "unstable-engine")]
+            tracing::warn!(
+                event_path = %change.path,
+                timeline_world = %address.world(),
+                "dropping mismatched timeline address from SSE event"
+            );
+        }
+    }
     Event::default()
         .event(method.to_ascii_lowercase())
         .id(change.id.to_string())
@@ -133,7 +152,7 @@ mod tests {
     use axum::body::Bytes;
 
     #[tokio::test]
-    async fn sse_change_event_is_control_plane_only() {
+    async fn sse_change_event_carries_timeline_address_without_body() {
         let (engine, dir) = test_engine_for_server("listen-sse-event");
         let mut subscription = engine
             .subscribe(
@@ -163,12 +182,47 @@ mod tests {
         assert!(wire.contains("put"));
         assert!(wire.contains("/home/task/a"));
         assert!(wire.contains("hmac-"));
-        assert!(!wire.contains("body"));
-        assert!(!wire.contains("timeline"));
-        assert!(!wire.contains("generation"));
-        assert!(!wire.contains("seq"));
-        assert!(!wire.contains("body_sha256"));
+        assert!(wire.contains("timeline-world: home/task/a"));
+        assert!(wire.contains("timeline-generation: "));
+        assert!(wire.contains("timeline-seq: 1"));
+        assert!(wire.contains("timeline-body-sha256: "));
         assert!(!wire.contains("secret-body"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn sse_change_event_drops_mismatched_timeline_address() {
+        let (engine, dir) = test_engine_for_server("listen-sse-mismatch");
+        let mut subscription = engine
+            .subscribe(
+                &SubscribePattern::new("home/task/*"),
+                AccessTier::Read,
+                None,
+            )
+            .expect("test subscription should be accepted");
+        let world = ValidatedWorldPath::new("home/task/source").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"body"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .expect("test write should notify subscription");
+
+        let mut event = subscription
+            .recv()
+            .await
+            .expect("test subscription should receive change");
+        assert!(event.timeline_address.is_some());
+        event.path = ValidatedWorldPath::new("home/task/other").unwrap();
+
+        let wire = format!("{:?}", sse_change_event(event));
+        assert!(wire.contains("path: /home/task/other"));
+        assert!(!wire.contains("timeline-world"));
+        assert!(!wire.contains("home/task/source"));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -605,8 +605,8 @@ const unsub = e.listen("home/task/*", (ev) => {
         console.error(ev.error);
         return;
     }
-    console.log(ev.method, ev.path, ev.etag);
-    // → "PUT /home/task/123 hmac-..."
+    console.log(ev.method, ev.path, ev.etag, ev.timelineSeq);
+    // → "PUT /home/task/123 hmac-... 42"
 });
 
 // Later:
@@ -622,7 +622,11 @@ Event shape:
     path:   "/home/task/123",
     method: "PUT",
     etag:   "hmac-...",
-    data:   "path: /home/task/123\nmethod: PUT\netag: hmac-...",  // raw multi-line, rarely needed
+    timelineWorld:      "home/task/123",       // durable body writes only
+    timelineGeneration: "0123456789abcdef0123456789abcdef",
+    timelineSeq:        "42",
+    timelineBodySha256: "...",
+    data:   "path: /home/task/123\nmethod: PUT\netag: hmac-...\ntimeline-world: home/task/123\n...",  // raw multi-line, rarely needed
 }
 ```
 
@@ -637,7 +641,8 @@ rejected promise because `listen()` is a long-lived stream, not a one-shot
 request. Handle that branch in the callback and keep your unsubscribe function.
 
 The stream is control-plane only — **the body of each write is NOT included in the event**.
-If you need the bytes, follow up with `e.get(ev.path)`.
+Durable body writes include timeline fields that identify the historical write.
+`e.get(ev.path)` reads the current value and may observe a later write.
 
 ### Convenience
 
@@ -776,9 +781,10 @@ own via `options.fetch`.
 import { Elastik } from "@elastikjs/client";
 const e = new Elastik("http://127.0.0.1:3105", { writeToken: "w" });
 
-// Worker: process tasks
+// Worker: react to changes where "latest value wins" is acceptable.
 e.listen("home/task/*", async (ev) => {
     if (ev.type !== "put") return;
+    // This is a current read, not a historical dereference of ev.timelineSeq.
     const body = await e.get(ev.path);
     const result = await doWork(body);
     const id = ev.path.split("/").pop();

--- a/sdk-js/index.d.ts
+++ b/sdk-js/index.d.ts
@@ -138,6 +138,10 @@ export interface ListenEvent {
     path?: string;
     method?: string;
     etag?: string;
+    timelineWorld?: string;
+    timelineGeneration?: string;
+    timelineSeq?: string;
+    timelineBodySha256?: string;
     data?: string;
     error?: unknown;
 }

--- a/sdk-js/index.mjs
+++ b/sdk-js/index.mjs
@@ -282,7 +282,7 @@ export class Elastik {
 
     // ─── LISTEN ──────────────────────────────────────────
     // Subscribe to /listen/<pattern>. Calls callback(event) for each SSE event.
-    // event: { type, id, path, method, etag, data }
+    // event: { type, id, path, method, etag, timeline*, data }
     //   type   "put" | "post" | "delete" | "lag" | "message" | "error"
     //   data   raw multi-line data string (rarely needed; structured fields above suffice)
     // Returns: () => void (unsubscribe)
@@ -755,7 +755,8 @@ async function consumeSSE(body, callback, signal) {
 //   path: /home/note
 //   method: PUT
 //   etag: hmac-abc...
-// Pull them out as named fields so the callback gets event.path / .method / .etag.
+//   timeline-world: home/note
+// Pull them out as named fields so callbacks do not parse raw SSE text.
 function parseElastikSseData(data) {
     const out = { path: "", method: "", etag: "" };
     if (!data) return out;
@@ -768,6 +769,10 @@ function parseElastikSseData(data) {
         if (k === "path") out.path = v;
         else if (k === "method") out.method = v;
         else if (k === "etag") out.etag = v;
+        else if (k === "timeline-world") out.timelineWorld = v;
+        else if (k === "timeline-generation") out.timelineGeneration = v;
+        else if (k === "timeline-seq") out.timelineSeq = v;
+        else if (k === "timeline-body-sha256") out.timelineBodySha256 = v;
     }
     return out;
 }

--- a/sdk-js/test.mjs
+++ b/sdk-js/test.mjs
@@ -364,8 +364,28 @@ check(ev?.type === "put", "event.type is 'put'", ev?.type);
 check(ev?.path === "/home/sdk-test/listen/a", "event.path", ev?.path);
 check(ev?.method === "PUT", "event.method", ev?.method);
 check(typeof ev?.etag === "string" && ev.etag.startsWith("hmac-"), "event.etag", ev?.etag);
+check(ev?.timelineWorld === "home/sdk-test/listen/a", "event.timelineWorld", ev?.timelineWorld);
+check(typeof ev?.timelineGeneration === "string" && ev.timelineGeneration.length === 32, "event.timelineGeneration", ev?.timelineGeneration);
+check(ev?.timelineSeq === "1", "event.timelineSeq", ev?.timelineSeq);
+check(typeof ev?.timelineBodySha256 === "string" && ev.timelineBodySha256.length === 64, "event.timelineBodySha256", ev?.timelineBodySha256);
 check(typeof ev?.id === "string" && ev.id.length > 0, "event.id present", ev?.id);
 check(!String(ev?.data ?? "").includes("evt-payload-secret"), "event.data does not leak body");
+
+const appendEvents = [];
+const appendUnsub = e.listen("home/sdk-test/listen/*", (appendEv) => {
+    if (appendEv.type !== "error") appendEvents.push(appendEv);
+});
+await sleep(300);
+await e.post("home/sdk-test/listen/a", "-append-secret");
+await sleep(500);
+appendUnsub();
+const appendEv = appendEvents[appendEvents.length - 1];
+check(appendEv?.type === "post", "append event.type is 'post'", appendEv?.type);
+check(appendEv?.method === "POST", "append event.method", appendEv?.method);
+check(appendEv?.timelineWorld === "home/sdk-test/listen/a", "append event.timelineWorld", appendEv?.timelineWorld);
+check(appendEv?.timelineSeq === "2", "append event.timelineSeq", appendEv?.timelineSeq);
+check(typeof appendEv?.timelineBodySha256 === "string" && appendEv.timelineBodySha256.length === 64, "append event.timelineBodySha256", appendEv?.timelineBodySha256);
+check(!String(appendEv?.data ?? "").includes("-append-secret"), "append event.data does not leak body");
 
 // ─── Test 16: listen unsubscribe terminates cleanly ──────────
 console.log("\n=== unsubscribe cleanup ===");

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -540,6 +540,8 @@ Handler rules:
 - Extra context is injected by name: `path`, `etag`, `pattern`, `meta`, `e`,
   `method`, and `event`.
 - `world` is still accepted as a compatibility alias for `path`.
+- `body` is a current `GET path` result at dispatch time. It is not a
+  historical dereference of the SSE event's timeline fields.
 - You can do normal Python side effects inside the handler.
 - Advanced users may return `Reply`, `Archive`, `MoveTo`, or `Drop` action
   objects, but they are not required.

--- a/sdk/src/elastik/reactor.py
+++ b/sdk/src/elastik/reactor.py
@@ -35,6 +35,10 @@ def listen(pattern: str, *, replace: bool = False) -> Callable[[F], F]:
     any named kwargs it asks for: `path`, `world` (compat alias),
     `etag`, `pattern`, `meta`, `e`.
 
+    `body` is fetched with `GET path` when the event is dispatched. It is
+    the current value at dispatch time, not a historical dereference of the
+    SSE event's timeline fields.
+
     Registering the same pattern twice is usually a bug, so it raises
     ValueError unless `replace=True` is explicit.
     """

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -1172,9 +1172,14 @@ class Elastik(MutableMapping[str, bytes]):
           data: path: /home/task/a
           data: method: PUT
           data: etag: hmac-...
+          data: timeline-world: home/task/a
+          data: timeline-generation: 0123456789abcdef0123456789abcdef
+          data: timeline-seq: 42
+          data: timeline-body-sha256: ...
 
-        The body is never embedded in the stream. Consumers that need
-        content call GET/HEAD with the path from the event.
+        The body is never embedded in the stream. Timeline fields are
+        historical coordinates for durable body writes; GET/HEAD with the
+        path reads the current value, not necessarily the signalled value.
         """
         url = self.url + "/listen/" + _quote_listen_pattern(pattern)
         h = {}

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -1278,6 +1278,16 @@ def main() -> int:
             check(ev.get("path") == "/home/sdk/listen/a", "SSE event path")
             check(ev.get("method") == "PUT", "SSE event method")
             check("etag" in ev and ev["etag"].startswith("hmac-"), "SSE event has etag")
+            check(ev.get("timeline-world") == "home/sdk/listen/a", "SSE event has timeline world")
+            check(
+                len(ev.get("timeline-generation", "")) == 32,
+                "SSE event has timeline generation",
+            )
+            check(ev.get("timeline-seq") == "1", "SSE event has timeline seq")
+            check(
+                len(ev.get("timeline-body-sha256", "")) == 64,
+                "SSE event has timeline body hash",
+            )
             check("payload" not in ev.get("data", ""), "SSE event does not embed body")
 
             replay_events: list[dict[str, str]] = []
@@ -1299,6 +1309,37 @@ def main() -> int:
             replay = replay_events[0]
             check(replay.get("path") == "/home/sdk/listen/b", "replayed SSE event path")
             check(int(replay.get("id", "0")) > int(ev.get("id", "0")), "replayed SSE id advances")
+
+            append_events: list[dict[str, str]] = []
+            append_done = threading.Event()
+
+            def consume_append() -> None:
+                for event in reader.listen("/home/sdk/listen/*"):
+                    append_events.append(event)
+                    append_done.set()
+                    break
+
+            append_t = threading.Thread(target=consume_append, daemon=True)
+            append_t.start()
+            time.sleep(0.2)
+            writer.post("/home/sdk/listen/a", b"-append-secret")
+            check(append_done.wait(5), "sdk listen receives append SSE event")
+            append_ev = append_events[0]
+            check(append_ev.get("event") == "post", "append SSE event type is post")
+            check(append_ev.get("method") == "POST", "append SSE event method")
+            check(
+                append_ev.get("timeline-world") == "home/sdk/listen/a",
+                "append SSE event has timeline world",
+            )
+            check(append_ev.get("timeline-seq") == "2", "append SSE event has timeline seq")
+            check(
+                len(append_ev.get("timeline-body-sha256", "")) == 64,
+                "append SSE event has timeline body hash",
+            )
+            check(
+                "-append-secret" not in append_ev.get("data", ""),
+                "append SSE event does not embed body",
+            )
 
             elastik.clear_routes()
             elastik.clear_lifecycle_hooks()


### PR DESCRIPTION
## Summary

- emit durable write timeline coordinates on `/listen/*` SSE events: `timeline-world`, `timeline-generation`, `timeline-seq`, and `timeline-body-sha256`
- keep SSE control-plane only: no body bytes are embedded in the event stream
- expose the new coordinates through Python and JS listen surfaces and tests
- document the crucial caveat: `GET path` is a current read, not historical dereference of the signalled write

## Why

This is the next small layer after #344 / `stack/22r28-delete-subject-proof`.

The CAS/timeline plan needs notifications to identify the historical write without pretending that subscribe itself is a body stream. This layer takes Path 3 literally:

- notification carries the timeline address
- notification does not carry the body
- clients can distinguish “this write happened” from “read current value now”

The HTTP timeline dereference endpoint is intentionally not added in this PR.

## Safety shape

- `TimelineAddress` remains an opaque core proof; this PR only de-seals it at the final SSE wire sink.
- The SSE formatter emits timeline fields only when `address.world() == event.path`.
- Mismatched path/address events fail closed: the event still announces the change, but timeline fields are dropped instead of publishing a false coordinate.
- SDKs expose plain strings, not trusted proof tokens.

## Validation

Local before push:

- `cargo fmt --manifest-path bin\Cargo.toml -- --check`
- `cargo test --manifest-path bin\Cargo.toml` — 110 passed
- `cargo clippy --manifest-path bin\Cargo.toml --all-targets -- -D warnings`
- `python -m compileall sdk\src\elastik sdk\tests\e2e_blackbox.py`
- `node --check sdk-js\index.mjs; node --check sdk-js\test.mjs; node --check sdk-js\test-start.mjs`
- targeted Python real-core listen smoke — PUT and POST timeline fields, no body leak
- JS real-core e2e against current `bin\target\debug\elastik-core.exe` — 152 passed
- `git diff --check`

Pre-push hook:

- Rust format
- Rust clippy
- Rust core tests — 179 passed, 2 ignored
- Rust doc tests — 6 passed
- Rust bin tests — 110 passed
- version consistency — 8.3.0
- bundled SQLite version check — 3.53.1
- `cargo audit` for core/bin/ffi locks
- Python SDK smoke — PASS
- header policy scanner and missing-baseline negative test
- JS syntax
- whitespace check

## Review ledger

Independent review rounds found and fixed:

- SDK missing JS timeline fields → fixed in parser, types, docs, tests
- docs overclaiming `GET` as historical deref → fixed in Python/JS docs and HTTP README
- path/address mismatch was representable → SSE sink now fails closed and has a regression test
- PUT-only SDK coverage → added POST/append timeline coverage for Python and JS
- HTTP `/listen` README lacked output shape → added wire example and current-read caveat
- JS README raw `data` sample omitted timeline lines → updated

Final narrow QA reported no P0-P3 findings.
