### PR TITLE
core: add timeline dereference result type

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -182,6 +182,7 @@ mod store;
 #[cfg(test)]
 mod test_support;
 mod timeline;
+mod timeline_dereference;
 mod world;
 mod world_generation;
 mod world_ops;
@@ -229,6 +230,11 @@ pub use path::{validate_world_name, NAMESPACE_PREFIXES};
 pub use timeline::{
     BodySha256, InvalidTimelineCoordinate, TimelineAddress, TimelineBody, TimelineCoordinate,
     TimelineCorruption, TimelineRead, TimelineSeq,
+};
+#[cfg(feature = "unstable-engine")]
+pub use timeline_dereference::{
+    TimelineDereference, VerifiedBodyHashMismatch, VerifiedGenerationMismatch, VerifiedMissingRow,
+    VerifiedNonBodyEvent,
 };
 #[cfg(feature = "unstable-engine")]
 pub use world_generation::WorldGeneration;

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -143,7 +143,7 @@ pub enum InvalidTimelineCoordinate {
     BodySha256NotLowerHex,
 }
 
-/// Corruption detected while resolving a timeline address.
+/// Corruption detected while resolving a timeline address or coordinate.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TimelineCorruption {

--- a/core/src/timeline_dereference.rs
+++ b/core/src/timeline_dereference.rs
@@ -1,0 +1,335 @@
+//! Coordinate dereference result contract for timeline reads.
+//!
+//! A [`TimelineCoordinate`] is wire syntax. This module names the later result
+//! states for the resolver that verifies a subject world's audit chain before
+//! it returns either a historical body or a proof-bearing negative fact.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use crate::timeline::{BodySha256, TimelineBody, TimelineCoordinate, TimelineCorruption};
+use crate::world_generation::WorldGeneration;
+
+/// Verified generation mismatch for coordinate-based timeline dereference.
+///
+/// This is a proof value, not a plain error bag. Callers can inspect it, but
+/// cannot construct one without going through this module's resolver path after
+/// it verifies the subject world's audit chain.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedGenerationMismatch {
+    requested: TimelineCoordinate,
+    actual: WorldGeneration,
+}
+
+/// Verified body-hash mismatch for coordinate-based timeline dereference.
+///
+/// The event row exists and has been verified at the requested world,
+/// generation, and sequence, but the row's body hash differs from the untrusted
+/// coordinate supplied by the caller.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedBodyHashMismatch {
+    requested: TimelineCoordinate,
+    actual_body_sha256: BodySha256,
+}
+
+/// Verified non-body event for coordinate-based timeline dereference.
+///
+/// The requested world/generation/sequence exists in an intact audit chain, but
+/// that event does not carry a historical body. The requested body hash remains
+/// caller-supplied syntax, not a proven row fact.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedNonBodyEvent {
+    requested: TimelineCoordinate,
+}
+
+/// Verified row absence for coordinate-based timeline dereference.
+///
+/// The subject world exists, its generation matches the coordinate, and its
+/// audit chain is intact, but no row exists at the requested sequence. The
+/// requested body hash remains caller-supplied syntax, not a proven row fact.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedMissingRow {
+    requested: TimelineCoordinate,
+}
+
+/// Result of dereferencing an untrusted [`TimelineCoordinate`].
+///
+/// This is intentionally separate from [`crate::TimelineRead`].
+/// [`crate::TimelineRead`] is for already proof-bearing timeline addresses and
+/// can report address-bearing states such as `Gone` or `Expired`. Coordinate
+/// dereference starts before that proof exists, so every verified historical
+/// negative outcome carries a sealed proof value and unproven absence stays
+/// distinct.
+///
+/// Public callers cannot mint verified negative outcomes with raw constructors:
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+/// let actual_generation: elastik_core::WorldGeneration = todo!();
+///
+/// let _ = elastik_core::VerifiedGenerationMismatch::new(requested, actual_generation);
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+/// let actual_hash: elastik_core::BodySha256 = todo!();
+///
+/// let _ = elastik_core::VerifiedBodyHashMismatch::new(requested, actual_hash);
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+///
+/// let _ = elastik_core::VerifiedNonBodyEvent::new(requested.clone());
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+///
+/// let _ = elastik_core::VerifiedMissingRow::new(requested);
+/// # }
+/// ```
+///
+/// Nor can they construct proofs with struct literals:
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+/// let actual_generation: elastik_core::WorldGeneration = todo!();
+///
+/// let _ = elastik_core::VerifiedGenerationMismatch {
+///     requested,
+///     actual: actual_generation,
+/// };
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+/// let actual_hash: elastik_core::BodySha256 = todo!();
+///
+/// let _ = elastik_core::VerifiedBodyHashMismatch {
+///     requested,
+///     actual_body_sha256: actual_hash,
+/// };
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+///
+/// let _ = elastik_core::VerifiedNonBodyEvent { requested };
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+///
+/// let _ = elastik_core::VerifiedMissingRow { requested };
+/// # }
+/// ```
+///
+/// A raw coordinate also cannot stand in for a verified proof:
+///
+/// ```compile_fail
+/// # #[cfg(feature = "unstable-engine")]
+/// # fn run() {
+/// let requested: elastik_core::TimelineCoordinate = todo!();
+///
+/// let _ = elastik_core::TimelineDereference::MissingRow(requested);
+/// # }
+/// ```
+#[non_exhaustive]
+pub enum TimelineDereference {
+    /// The addressed historical body was found.
+    Body(TimelineBody),
+    /// The subject world exists and verified, but belongs to a different
+    /// generation than the coordinate requested.
+    GenMismatch(VerifiedGenerationMismatch),
+    /// The event row exists and verified, but promised a different body hash.
+    BodyHashMismatch(VerifiedBodyHashMismatch),
+    /// The event row exists and verified, but it is metadata-only.
+    NonBodyEvent(VerifiedNonBodyEvent),
+    /// The subject world exists and verified, but the sequence row is absent.
+    MissingRow(VerifiedMissingRow),
+    /// No bounded proof source can currently prove the requested coordinate.
+    UnprovenCoordinate(TimelineCoordinate),
+    /// Integrity failure while resolving the coordinate.
+    Corrupt {
+        /// Coordinate being resolved when corruption was detected.
+        coordinate: TimelineCoordinate,
+        /// Integrity failure category.
+        reason: TimelineCorruption,
+    },
+}
+
+impl VerifiedGenerationMismatch {
+    fn new(requested: TimelineCoordinate, actual: WorldGeneration) -> Option<Self> {
+        if requested.generation() == &actual {
+            return None;
+        }
+        Some(Self { requested, actual })
+    }
+
+    /// Returns the untrusted coordinate after the resolver proved the mismatch.
+    pub fn requested(&self) -> &TimelineCoordinate {
+        &self.requested
+    }
+
+    /// Returns the actual generation stored in the subject world.
+    pub fn actual(&self) -> &WorldGeneration {
+        &self.actual
+    }
+}
+
+impl VerifiedBodyHashMismatch {
+    fn new(requested: TimelineCoordinate, actual_body_sha256: BodySha256) -> Option<Self> {
+        if requested.body_sha256() == &actual_body_sha256 {
+            return None;
+        }
+        Some(Self {
+            requested,
+            actual_body_sha256,
+        })
+    }
+
+    /// Returns the untrusted coordinate after the resolver proved the mismatch.
+    pub fn requested(&self) -> &TimelineCoordinate {
+        &self.requested
+    }
+
+    /// Returns the body digest found in the verified event row.
+    pub fn actual_body_sha256(&self) -> &BodySha256 {
+        &self.actual_body_sha256
+    }
+}
+
+impl VerifiedNonBodyEvent {
+    fn new(requested: TimelineCoordinate) -> Self {
+        Self { requested }
+    }
+
+    /// Returns the requested coordinate after the resolver proved the row is
+    /// non-body-bearing.
+    pub fn requested(&self) -> &TimelineCoordinate {
+        &self.requested
+    }
+}
+
+impl VerifiedMissingRow {
+    fn new(requested: TimelineCoordinate) -> Self {
+        Self { requested }
+    }
+
+    /// Returns the requested coordinate after the resolver proved the row is
+    /// absent.
+    pub fn requested(&self) -> &TimelineCoordinate {
+        &self.requested
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn coordinate_with_hash(seq: i64, hash: &str) -> TimelineCoordinate {
+        TimelineCoordinate::from_wire_parts(
+            "home/timeline",
+            "0123456789abcdef0123456789abcdef",
+            seq,
+            hash,
+        )
+        .unwrap()
+    }
+
+    fn coordinate(seq: i64) -> TimelineCoordinate {
+        coordinate_with_hash(
+            seq,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+    }
+
+    fn other_body_hash() -> BodySha256 {
+        BodySha256::new("fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210").unwrap()
+    }
+
+    #[test]
+    fn timeline_dereference_negative_outcomes_carry_verified_proofs() {
+        let requested = coordinate(42);
+        let actual_gen = WorldGeneration::new("fedcba9876543210fedcba9876543210").unwrap();
+        let actual_hash = other_body_hash();
+
+        let gen_mismatch =
+            VerifiedGenerationMismatch::new(requested.clone(), actual_gen.clone()).unwrap();
+        assert_eq!(gen_mismatch.requested(), &requested);
+        assert_eq!(gen_mismatch.actual(), &actual_gen);
+
+        let body_hash_mismatch =
+            VerifiedBodyHashMismatch::new(requested.clone(), actual_hash.clone()).unwrap();
+        assert_eq!(body_hash_mismatch.requested(), &requested);
+        assert_eq!(body_hash_mismatch.actual_body_sha256(), &actual_hash);
+
+        let non_body = VerifiedNonBodyEvent::new(requested.clone());
+        assert_eq!(non_body.requested(), &requested);
+
+        let missing = VerifiedMissingRow::new(requested.clone());
+        assert_eq!(missing.requested(), &requested);
+
+        let results = [
+            TimelineDereference::GenMismatch(gen_mismatch),
+            TimelineDereference::BodyHashMismatch(body_hash_mismatch),
+            TimelineDereference::NonBodyEvent(non_body),
+            TimelineDereference::MissingRow(missing),
+            TimelineDereference::UnprovenCoordinate(requested.clone()),
+        ];
+
+        for result in results {
+            match result {
+                TimelineDereference::GenMismatch(proof) => {
+                    assert_eq!(proof.requested(), &requested)
+                }
+                TimelineDereference::BodyHashMismatch(proof) => {
+                    assert_eq!(proof.requested(), &requested)
+                }
+                TimelineDereference::NonBodyEvent(proof) => {
+                    assert_eq!(proof.requested(), &requested)
+                }
+                TimelineDereference::MissingRow(proof) => assert_eq!(proof.requested(), &requested),
+                TimelineDereference::UnprovenCoordinate(coord) => assert_eq!(coord, requested),
+                TimelineDereference::Body(_) | TimelineDereference::Corrupt { .. } => {
+                    panic!("unexpected dereference state")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn mismatch_proofs_reject_non_mismatches() {
+        let requested = coordinate(42);
+        assert!(
+            VerifiedGenerationMismatch::new(requested.clone(), requested.generation().clone())
+                .is_none()
+        );
+        assert!(
+            VerifiedBodyHashMismatch::new(requested.clone(), requested.body_sha256().clone())
+                .is_none()
+        );
+    }
+}

--- a/design_notes/PLAN-http-timeline-dereference.md
+++ b/design_notes/PLAN-http-timeline-dereference.md
@@ -221,7 +221,7 @@ TimelineCoordinate
   -> live event row exists but is not body-bearing
      -> mint VerifiedNonBodyEvent and return NonBodyEvent
   -> event row exists but body hash differs from the requested coordinate
-     -> mint VerifiedAddressMismatch and return AddressMismatch
+     -> mint VerifiedBodyHashMismatch and return BodyHashMismatch
   -> verified subject DB and generation exist, but the requested seq is absent
      -> mint VerifiedMissingRow and return MissingRow
   -> event row shape is impossible or malformed after chain verification
@@ -251,7 +251,7 @@ such as:
 TimelineDereferenceV1 =
     Body(TimelineBody)                  // contains verified TimelineAddress
   | GenMismatch(VerifiedGenerationMismatch)
-  | AddressMismatch(VerifiedAddressMismatch)
+  | BodyHashMismatch(VerifiedBodyHashMismatch)
   | NonBodyEvent(VerifiedNonBodyEvent)
   | MissingRow(VerifiedMissingRow)
   | UnprovenCoordinate(TimelineCoordinate)
@@ -262,7 +262,7 @@ The exact Rust names can change, but the proof rule cannot:
 
 - only variants whose event row has been verified may carry `TimelineAddress`;
 - verified negative historical facts are proof values too. `GenMismatch`,
-  `AddressMismatch`, `NonBodyEvent`, and `MissingRow` must use opaque
+  `BodyHashMismatch`, `NonBodyEvent`, and `MissingRow` must use opaque
   private-field proof structs or private resolver-only constructors. A raw
   `TimelineCoordinate` is syntax, not proof;
 - `GenMismatch` requires an intact subject audit-chain verification before the
@@ -270,9 +270,9 @@ The exact Rust names can change, but the proof rule cannot:
   as harmless generation mismatch;
 - `NonBodyEvent` is distinct from `MissingRow` and `Corrupt`: the row exists and
   the chain is intact, but the event class does not carry a body;
-- `AddressMismatch` is distinct from `MissingRow` and `Corrupt`: the row exists,
-  but its body hash disagrees with the requested coordinate, so the resolver
-  must stop before any CAS lookup;
+- `BodyHashMismatch` is distinct from `MissingRow` and `Corrupt`: the row
+  exists, but its body hash disagrees with the requested coordinate, so the
+  resolver must stop before any CAS lookup;
 - retention states (`NeverRetained`, `Expired`) are not v1 HTTP outcomes. They
   require a verified address plus the retention / pruning proof described in
   `PLAN-cas-body-schema.md`;
@@ -313,7 +313,7 @@ The HTTP route maps the resolver outcome without substituting current state.
 | `Body` | 200 | historical body bytes |
 | `Body` via `HEAD` | 200 | empty |
 | `GenMismatch` | 409 | text reason |
-| `AddressMismatch` | 409 | text reason |
+| `BodyHashMismatch` | 409 | text reason |
 | `NonBodyEvent` | 404 | text reason |
 | `MissingRow` | 404 | text reason |
 | `UnprovenCoordinate` | 404 | text reason |
@@ -445,7 +445,7 @@ client asks for body_sha256=B
 ```
 
 If the resolver returns `MissingRow`, `Corrupt`, or performs a CAS lookup for
-`B`, the resolver failed. Correct result: typed `AddressMismatch` before CAS
+`B`, the resolver failed. Correct result: typed `BodyHashMismatch` before CAS
 lookup, mapped to `409 Conflict`.
 
 ### Counterexample I: Generation Mismatch Precedes Row Lookup
@@ -656,7 +656,7 @@ record the AGENTS endpoint checklist result:
   `Range`, `If-None-Match`, and `If-Range` for v1: no `304`, `206`, `416`,
   current-world ETag, or partial historical body;
 - proof-state tests for `GenMismatch` after intact audit-chain verification,
-  `AddressMismatch`, `NonBodyEvent`, `MissingRow`, `UnprovenCoordinate`,
+  `BodyHashMismatch`, `NonBodyEvent`, `MissingRow`, `UnprovenCoordinate`,
   malformed/corrupt event-row shape, internal distinction before HTTP mapping
   when two states share status, and explicit proof that v1 does not scan the
   delete ledger or emit `Gone`;


### PR DESCRIPTION
## Summary

Adds the coordinate dereference result contract for HTTP timeline reads:

- new `TimelineDereference` result type
- sealed verified negative proof carriers:
  - `VerifiedGenerationMismatch`
  - `VerifiedBodyHashMismatch`
  - `VerifiedNonBodyEvent`
  - `VerifiedMissingRow`
- aligns the HTTP timeline plan wording from `AddressMismatch` to the more precise `BodyHashMismatch`
- no resolver, HTTP route, CAS lookup, delete-ledger lookup, retention behaviour, or current-read fallback in this layer

## Stack Position

Base / prior layer: `stack/22r31-http-timeline-deref-plan` at `30883f6` (#347).

Branch / layer: `stack/22r32-timeline-deref-result-type` at `7aa514f`.

Stack-depth note: maintainer explicitly allowed infinite stacking in this thread, so this PR intentionally proceeds beyond the normal AGENTS cascade-depth cap under that one-off override.

## Plan Section

Implements the type-surface portion of `design_notes/PLAN-http-timeline-dereference.md`:

- section 4, type seal boundary
- section 7 item 1, core resolver result type / proof-bearing negative outcomes

`Gone`, `Expired`, and `NeverRetained` remain out of v1 until bounded delete / retention proof layers exist.

## Type-Seal Contract

- Public callers can inspect proof values but cannot forge them.
- Proof fields are private.
- Proof constructors are module-private.
- Verified enum variants require sealed proof carriers.
- `BodyHashMismatch` carries the requested coordinate plus the actual verified row body hash, and its constructor rejects equal hashes.
- `GenMismatch` rejects equal generations.
- Compile-fail docs cover constructor, struct-literal, and raw-coordinate bypass attempts.

## Budget

AGENTS production-line counts:

- `core/src/lib.rs`: 181
- `core/src/timeline.rs`: 455
- `core/src/timeline_dereference.rs`: 247

PR production surface remains under the 500-line budget.

## Validation

Local targeted validation after the final doctest edit:

- `cargo fmt --manifest-path core\Cargo.toml --check`
- `cargo test --manifest-path core\Cargo.toml timeline --quiet` -> 33 passed
- `cargo test --manifest-path core\Cargo.toml --doc --quiet` -> 17 passed
- `cargo clippy --manifest-path core\Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path core\Cargo.toml --no-deps --lib`

Pre-push hook also passed:

- Rust format
- Rust clippy
- Rust tests -> 184 passed, 2 ignored; bin tests -> 110 passed
- doc tests -> 17 passed
- version consistency -> 8.3.0
- bundled SQLite version check -> SQLite 3.53.1
- cargo audit for core/bin/ffi locks
- Python SDK smoke
- header policy scanner + missing-baseline negative test
- JS syntax
- whitespace check

## Review Ledger

Fresh final blind review cleared P0-P3:

- Linnaeus / Popper: result/proof contract and plan drift CLEAN
- Euclid / Mencius-Noether: type-seal invariants CLEAN
- Popper / Poincare-Dirac: minimality and file budget CLEAN
- Pascal / Socrates-QA: AGENTS/process CLEAN

Earlier review findings were fixed before this commit:

- constructor visibility reduced from crate-wide to module-private
- body-hash mismatch no longer exposes a full `TimelineAddress`
- non-body / missing-row accessors use `requested()` rather than implying the body hash is proven
- `AddressMismatch` renamed to `BodyHashMismatch`
- compile-fail doctests split so one failing proof type cannot mask another
- new module staged and committed