### PR TITLE
core: add timeline coordinate resolver

### DIFF
--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -1,7 +1,4 @@
-//! HMAC event chain. One row per write, hash includes prev_hmac so
-//! tampering with any row breaks every row after it. The chain is a
-//! core storage invariant, independent of which SDK or bridge produced
-//! the write.
+//! HMAC event chain: one row per write, linked by `prev_hmac`.
 
 use hmac::{Hmac, KeyInit, Mac};
 use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
@@ -22,7 +19,7 @@ mod retention;
 #[cfg(test)]
 mod test_support;
 mod timeline_address;
-mod timeline_dereference;
+pub(crate) mod timeline_dereference;
 
 #[cfg(test)]
 use append::test_only_append_tx_inner as append_tx_inner;

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -8,14 +8,21 @@ use crate::{
     event::AuditEventKind,
     read_cache::TrackedReadConnection,
     timeline::{
-        BodySha256, TimelineAddress, TimelineAddressLookup, TimelineCorruption, TimelineRead,
-        TimelineSeq,
+        BodySha256, TimelineAddress, TimelineAddressLookup, TimelineCoordinate, TimelineCorruption,
+        TimelineRead, TimelineSeq,
     },
     world_generation::WorldGeneration,
     world_schema,
 };
 
 pub(crate) struct VerifiedBodyEvent {
+    world: ValidatedWorldPath,
+    gen: WorldGeneration,
+    seq: TimelineSeq,
+    body_sha256: BodySha256,
+}
+
+pub(super) struct VerifiedCoordinateBodyEvent {
     world: ValidatedWorldPath,
     gen: WorldGeneration,
     seq: TimelineSeq,
@@ -52,6 +59,35 @@ impl VerifiedBodyEvent {
     pub(crate) fn body_sha256(&self) -> &BodySha256 {
         &self.body_sha256
     }
+}
+
+impl VerifiedCoordinateBodyEvent {
+    pub(super) fn new(
+        coordinate: &TimelineCoordinate,
+        gen: WorldGeneration,
+        body_sha256: BodySha256,
+    ) -> Option<Self> {
+        if coordinate.generation() != &gen || coordinate.body_sha256() != &body_sha256 {
+            return None;
+        }
+        Some(Self {
+            world: coordinate.world().clone(),
+            gen,
+            seq: coordinate.seq(),
+            body_sha256,
+        })
+    }
+}
+
+pub(super) fn timeline_address_from_verified_coordinate_body_event(
+    event: VerifiedCoordinateBodyEvent,
+) -> TimelineAddress {
+    TimelineAddress::from_verified_body_event(VerifiedBodyEvent::new(
+        event.world,
+        event.gen,
+        event.seq,
+        event.body_sha256,
+    ))
 }
 
 pub(crate) struct VerifiedBodyHead {

--- a/core/src/audit/timeline_dereference.rs
+++ b/core/src/audit/timeline_dereference.rs
@@ -6,8 +6,178 @@
 
 #![cfg_attr(not(test), allow(dead_code))]
 
-use crate::timeline::{BodySha256, TimelineBody, TimelineCoordinate, TimelineCorruption};
-use crate::world_generation::WorldGeneration;
+use bytes::Bytes;
+use rusqlite::{params, OptionalExtension};
+
+use crate::{
+    engine_types::{AuditHmacKey, Representation},
+    event::AuditEventKind,
+    read_cache::TrackedReadConnection,
+    timeline::{
+        BodySha256, TimelineBody, TimelineCoordinate, TimelineCorruption, TimelineRead, TimelineSeq,
+    },
+    world_generation::WorldGeneration,
+    world_schema,
+};
+
+struct TimelineEventSnapshot {
+    event_type: String,
+    target: String,
+    body_sha256: String,
+    size: i64,
+    content_type: String,
+    headers: Vec<(String, String)>,
+}
+
+pub(crate) fn dereference_timeline_coordinate_via_conn(
+    tracked: &mut TrackedReadConnection,
+    coordinate: &TimelineCoordinate,
+    key: &AuditHmacKey,
+) -> super::AuditResult<TimelineDereference> {
+    let conn = tracked.as_mut_conn();
+    let tx = conn.transaction()?;
+    let actual_gen = world_schema::generation(&tx)?;
+    super::require_intact(super::verify_world_connection(
+        &tx,
+        coordinate.world(),
+        key,
+    )?)?;
+
+    let result = if &actual_gen != coordinate.generation() {
+        match VerifiedGenerationMismatch::new(coordinate.clone(), actual_gen) {
+            Some(proof) => TimelineDereference::GenMismatch(proof),
+            None => corrupt(coordinate, TimelineCorruption::InvalidEventShape),
+        }
+    } else {
+        match load_event_snapshot(&tx, coordinate.seq())? {
+            Some(row) => dereference_snapshot(&tx, coordinate, row, actual_gen)?,
+            None => TimelineDereference::MissingRow(VerifiedMissingRow::new(coordinate.clone())),
+        }
+    };
+    tx.commit()?;
+    Ok(result)
+}
+
+fn load_event_snapshot(
+    tx: &rusqlite::Transaction<'_>,
+    seq: TimelineSeq,
+) -> rusqlite::Result<Option<TimelineEventSnapshot>> {
+    let Some((event_type, target, body_sha256, size, content_type)) = tx
+        .query_row(
+            "SELECT event_type, target, body_sha256, size, content_type FROM events WHERE id=?1",
+            params![seq.get()],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                    r.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()?
+    else {
+        return Ok(None);
+    };
+
+    let mut headers = Vec::new();
+    {
+        let mut stmt = tx.prepare(
+            "SELECT name, value FROM event_headers WHERE event_id=?1 ORDER BY name, value",
+        )?;
+        let rows = stmt.query_map(params![seq.get()], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })?;
+        for pair in rows {
+            headers.push(pair?);
+        }
+    }
+
+    Ok(Some(TimelineEventSnapshot {
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+    }))
+}
+
+fn dereference_snapshot(
+    tx: &rusqlite::Transaction<'_>,
+    coordinate: &TimelineCoordinate,
+    row: TimelineEventSnapshot,
+    gen: WorldGeneration,
+) -> rusqlite::Result<TimelineDereference> {
+    let Some(kind) = AuditEventKind::from_storage(&row.event_type) else {
+        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
+    };
+    if row.target != coordinate.world().as_str() {
+        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
+    }
+    if !kind.class().body_bearing {
+        return Ok(TimelineDereference::NonBodyEvent(
+            VerifiedNonBodyEvent::new(coordinate.clone()),
+        ));
+    }
+    let Ok(body_sha256) = BodySha256::new(row.body_sha256) else {
+        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
+    };
+    if &body_sha256 != coordinate.body_sha256() {
+        return Ok(
+            match VerifiedBodyHashMismatch::new(coordinate.clone(), body_sha256) {
+                Some(proof) => TimelineDereference::BodyHashMismatch(proof),
+                None => corrupt(coordinate, TimelineCorruption::InvalidEventShape),
+            },
+        );
+    }
+
+    let Some(body) = tx
+        .query_row(
+            "SELECT body FROM cas_bodies WHERE body_sha256=?1",
+            params![coordinate.body_sha256().as_str()],
+            |r| r.get::<_, Vec<u8>>(0),
+        )
+        .optional()?
+    else {
+        return Ok(corrupt(
+            coordinate,
+            TimelineCorruption::MissingBodyForPresentRow,
+        ));
+    };
+    if i64::try_from(body.len()).ok() != Some(row.size) {
+        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
+    }
+
+    let Some(event) =
+        super::timeline_address::VerifiedCoordinateBodyEvent::new(coordinate, gen, body_sha256)
+    else {
+        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
+    };
+    let address =
+        super::timeline_address::timeline_address_from_verified_coordinate_body_event(event);
+    match TimelineRead::body(
+        address,
+        Representation::new(Bytes::from(body), row.content_type, row.headers),
+    ) {
+        TimelineRead::Body(body) => Ok(TimelineDereference::Body(body)),
+        TimelineRead::Corrupt { reason, .. } => Ok(corrupt(coordinate, reason)),
+        TimelineRead::Expired { .. }
+        | TimelineRead::Gone { .. }
+        | TimelineRead::GenMismatch { .. }
+        | TimelineRead::MissingRow { .. } => {
+            Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape))
+        }
+    }
+}
+
+fn corrupt(coordinate: &TimelineCoordinate, reason: TimelineCorruption) -> TimelineDereference {
+    TimelineDereference::Corrupt {
+        coordinate: coordinate.clone(),
+        reason,
+    }
+}
 
 /// Verified generation mismatch for coordinate-based timeline dereference.
 ///
