### PR TITLE
bin: split pipeline context support

### DIFF
--- a/bin/src/server/pipeline.rs
+++ b/bin/src/server/pipeline.rs
@@ -39,12 +39,14 @@
 //! `/listen/*` and `/proc/*` keep dedicated handlers because their wire
 //! shapes are SSE streams and generated introspection responses.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
+mod context;
+#[cfg(test)]
+use context::trace_enabled_for_tests;
+pub(crate) use context::{init_trace_from_env, RequestId, TraceCtx};
 
 use axum::{
     body::Bytes,
-    http::{HeaderMap, Method, StatusCode},
+    http::{HeaderMap, Method},
     response::Response,
 };
 
@@ -53,17 +55,6 @@ use crate::{
     server::{bad_request, method_not_allowed, path::canonicalize_path, ServerState, WORLD_ALLOW},
     AuthGate,
 };
-
-/// Request ID stamped onto each incoming request by the
-/// `add_server_response_headers` middleware in `server/middleware.rs` and threaded
-/// through axum's request extensions so the pipeline driver and the
-/// `x-request-id` response header are guaranteed to use the same
-/// number. Without this, two independent request-id allocations
-/// (one in the middleware, one in `pipeline::run`) produced
-/// off-by-one ids: trace said `req-43` while the response header
-/// said `42`.
-#[derive(Clone, Copy)]
-pub(crate) struct RequestId(pub(crate) u64);
 
 // ─── Phase enum ──────────────────────────────────────────────────
 
