### PR TITLE
core: split audit header helpers

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -9,15 +9,18 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     engine_types::{AuditHmacKey, ValidatedWorldPath},
-    timeline::{TimelineAddress, TimelineSeq},
+    timeline::TimelineSeq,
     world,
     world_generation::WorldGeneration,
 };
 use std::{collections::HashSet, fmt, path::Path};
 
 mod append;
+mod headers;
 mod live_body;
 mod retention;
+#[cfg(test)]
+mod test_support;
 mod timeline_address;
 
 #[cfg(test)]
@@ -26,6 +29,14 @@ pub(crate) use append::{
     append_retained_body_tx_row, append_with_conn_existing, append_with_conn_genesis,
     AppendedBodyEvent,
 };
+pub(crate) use headers::{AuditHeaders, VerifiedDeleteSubject};
+#[cfg(test)]
+pub(crate) use headers::{
+    DELETE_SUBJECT_BODY_SHA256, DELETE_SUBJECT_GENERATION, DELETE_SUBJECT_HMAC, DELETE_SUBJECT_SEQ,
+    DELETE_SUBJECT_WORLD,
+};
+#[cfg(test)]
+pub use test_support::latest_hmac;
 pub(crate) use timeline_address::read_timeline_body_via_conn;
 pub(crate) use timeline_address::{
     verified_latest_body_head_via_conn, VerifiedBodyEvent, VerifiedBodyHead,
@@ -38,12 +49,6 @@ const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256
            LEFT JOIN event_headers h ON h.event_id=e.id
            ORDER BY e.id ASC, h.name ASC, h.value ASC"#;
 pub(crate) const AUDIT_CHAIN_BROKEN_PREFIX: &str = "audit chain broken at event ";
-pub(crate) const DELETE_SUBJECT_WORLD: &str = "auditedb-delete-subject-world";
-pub(crate) const DELETE_SUBJECT_GENERATION: &str = "auditedb-delete-subject-generation";
-pub(crate) const DELETE_SUBJECT_SEQ: &str = "auditedb-delete-subject-seq";
-pub(crate) const DELETE_SUBJECT_BODY_SHA256: &str = "auditedb-delete-subject-body-sha256";
-pub(crate) const DELETE_SUBJECT_HMAC: &str = "auditedb-delete-subject-hmac";
-const DELETE_SUBJECT_RESERVED_PREFIX: &str = "auditedb-delete-subject-";
 
 pub struct VerifiedAuditTx<'tx, 'conn, 'key> {
     tx: &'tx Transaction<'conn>,
@@ -77,97 +82,6 @@ impl From<rusqlite::Error> for AuditError {
     fn from(value: rusqlite::Error) -> Self {
         Self::Storage(value)
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ReservedAuditHeader;
-
-#[derive(Clone)]
-pub(crate) struct VerifiedDeleteSubject {
-    address: TimelineAddress,
-    hmac: String,
-}
-
-impl VerifiedDeleteSubject {
-    pub(crate) fn from_body_head(head: VerifiedBodyHead) -> Self {
-        Self {
-            address: head.address().clone(),
-            hmac: head.hmac().to_owned(),
-        }
-    }
-
-    fn headers(&self) -> [(String, String); 5] {
-        [
-            (
-                DELETE_SUBJECT_WORLD.to_owned(),
-                self.address.world().as_str().to_owned(),
-            ),
-            (
-                DELETE_SUBJECT_GENERATION.to_owned(),
-                self.address.generation().as_str().to_owned(),
-            ),
-            (
-                DELETE_SUBJECT_SEQ.to_owned(),
-                self.address.seq().get().to_string(),
-            ),
-            (
-                DELETE_SUBJECT_BODY_SHA256.to_owned(),
-                self.address.body_sha256().as_str().to_owned(),
-            ),
-            (DELETE_SUBJECT_HMAC.to_owned(), self.hmac.clone()),
-        ]
-    }
-
-    pub(crate) fn body_sha256(&self) -> crate::timeline::BodySha256 {
-        self.address.body_sha256().clone()
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct AuditHeaders {
-    user: Vec<(String, String)>,
-    delete_subject: Option<VerifiedDeleteSubject>,
-}
-
-impl AuditHeaders {
-    #[cfg(test)]
-    pub(crate) fn empty() -> Self {
-        Self {
-            user: Vec::new(),
-            delete_subject: None,
-        }
-    }
-
-    pub(crate) fn from_user(headers: Vec<(String, String)>) -> Result<Self, ReservedAuditHeader> {
-        if headers
-            .iter()
-            .any(|(name, _)| is_reserved_audit_header(name))
-        {
-            return Err(ReservedAuditHeader);
-        }
-        Ok(Self {
-            user: headers,
-            delete_subject: None,
-        })
-    }
-
-    pub(crate) fn with_delete_subject(mut self, subject: VerifiedDeleteSubject) -> Self {
-        self.delete_subject = Some(subject);
-        self
-    }
-
-    fn to_storage_pairs(&self) -> Vec<(String, String)> {
-        let mut pairs = self.user.clone();
-        if let Some(subject) = &self.delete_subject {
-            pairs.extend(subject.headers());
-        }
-        pairs
-    }
-}
-
-fn is_reserved_audit_header(name: &str) -> bool {
-    name.to_ascii_lowercase()
-        .starts_with(DELETE_SUBJECT_RESERVED_PREFIX)
 }
 
 #[derive(Clone, Copy)]
@@ -576,21 +490,6 @@ fn canonical_headers(headers: &[(String, String)]) -> Vec<(String, String)> {
         .collect();
     out.sort();
     out
-}
-
-#[cfg(test)]
-pub fn latest_hmac(data_root: &Path, world_name: &str) -> Option<String> {
-    let path = world::world_db(data_root, world_name);
-    if !path.exists() {
-        return None;
-    }
-    let c = rusqlite::Connection::open(path).ok()?;
-    c.query_row(
-        "SELECT hmac FROM events ORDER BY id DESC LIMIT 1",
-        [],
-        |r| r.get::<_, String>(0),
-    )
-    .ok()
 }
 
 #[cfg(test)]

--- a/core/src/audit/headers.rs
+++ b/core/src/audit/headers.rs
@@ -1,0 +1,101 @@
+use crate::timeline::{BodySha256, TimelineAddress};
+
+use super::VerifiedBodyHead;
+
+pub(crate) const DELETE_SUBJECT_WORLD: &str = "auditedb-delete-subject-world";
+pub(crate) const DELETE_SUBJECT_GENERATION: &str = "auditedb-delete-subject-generation";
+pub(crate) const DELETE_SUBJECT_SEQ: &str = "auditedb-delete-subject-seq";
+pub(crate) const DELETE_SUBJECT_BODY_SHA256: &str = "auditedb-delete-subject-body-sha256";
+pub(crate) const DELETE_SUBJECT_HMAC: &str = "auditedb-delete-subject-hmac";
+const DELETE_SUBJECT_RESERVED_PREFIX: &str = "auditedb-delete-subject-";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ReservedAuditHeader;
+
+#[derive(Clone)]
+pub(crate) struct VerifiedDeleteSubject {
+    address: TimelineAddress,
+    hmac: String,
+}
+
+impl VerifiedDeleteSubject {
+    pub(crate) fn from_body_head(head: VerifiedBodyHead) -> Self {
+        Self {
+            address: head.address().clone(),
+            hmac: head.hmac().to_owned(),
+        }
+    }
+
+    fn headers(&self) -> [(String, String); 5] {
+        [
+            (
+                DELETE_SUBJECT_WORLD.to_owned(),
+                self.address.world().as_str().to_owned(),
+            ),
+            (
+                DELETE_SUBJECT_GENERATION.to_owned(),
+                self.address.generation().as_str().to_owned(),
+            ),
+            (
+                DELETE_SUBJECT_SEQ.to_owned(),
+                self.address.seq().get().to_string(),
+            ),
+            (
+                DELETE_SUBJECT_BODY_SHA256.to_owned(),
+                self.address.body_sha256().as_str().to_owned(),
+            ),
+            (DELETE_SUBJECT_HMAC.to_owned(), self.hmac.clone()),
+        ]
+    }
+
+    pub(crate) fn body_sha256(&self) -> BodySha256 {
+        self.address.body_sha256().clone()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AuditHeaders {
+    user: Vec<(String, String)>,
+    delete_subject: Option<VerifiedDeleteSubject>,
+}
+
+impl AuditHeaders {
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self {
+            user: Vec::new(),
+            delete_subject: None,
+        }
+    }
+
+    pub(crate) fn from_user(headers: Vec<(String, String)>) -> Result<Self, ReservedAuditHeader> {
+        if headers
+            .iter()
+            .any(|(name, _)| is_reserved_audit_header(name))
+        {
+            return Err(ReservedAuditHeader);
+        }
+        Ok(Self {
+            user: headers,
+            delete_subject: None,
+        })
+    }
+
+    pub(crate) fn with_delete_subject(mut self, subject: VerifiedDeleteSubject) -> Self {
+        self.delete_subject = Some(subject);
+        self
+    }
+
+    pub(super) fn to_storage_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs = self.user.clone();
+        if let Some(subject) = &self.delete_subject {
+            pairs.extend(subject.headers());
+        }
+        pairs
+    }
+}
+
+fn is_reserved_audit_header(name: &str) -> bool {
+    name.to_ascii_lowercase()
+        .starts_with(DELETE_SUBJECT_RESERVED_PREFIX)
+}

--- a/core/src/audit/test_support.rs
+++ b/core/src/audit/test_support.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+use crate::world;
+
+pub fn latest_hmac(data_root: &Path, world_name: &str) -> Option<String> {
+    let path = world::world_db(data_root, world_name);
+    if !path.exists() {
+        return None;
+    }
+    let c = rusqlite::Connection::open(path).ok()?;
+    c.query_row(
+        "SELECT hmac FROM events ORDER BY id DESC LIMIT 1",
+        [],
+        |r| r.get::<_, String>(0),
+    )
+    .ok()
+}


### PR DESCRIPTION
## Summary

- Mechanical split: move audit header/delete-subject helpers from `core/src/audit.rs` into `core/src/audit/headers.rs`.
- Move the test-only `latest_hmac` helper into `core/src/audit/test_support.rs` behind `#[cfg(test)]`.
- Keep the existing crate-private audit surface intact: `AuditHeaders`, `VerifiedDeleteSubject`, and test-only delete-subject constants remain reachable through `crate::audit` where existing tests expect them.

## Scope

Base / prior layer: #348, `stack/22r32-timeline-deref-result-type` at `7aa514f`.

Plan section: preparatory refactor only. This PR does not implement `PLAN-http-timeline-dereference.md` section 7 item 2. It makes room under the audit boundary before the resolver layer.

This is a mechanical split, not a semantic change. It does not change HMAC computation, audit verification, delete-subject metadata, reserved-header rejection, storage-pair ordering, HTTP behavior, or timeline dereference behavior.

## Budget

- `core/src/audit.rs`: production count reduced to 476 by QA count.
- `core/src/audit/headers.rs`: 94 production lines by QA count.
- `core/src/audit/test_support.rs`: test-only module, production count 0.
- Raw staged diff: 3 files, 130 insertions, 113 deletions, 243 changed lines.

## Validation

Local:

- `cargo fmt --manifest-path core\Cargo.toml --check`
- `cargo check --manifest-path core\Cargo.toml --no-default-features` (passed with two unrelated existing warnings in `engine_error.rs` and `auth.rs`)
- `cargo clippy --manifest-path core\Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path core\Cargo.toml --quiet` (184 passed, 2 ignored; doctests 17 passed)
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path core\Cargo.toml --no-deps --lib`
- `git diff --cached --check`
- `git diff --check`

Pre-push hook:

- Rust format
- Rust clippy
- Rust tests: core 184 passed, 2 ignored; doctests 17 passed; bin 110 passed
- Version consistency: 8.3.0
- Bundled SQLite version check: SQLite 3.53.1
- `cargo audit` for core/bin/ffi locks
- Python SDK smoke
- Header policy scanner and missing-baseline negative test
- JS syntax
- Whitespace check

## Review Ledger

Fresh staged-diff review round:

- Planck the 4th / Poincare-Dirac: CLEAN. Confirmed topology/minimality, test-only helper move, and no widened constant surface.
- Boyle the 4th / Mencius-Noether: CLEAN. Confirmed constructor visibility, `VerifiedDeleteSubject` proof semantics, reserved header rejection, and storage-pair ordering.
- Archimedes the 4th / Heisenberg-Sagan: CLEAN. Confirmed the change can truthfully be described as a mechanical split with no runtime semantic change.
- Turing the 4th / Socrates QA: code/process clean for staging, file budget, and diff budget. Noted PR-body evidence and mechanical-split declaration were pending; this PR body supplies them.

## Stack Note

The user explicitly signed off on infinite stacking for this CAS/timeline work. This layer exists because QA correctly rejected adding more production lines to over-budget `audit.rs`.