@@ -248,6 +418,16 @@ impl VerifiedMissingRow {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        engine::Engine,
+        engine_types::{AccessTier, Preconditions, Representation, ValidatedWorldPath},
+    };
+    use bytes::Bytes;
+    use rusqlite::Connection;
+    use std::{
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     fn coordinate_with_hash(seq: i64, hash: &str) -> TimelineCoordinate {
         TimelineCoordinate::from_wire_parts(
@@ -268,6 +448,121 @@ mod tests {
 
     fn other_body_hash() -> BodySha256 {
         BodySha256::new("fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210").unwrap()
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "elastik-audit-timeline-deref-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        root
+    }
+
+    fn key() -> AuditHmacKey {
+        AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
+    fn coordinate_for_event(
+        engine: &Engine,
+        world: &ValidatedWorldPath,
+        id: i64,
+    ) -> TimelineCoordinate {
+        let conn =
+            Connection::open(crate::world::world_db(&engine.core().data, world.as_str())).unwrap();
+        let generation = world_schema::generation(&conn).unwrap();
+        let body_sha256: String = conn
+            .query_row("SELECT body_sha256 FROM events WHERE id=?1", [id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        TimelineCoordinate::from_wire_parts(world.as_str(), generation.as_str(), id, body_sha256)
+            .unwrap()
+    }
+
+    fn dereference(engine: &Engine, coordinate: &TimelineCoordinate) -> TimelineDereference {
+        let conn = Connection::open(crate::world::world_db(
+            &engine.core().data,
+            coordinate.world().as_str(),
+        ))
+        .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+        dereference_timeline_coordinate_via_conn(&mut tracked, coordinate, &engine.core().hmac_key)
+            .unwrap()
+    }
+
+    fn single_metadata_event_conn(
+        event_type: &str,
+        target: &str,
+        key: &AuditHmacKey,
+    ) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE stage_meta(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                generation TEXT NOT NULL,
+                body BLOB DEFAULT x'',
+                content_type TEXT DEFAULT 'application/octet-stream'
+            );
+            INSERT INTO stage_meta(id, generation, body)
+                VALUES(1, '0123456789abcdef0123456789abcdef', x'');
+            CREATE TABLE events(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                target TEXT NOT NULL,
+                body_sha256 TEXT NOT NULL,
+                size INTEGER NOT NULL,
+                content_type TEXT NOT NULL,
+                meta_sha256 TEXT NOT NULL,
+                hmac TEXT NOT NULL,
+                prev_hmac TEXT NOT NULL
+            );
+            CREATE TABLE event_headers(
+                event_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY,
+                body BLOB NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE cas_state(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                first_retained_seq INTEGER
+            );
+            INSERT INTO cas_state(id, first_retained_seq) VALUES(1, NULL);
+            "#,
+        )
+        .unwrap();
+        let generation = world_schema::generation(&conn).unwrap();
+        let meta_sha256 = super::super::meta_sha256_canonical("", &[]);
+        let hmac = super::super::event_hmac(
+            key,
+            super::super::EventHmacInput {
+                prev: "",
+                event_type,
+                target,
+                generation: &generation,
+                body_sha256: "",
+                size: 0,
+                content_type: "",
+                meta_sha256: &meta_sha256,
+            },
+        );
+        conn.execute(
+            r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
+                                  content_type, meta_sha256, hmac, prev_hmac)
+               VALUES(datetime('now'), ?1, ?2, '', 0, '', ?3, ?4, '')"#,
+            rusqlite::params![event_type, target, meta_sha256, hmac],
+        )
+        .unwrap();
+        conn
     }
 
     #[test]
@@ -331,5 +626,146 @@ mod tests {
             VerifiedBodyHashMismatch::new(requested.clone(), requested.body_sha256().clone())
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn coordinate_resolver_returns_historical_body() {
+        let root = temp_root("body");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/timeline-body").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"old"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"new"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let coordinate = coordinate_for_event(&engine, &world, 1);
+        match dereference(&engine, &coordinate) {
+            TimelineDereference::Body(body) => {
+                assert_eq!(body.address().world(), &world);
+                assert_eq!(body.address().seq().get(), 1);
+                assert_eq!(body.representation().body.as_ref(), b"old");
+            }
+            _ => panic!("expected body"),
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn coordinate_resolver_returns_body_hash_mismatch_and_missing_row() {
+        let root = temp_root("negative");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/timeline-negative").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let coordinate = coordinate_for_event(&engine, &world, 1);
+        let wrong_hash = other_body_hash();
+        let mismatch = TimelineCoordinate::from_wire_parts(
+            world.as_str(),
+            coordinate.generation().as_str(),
+            1,
+            wrong_hash.as_str(),
+        )
+        .unwrap();
+        match dereference(&engine, &mismatch) {
+            TimelineDereference::BodyHashMismatch(proof) => {
+                assert_eq!(proof.requested(), &mismatch);
+                assert_eq!(proof.actual_body_sha256(), coordinate.body_sha256());
+            }
+            _ => panic!("expected hash mismatch"),
+        }
+
+        let missing = TimelineCoordinate::from_wire_parts(
+            world.as_str(),
+            coordinate.generation().as_str(),
+            99,
+            coordinate.body_sha256().as_str(),
+        )
+        .unwrap();
+        match dereference(&engine, &missing) {
+            TimelineDereference::MissingRow(proof) => assert_eq!(proof.requested(), &missing),
+            _ => panic!("expected missing row"),
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn coordinate_resolver_returns_non_body_event_after_chain_verification() {
+        let key = key();
+        let world = ValidatedWorldPath::new("home/timeline-metadata").unwrap();
+        let conn = single_metadata_event_conn("delete_intent", world.as_str(), &key);
+        let coordinate = TimelineCoordinate::from_wire_parts(
+            world.as_str(),
+            "0123456789abcdef0123456789abcdef",
+            1,
+            other_body_hash().as_str(),
+        )
+        .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        match dereference_timeline_coordinate_via_conn(&mut tracked, &coordinate, &key).unwrap() {
+            TimelineDereference::NonBodyEvent(proof) => {
+                assert_eq!(proof.requested(), &coordinate)
+            }
+            _ => panic!("expected non-body event"),
+        }
+    }
+
+    #[test]
+    fn coordinate_resolver_rejects_wrong_target_non_body_event() {
+        let key = key();
+        let world = ValidatedWorldPath::new("home/timeline-metadata-target").unwrap();
+        let conn = single_metadata_event_conn("delete_intent", "home/other", &key);
+        let coordinate = TimelineCoordinate::from_wire_parts(
+            world.as_str(),
+            "0123456789abcdef0123456789abcdef",
+            1,
+            other_body_hash().as_str(),
+        )
+        .unwrap();
+        let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
+
+        match dereference_timeline_coordinate_via_conn(&mut tracked, &coordinate, &key).unwrap() {
+            TimelineDereference::Corrupt {
+                coordinate: got,
+                reason: TimelineCorruption::InvalidEventShape,
+            } => assert_eq!(got, coordinate),
+            _ => panic!("wrong-target metadata event must be corrupt"),
+        }
     }
 }

--- a/core/src/audit/timeline_dereference.rs
+++ b/core/src/audit/timeline_dereference.rs
@@ -37,11 +37,7 @@ pub(crate) fn dereference_timeline_coordinate_via_conn(
     let conn = tracked.as_mut_conn();
     let tx = conn.transaction()?;
     let actual_gen = world_schema::generation(&tx)?;
-    super::require_intact(super::verify_world_connection(
-        &tx,
-        coordinate.world(),
-        key,
-    )?)?;
+    super::require_intact(super::verify_world_tx(&tx, coordinate.world(), key)?)?;
 
     let result = if &actual_gen != coordinate.generation() {
         match VerifiedGenerationMismatch::new(coordinate.clone(), actual_gen) {

--- a/core/src/read_cache/ops.rs
+++ b/core/src/read_cache/ops.rs
@@ -4,6 +4,9 @@ use super::ReadCache;
 
 #[cfg_attr(not(test), allow(dead_code))]
 type TimelineReadResult = crate::audit::AuditResult<crate::timeline::TimelineRead>;
+#[cfg_attr(not(test), allow(dead_code))]
+type TimelineDereferenceResult =
+    crate::audit::AuditResult<crate::audit::timeline_dereference::TimelineDereference>;
 
 impl ReadCache {
     /// Read body + meta + latest hmac via the cached read path.
@@ -63,6 +66,32 @@ impl ReadCache {
             Ok(crate::audit::read_timeline_body_via_conn(
                 conn, address, &key,
             ))
+        })
+    }
+
+    /// Coordinate dereference through the cached read path. The resolver runs
+    /// inside one tracked read transaction so audit verification, row proof,
+    /// and retained-CAS lookup share one SQLite snapshot.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn cached_dereference_timeline_coordinate(
+        &self,
+        data: &std::path::Path,
+        // Deliberately require the read permit here so cache helpers cannot
+        // turn raw coordinate syntax into a proof outside the read gate.
+        permit: &crate::world_read_ops::ReadPermit,
+        coordinate: &crate::timeline::TimelineCoordinate,
+        key: &crate::engine_types::AuditHmacKey,
+    ) -> rusqlite::Result<Option<TimelineDereferenceResult>> {
+        if permit.world() != coordinate.world() {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        let key = key.clone_secret();
+        self.with_tracked_conn(data, coordinate.world().as_str(), move |conn| {
+            Ok(
+                crate::audit::timeline_dereference::dereference_timeline_coordinate_via_conn(
+                    conn, coordinate, &key,
+                ),
+            )
         })
     }
 

--- a/core/src/world_read_ops.rs
+++ b/core/src/world_read_ops.rs
@@ -8,13 +8,19 @@
 use crate::{
     audit, auth, can_read,
     engine_types::ValidatedWorldPath,
-    timeline::{TimelineAddress, TimelineRead},
+    timeline::{TimelineAddress, TimelineCoordinate, TimelineRead},
     world, AuthGate, Core, StorageFailureClass,
 };
 
 #[derive(Debug)]
 pub(crate) struct ReadPermit {
     world: ValidatedWorldPath,
+}
+
+impl ReadPermit {
+    pub(crate) fn world(&self) -> &ValidatedWorldPath {
+        &self.world
+    }
 }
 
 pub(crate) enum ReadOutcome {
@@ -83,6 +89,32 @@ pub(crate) fn read_timeline_body(
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn dereference_timeline_coordinate(
+    core: &Core,
+    permit: &ReadPermit,
+    coordinate: &TimelineCoordinate,
+) -> Result<audit::timeline_dereference::TimelineDereference, ReadError> {
+    if permit.world != *coordinate.world() {
+        return Err(ReadError::PermitWorldMismatch);
+    }
+    let read = core
+        .read_cache
+        .cached_dereference_timeline_coordinate(&core.data, permit, coordinate, &core.hmac_key)
+        .map_err(audit::AuditError::from)
+        .map_err(|err| classify_read_audit_error("timeline dereference", err))?;
+    match read {
+        Some(result) => {
+            result.map_err(|err| classify_read_audit_error("timeline dereference", err))
+        }
+        None => Ok(
+            audit::timeline_dereference::TimelineDereference::UnprovenCoordinate(
+                coordinate.clone(),
+            ),
+        ),
+    }
+}
+
 pub(crate) fn read_world_for(
     core: &Core,
     permit: &ReadPermit,
@@ -122,7 +154,7 @@ mod tests {
     use crate::{
         engine_types::AuditHmacKey,
         test_support::test_core,
-        timeline::{BodySha256, TimelineAddress, TimelineSeq},
+        timeline::{BodySha256, TimelineAddress, TimelineCoordinate, TimelineSeq},
         world,
         world_generation::WorldGeneration,
     };
@@ -140,6 +172,16 @@ mod tests {
         )
     }
 
+    fn timeline_coordinate(world: &str) -> TimelineCoordinate {
+        TimelineCoordinate::from_wire_parts(
+            world,
+            "0123456789abcdef0123456789abcdef",
+            1,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap()
+    }
+
     #[test]
     fn timeline_read_permit_is_bound_to_address_world() {
         let (core, dir) = test_core("timeline-permit-bound");
@@ -151,6 +193,39 @@ mod tests {
             read_timeline_body(&core, &permit, &address),
             Err(ReadError::PermitWorldMismatch)
         ));
+
+        drop(core);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn timeline_dereference_permit_is_bound_to_coordinate_world() {
+        let (core, dir) = test_core("timeline-coordinate-permit-bound");
+        let permit_world = world_path("home/right");
+        let permit = authorize_read(&core, &permit_world, auth::Tier::Read).unwrap();
+        let coordinate = timeline_coordinate("home/wrong");
+
+        assert!(matches!(
+            dereference_timeline_coordinate(&core, &permit, &coordinate),
+            Err(ReadError::PermitWorldMismatch)
+        ));
+
+        drop(core);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn timeline_dereference_missing_world_is_unproven_coordinate() {
+        let (core, dir) = test_core("timeline-coordinate-missing-world");
+        let coordinate = timeline_coordinate("home/missing");
+        let permit = authorize_read(&core, coordinate.world(), auth::Tier::Read).unwrap();
+
+        match dereference_timeline_coordinate(&core, &permit, &coordinate).unwrap() {
+            audit::timeline_dereference::TimelineDereference::UnprovenCoordinate(got) => {
+                assert_eq!(got, coordinate)
+            }
+            _ => panic!("missing subject DB must not prove a timeline state"),
+        }
 
         drop(core);
         let _ = std::fs::remove_dir_all(dir);


### PR DESCRIPTION
## Summary
- add an internal timeline-coordinate resolver that verifies the subject world's audit chain before returning a historical body or proof-bearing negative result
- route coordinate dereference through the read-cache tracked connection so audit verification, row lookup, and retained-CAS lookup share one SQLite snapshot
- require `ReadPermit` at both `world_read_ops` and the read-cache helper so raw `TimelineCoordinate` syntax cannot bypass the read gate

## Stack
- Base: #351 / `stack/22r35-read-cache-ops-split` @ `500bf29`
- Commit: `783c01e` (`core: add timeline coordinate resolver`)
- Plan: CAS/write-retention plan section 4, internal resolver layer only

## Scope
- No HTTP adapter changes
- No public `Engine` method
- No SDK/bin/README changes
- This PR only adds the core/internal resolver and tests

## Important semantics
- A raw `TimelineCoordinate` is wire syntax, not proof. It becomes proof-bearing only after `verify_world_connection` + `require_intact` inside one read transaction.
- Wrong-target events are `Corrupt(InvalidEventShape)`, including non-body events. They do not mint `NonBodyEvent` proofs for another world.
- Missing subject DB maps to `UnprovenCoordinate`, because there is no bounded proof source for that coordinate.
- Normal missing retained-CAS corruption is caught by audit verification before dereference and surfaces as audit chain failure. The resolver's `MissingBodyForPresentRow` branch is defensive, not the ordinary missing-CAS path.

## Diff budget
- GitHub raw diff: `+584/-11`, dominated by proof docs, compile-fail doctests, and unit tests.
- Production-only diff: `+274/-10` (`284` lines), under the AGENTS budget; tests/doctests excluded by the local budget rule.

## Validation
- `cargo fmt --manifest-path core\Cargo.toml -- --check`
- `cargo check --manifest-path core\Cargo.toml`
- `cargo test --manifest-path core\Cargo.toml timeline_dereference --quiet` (`8 passed`)
- `cargo test --manifest-path core\Cargo.toml world_read_ops --quiet` (`4 passed`)
- `cargo clippy --manifest-path core\Cargo.toml --all-targets -- -D warnings`
- `cargo check --manifest-path core\Cargo.toml --no-default-features` (passed with 2 existing warnings)
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path core\Cargo.toml --no-deps --lib`
- `git diff --check`
- `scripts\pre-push.ps1` (core `190 passed / 2 ignored`, doctests `17 passed`, bin `110 passed`, supply-chain/header/SDK smoke passed)

## Review ledger
- Bacon/Mencius found two P1s in the first pass: wrong-target non-body proof and a Core bypass without `ReadPermit`. Both were fixed before commit.
- Anscombe independently confirmed the wrong-target P1 and the missing-retained-CAS wording caveat.
- Locke QA caught the transient compile failure and production `expect`/`unreachable!` debt; fixed by mapping impossible states to typed corruption instead of panicking.
- Feynman seal review after fixes: P0/P1/P2 none; P3 comment added to keep the read-cache `ReadPermit` dependency deliberate.
- Halley QA after fixes: P0/P1/P2 none; P3 PR body wording items captured above.