@@ -177,134 +168,6 @@ pub(crate) enum ErrorReason {
     /// when the proc surface migrates onto the pipeline.
     #[allow(dead_code)]
     AuditChainBroken,
-}
-
-// ─── Trace ───────────────────────────────────────────────────────
-
-static PIPELINE_TRACE: AtomicBool = AtomicBool::new(false);
-
-/// Read `ELASTIK_TRACE_PIPELINE` once and freeze the result for the
-/// process lifetime. Called from `main()` after env is loaded. The
-/// flag is process-global because per-request trace state would add
-/// overhead even when the feature is off, and the use case here is
-/// "running the binary with trace on for a debug session".
-pub(crate) fn init_trace_from_env() {
-    let enabled = matches!(
-        std::env::var("ELASTIK_TRACE_PIPELINE").as_deref(),
-        Ok("1") | Ok("true") | Ok("yes") | Ok("on")
-    );
-    PIPELINE_TRACE.store(enabled, Ordering::Relaxed);
-    if enabled {
-        eprintln!("elastik-core: pipeline trace ENABLED via ELASTIK_TRACE_PIPELINE");
-    }
-}
-
-/// Per-request trace context. Construct once at the top of `run()`,
-/// pass through to verb handlers (in 4b/4c) so they can emit aux
-/// lines for sub-steps. `enabled` is sampled once on construction
-/// so a runtime toggle would only take effect for new requests
-/// (acceptable for env-var gating; PR 5 adds a runtime-toggleable
-/// `/etc/debug` world).
-pub(crate) struct TraceCtx {
-    req_id: u64,
-    started: Instant,
-    enabled: bool,
-}
-
-impl TraceCtx {
-    pub(crate) fn new(req_id: u64, started: Instant) -> Self {
-        Self {
-            req_id,
-            started,
-            enabled: PIPELINE_TRACE.load(Ordering::Relaxed),
-        }
-    }
-
-    /// Test-only no-op trace context. Always disabled. Used as a
-    /// stand-in argument when calling `execute_*` handlers from
-    /// unit tests in PR 4b/4c.
-    #[cfg(test)]
-    pub(crate) fn disabled() -> Self {
-        Self {
-            req_id: 0,
-            started: Instant::now(),
-            enabled: false,
-        }
-    }
-
-    /// Top-level phase transition. Called by the driver after each
-    /// transition. Skipped for `Done` / `Error` because those have
-    /// dedicated emit_done / emit_error formatters.
-    pub(crate) fn emit_phase(&self, phase: &Phase) {
-        if !self.enabled {
-            return;
-        }
-        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
-        eprintln!(
-            "[req-{:<3} +{:>7.3}ms] {}",
-            self.req_id,
-            elapsed_ms,
-            phase_summary(phase)
-        );
-    }
-
-    /// Indented sub-step emitted from inside a verb handler.
-    /// Surfaces what is happening between Dispatched and
-    /// ExecutedRead/CommittedWrite (lock acquisition, SQLite commits,
-    /// audit appends, notify dispatch, quota reservations, ...).
-    /// Currently unused — verb handlers wire these up in 4b/4c.
-    #[allow(dead_code)]
-    pub(crate) fn emit_aux(&self, label: &str) {
-        if !self.enabled {
-            return;
-        }
-        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
-        eprintln!(
-            "[req-{:<3} +{:>7.3}ms]   aux            {}",
-            self.req_id, elapsed_ms, label
-        );
-    }
-
-    /// Same as `emit_aux` but with a key=value tail.
-    /// Currently unused — verb handlers wire these up in 4b/4c.
-    #[allow(dead_code)]
-    pub(crate) fn emit_aux_kv(&self, label: &str, kv: &str) {
-        if !self.enabled {
-            return;
-        }
-        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
-        eprintln!(
-            "[req-{:<3} +{:>7.3}ms]   aux            {} {}",
-            self.req_id, elapsed_ms, label, kv
-        );
-    }
-
-    /// Terminal Done line with total elapsed.
-    fn emit_done(&self, resp: &Response) {
-        if !self.enabled {
-            return;
-        }
-        let total_ms = self.started.elapsed().as_secs_f64() * 1000.0;
-        eprintln!(
-            "[req-{:<3} +{:>7.3}ms] Done           status={} total={:.3}ms",
-            self.req_id,
-            total_ms,
-            resp.status(),
-            total_ms
-        );
-    }
-
-    /// Terminal Error line with status + structured reason.
-    fn emit_error(&self, reason: &ErrorReason, status: StatusCode) {
-        if !self.enabled {
-            return;
-        }
-        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
-        eprintln!(
-            "[req-{:<3} +{:>7.3}ms] Error          status={} reason={:?}",
-            self.req_id, elapsed_ms, status, reason
-        );
-    }
 }
 
 fn phase_summary(p: &Phase) -> String {
@@ -445,7 +308,7 @@ pub(crate) async fn run(
     // the RequestId doc comment for the off-by-one history. `state` itself
     // is consumed inside the loop (used for auth and handed to
     // `handler::execute` for the verb).
-    let trace = TraceCtx::new(req_id, Instant::now());
+    let trace = TraceCtx::new(req_id);
 
     let mut phase = Phase::Received {
         method,
@@ -546,7 +409,7 @@ mod tests {
     };
     use axum::{
         body::to_bytes,
-        http::{header, HeaderValue},
+        http::{header, HeaderValue, StatusCode},
     };
 
     fn world_path(world: &str) -> ValidatedWorldPath {
@@ -816,7 +679,7 @@ mod tests {
         let prior = std::env::var("ELASTIK_TRACE_PIPELINE").ok();
         std::env::remove_var("ELASTIK_TRACE_PIPELINE");
         init_trace_from_env();
-        assert!(!PIPELINE_TRACE.load(Ordering::Relaxed));
+        assert!(!trace_enabled_for_tests());
         // Restore.
         if let Some(v) = prior {
             std::env::set_var("ELASTIK_TRACE_PIPELINE", v);

--- a/bin/src/server/pipeline/context.rs
+++ b/bin/src/server/pipeline/context.rs
@@ -1,0 +1,150 @@
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Instant,
+};
+
+use axum::{http::StatusCode, response::Response};
+
+use super::{phase_summary, ErrorReason, Phase};
+
+/// Request ID stamped onto each incoming request by the
+/// `add_server_response_headers` middleware in `server/middleware.rs` and threaded
+/// through axum's request extensions so the pipeline driver and the
+/// `x-request-id` response header are guaranteed to use the same
+/// number. Without this, two independent request-id allocations
+/// (one in the middleware, one in `pipeline::run`) produced
+/// off-by-one ids: trace said `req-43` while the response header
+/// said `42`.
+#[derive(Clone, Copy)]
+pub(crate) struct RequestId(pub(crate) u64);
+
+static PIPELINE_TRACE: AtomicBool = AtomicBool::new(false);
+
+/// Read `ELASTIK_TRACE_PIPELINE` once and freeze the result for the
+/// process lifetime. Called from `main()` after env is loaded. The
+/// flag is process-global because per-request trace state would add
+/// overhead even when the feature is off, and the use case here is
+/// "running the binary with trace on for a debug session".
+pub(crate) fn init_trace_from_env() {
+    let enabled = matches!(
+        std::env::var("ELASTIK_TRACE_PIPELINE").as_deref(),
+        Ok("1") | Ok("true") | Ok("yes") | Ok("on")
+    );
+    PIPELINE_TRACE.store(enabled, Ordering::Relaxed);
+    if enabled {
+        eprintln!("elastik-core: pipeline trace ENABLED via ELASTIK_TRACE_PIPELINE");
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn trace_enabled_for_tests() -> bool {
+    PIPELINE_TRACE.load(Ordering::Relaxed)
+}
+
+/// Per-request trace context. Construct once at the top of `run()`,
+/// pass through to verb handlers (in 4b/4c) so they can emit aux
+/// lines for sub-steps. `enabled` is sampled once on construction
+/// so a runtime toggle would only take effect for new requests
+/// (acceptable for env-var gating; PR 5 adds a runtime-toggleable
+/// `/etc/debug` world).
+pub(crate) struct TraceCtx {
+    req_id: u64,
+    started: Instant,
+    enabled: bool,
+}
+
+impl TraceCtx {
+    pub(crate) fn new(req_id: u64) -> Self {
+        Self {
+            req_id,
+            started: Instant::now(),
+            enabled: PIPELINE_TRACE.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Test-only no-op trace context. Always disabled. Used as a
+    /// stand-in argument when calling `execute_*` handlers from
+    /// unit tests in PR 4b/4c.
+    #[cfg(test)]
+    pub(crate) fn disabled() -> Self {
+        Self {
+            req_id: 0,
+            started: Instant::now(),
+            enabled: false,
+        }
+    }
+
+    /// Top-level phase transition. Called by the driver after each
+    /// transition. Skipped for `Done` / `Error` because those have
+    /// dedicated emit_done / emit_error formatters.
+    pub(crate) fn emit_phase(&self, phase: &Phase) {
+        if !self.enabled {
+            return;
+        }
+        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+        eprintln!(
+            "[req-{:<3} +{:>7.3}ms] {}",
+            self.req_id,
+            elapsed_ms,
+            phase_summary(phase)
+        );
+    }
+
+    /// Indented sub-step emitted from inside a verb handler.
+    /// Surfaces what is happening between Dispatched and
+    /// ExecutedRead/CommittedWrite (lock acquisition, SQLite commits,
+    /// audit appends, notify dispatch, quota reservations, ...).
+    /// Currently unused — verb handlers wire these up in 4b/4c.
+    #[allow(dead_code)]
+    pub(crate) fn emit_aux(&self, label: &str) {
+        if !self.enabled {
+            return;
+        }
+        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+        eprintln!(
+            "[req-{:<3} +{:>7.3}ms]   aux            {}",
+            self.req_id, elapsed_ms, label
+        );
+    }
+
+    /// Same as `emit_aux` but with a key=value tail.
+    /// Currently unused — verb handlers wire these up in 4b/4c.
+    #[allow(dead_code)]
+    pub(crate) fn emit_aux_kv(&self, label: &str, kv: &str) {
+        if !self.enabled {
+            return;
+        }
+        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+        eprintln!(
+            "[req-{:<3} +{:>7.3}ms]   aux            {} {}",
+            self.req_id, elapsed_ms, label, kv
+        );
+    }
+
+    /// Terminal Done line with total elapsed.
+    pub(super) fn emit_done(&self, resp: &Response) {
+        if !self.enabled {
+            return;
+        }
+        let total_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+        eprintln!(
+            "[req-{:<3} +{:>7.3}ms] Done           status={} total={:.3}ms",
+            self.req_id,
+            total_ms,
+            resp.status(),
+            total_ms
+        );
+    }
+
+    /// Terminal Error line with status + structured reason.
+    pub(super) fn emit_error(&self, reason: &ErrorReason, status: StatusCode) {
+        if !self.enabled {
+            return;
+        }
+        let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+        eprintln!(
+            "[req-{:<3} +{:>7.3}ms] Error          status={} reason={:?}",
+            self.req_id, elapsed_ms, status, reason
+        );
+    }
+}


### PR DESCRIPTION
## Stack

Base: `stack/22r36-timeline-coordinate-resolver` / PR #352 (`783c01e`).

## What

Split pipeline request/trace context support out of `bin/src/server/pipeline.rs` into `bin/src/server/pipeline/context.rs` before the next HTTP raw-query plumbing layer.

This is a mechanical support split, not a pure-mv PR: `TraceCtx::new(req_id, Instant::now())` became `TraceCtx::new(req_id)` and the constructor now captures `Instant::now()` internally. Request behaviour, route dispatch, auth, path validation, audit, and response mapping are unchanged.

## Why

AGENTS.md production-file budget flagged `pipeline.rs` as too large to keep touching. This layer pays down that budget first so PLAN §7.3 can thread raw query state through the pipeline in the next stacked PR without compounding review surface.

## Budget

- Files: 2
- Raw diff: +158 / -145
- `bin/src/server/pipeline.rs`: ~375 nonblank production lines before the bottom test module
- `bin/src/server/pipeline/context.rs`: ~136 nonblank production lines
- Production files remain under the 500-line cap

## Validation

Parent/local:

```powershell
cargo fmt --manifest-path bin\Cargo.toml
cargo test --manifest-path bin\Cargo.toml server::pipeline --quiet
cargo clippy --manifest-path bin\Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path bin\Cargo.toml --quiet
scripts\pre-push.ps1
```

Push hook reran the local gates and passed:

- core tests: 190 passed, 2 ignored
- core doctests: 17 passed
- bin tests: 110 passed
- version consistency: 8.3.0
- bundled SQLite check: libsqlite3-sys 0.38.0 / SQLite 3.53.1
- cargo audit: core/bin/ffi passed
- SDK smoke: passed
- header policy scanner: no drift
- whitespace check: passed

## Review Ledger

Fresh blind round, staged diff only:

- Anscombe the 5th, Poincare/Newton/Dirac semantics lens: PASS, zero P0-P2. P3: not a strict pure move because `TraceCtx::new` now captures `Instant::now()` internally.
- Locke the 5th, Mencius/Noether/type-seal lens: PASS, zero P0-P2. `PIPELINE_TRACE` is private to `context.rs`; `trace_enabled_for_tests` is `#[cfg(test)]`; re-exports do not add a new FSM bypass.
- Bacon the 5th, QA/AGENTS lens: PASS, zero P0-P2. Production file budget is clean; focused validation passed.

P3 disposition: PR wording avoids claiming pure mv and records the small constructor-shape change.