### PR TITLE
bin: thread raw query through pipeline

### DIFF
--- a/bin/src/server/pipeline.rs
+++ b/bin/src/server/pipeline.rs
@@ -42,7 +42,7 @@
 mod context;
 #[cfg(test)]
 use context::trace_enabled_for_tests;
-pub(crate) use context::{init_trace_from_env, RequestId, TraceCtx};
+pub(crate) use context::{init_trace_from_env, RawQuery, RequestId, TraceCtx};
 
 use axum::{
     body::Bytes,
@@ -74,18 +74,21 @@ pub(crate) enum Phase {
     Received {
         method: Method,
         path: String,
+        raw_query: RawQuery,
         headers: HeaderMap,
         body: Bytes,
     },
     Authenticated {
         method: Method,
         path: String,
+        raw_query: RawQuery,
         headers: HeaderMap,
         body: Bytes,
         tier: AccessTier,
     },
     PathValidated {
         method: Method,
+        raw_query: RawQuery,
         headers: HeaderMap,
         body: Bytes,
         tier: AccessTier,
@@ -196,6 +199,7 @@ fn phase_summary(p: &Phase) -> String {
 fn authenticate(
     method: Method,
     path: String,
+    raw_query: RawQuery,
     headers: HeaderMap,
     body: Bytes,
     tier: AccessTier,
@@ -203,6 +207,7 @@ fn authenticate(
     Phase::Authenticated {
         method,
         path,
+        raw_query,
         headers,
         body,
         tier,
@@ -217,6 +222,7 @@ fn authenticate(
 fn validate_path(
     method: Method,
     path: String,
+    raw_query: RawQuery,
     headers: HeaderMap,
     body: Bytes,
     tier: AccessTier,
@@ -240,6 +246,7 @@ fn validate_path(
     };
     Phase::PathValidated {
         method,
+        raw_query,
         headers,
         body,
         tier,
@@ -299,6 +306,7 @@ fn dispatch(
 pub(crate) async fn run(
     method: Method,
     path: String,
+    raw_query: RawQuery,
     headers: HeaderMap,
     body: Bytes,
     state: &ServerState,
@@ -313,6 +321,7 @@ pub(crate) async fn run(
     let mut phase = Phase::Received {
         method,
         path,
+        raw_query,
         headers,
         body,
     };
@@ -323,23 +332,26 @@ pub(crate) async fn run(
             Phase::Received {
                 method,
                 path,
+                raw_query,
                 headers,
                 body,
             } => {
                 let tier = state.access_tier_from_headers(&headers);
-                authenticate(method, path, headers, body, tier)
+                authenticate(method, path, raw_query, headers, body, tier)
             }
 
             Phase::Authenticated {
                 method,
                 path,
+                raw_query,
                 headers,
                 body,
                 tier,
-            } => validate_path(method, path, headers, body, tier),
+            } => validate_path(method, path, raw_query, headers, body, tier),
 
             Phase::PathValidated {
                 method,
+                raw_query: _raw_query,
                 headers,
                 body,
                 tier,
@@ -440,6 +452,7 @@ mod tests {
         let phase = authenticate(
             Method::GET,
             "/home/foo".into(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             AccessTier::Anon,
@@ -455,6 +468,7 @@ mod tests {
         let phase = authenticate(
             Method::PUT,
             "/home/foo".into(),
+            RawQuery::absent(),
             header_map_with_auth(&bearer("writer")),
             Bytes::from_static(b"hi"),
             AccessTier::Write,
@@ -470,6 +484,7 @@ mod tests {
         let phase = authenticate(
             Method::PUT,
             "/home/foo".into(),
+            RawQuery::absent(),
             header_map_with_auth(&bearer("wrong")),
             Bytes::new(),
             AccessTier::Anon,
@@ -487,6 +502,7 @@ mod tests {
         let phase = validate_path(
             Method::GET,
             "/foo".into(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             AccessTier::Anon,
@@ -502,6 +518,7 @@ mod tests {
         let phase = validate_path(
             Method::GET,
             "/etc/foo".into(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             AccessTier::Approve,
@@ -513,10 +530,30 @@ mod tests {
     }
 
     #[test]
+    fn validate_path_preserves_raw_query_for_later_classification() {
+        let raw_query = RawQuery::from_uri(&"/home/foo?timeline%2dgeneration=abc".parse().unwrap());
+        let phase = validate_path(
+            Method::GET,
+            "/home/foo".into(),
+            raw_query,
+            HeaderMap::new(),
+            Bytes::new(),
+            AccessTier::Anon,
+        );
+        match phase {
+            Phase::PathValidated { raw_query, .. } => {
+                assert_eq!(raw_query.as_deref(), Some("timeline%2dgeneration=abc"));
+            }
+            _ => panic!("expected PathValidated"),
+        }
+    }
+
+    #[test]
     fn validate_path_rejects_dot_segments_with_pathinvalid() {
         let phase = validate_path(
             Method::PUT,
             "/home/../etc/secret".into(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             AccessTier::Write,
@@ -535,6 +572,7 @@ mod tests {
         let phase = validate_path(
             Method::PUT,
             "/home".into(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             AccessTier::Write,
@@ -553,6 +591,7 @@ mod tests {
         let phase = validate_path(
             Method::GET,
             "/home/%2E%2E/etc/secret".into(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             AccessTier::Read,
@@ -646,6 +685,7 @@ mod tests {
         let phase = Phase::Received {
             method: Method::GET,
             path: "/home/foo".into(),
+            raw_query: RawQuery::absent(),
             headers: HeaderMap::new(),
             body: Bytes::new(),
         };
@@ -714,6 +754,7 @@ mod tests {
         let patch = run(
             Method::PATCH,
             "home/allow".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             &state,
@@ -735,6 +776,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/hello".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             &state,
@@ -763,6 +805,7 @@ mod tests {
         let resp = run(
             Method::HEAD,
             "/home/hello".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             &state,
@@ -791,6 +834,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/missing".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             &state,
@@ -811,6 +855,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/../etc/secret".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             &state,
@@ -833,6 +878,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/secret".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(), // no Authorization header
             Bytes::new(),
             &state,
@@ -858,6 +904,7 @@ mod tests {
         let first = run(
             Method::GET,
             "/home/cached".to_string(),
+            RawQuery::absent(),
             HeaderMap::new(),
             Bytes::new(),
             &state,
@@ -876,6 +923,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/cached".to_string(),
+            RawQuery::absent(),
             headers,
             Bytes::new(),
             &state,
@@ -912,6 +960,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/short".to_string(),
+            RawQuery::absent(),
             headers,
             Bytes::new(),
             &state,
@@ -959,6 +1008,7 @@ mod tests {
         let resp = run(
             Method::GET,
             "/home/range".to_string(),
+            RawQuery::absent(),
             headers,
             Bytes::new(),
             &state,

--- a/bin/src/server/pipeline/context.rs
+++ b/bin/src/server/pipeline/context.rs
@@ -3,7 +3,10 @@ use std::{
     time::Instant,
 };
 
-use axum::{http::StatusCode, response::Response};
+use axum::{
+    http::{StatusCode, Uri},
+    response::Response,
+};
 
 use super::{phase_summary, ErrorReason, Phase};
 
@@ -17,6 +20,31 @@ use super::{phase_summary, ErrorReason, Phase};
 /// said `42`.
 #[derive(Clone, Copy)]
 pub(crate) struct RequestId(pub(crate) u64);
+
+#[derive(Clone)]
+pub(crate) struct RawQuery(
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "raw query is opaque until the classifier layer")
+    )]
+    Option<String>,
+);
+
+impl RawQuery {
+    pub(crate) fn from_uri(uri: &Uri) -> Self {
+        Self(uri.query().map(str::to_owned))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn absent() -> Self {
+        Self(None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_deref(&self) -> Option<&str> {
+        self.0.as_deref()
+    }
+}
 
 static PIPELINE_TRACE: AtomicBool = AtomicBool::new(false);
 

--- a/bin/src/server/route.rs
+++ b/bin/src/server/route.rs
@@ -10,7 +10,7 @@
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, Path as AxPath, State},
-    http::{HeaderMap, Method},
+    http::{HeaderMap, Method, Uri},
     middleware::from_fn_with_state,
     response::Response,
     routing::any,
@@ -55,6 +55,7 @@ pub(crate) async fn world_handler(
         crate::server::pipeline::RequestId,
     >,
     method: Method,
+    uri: Uri,
     AxPath(path): AxPath<String>,
     headers: HeaderMap,
     body: Bytes,
@@ -73,7 +74,8 @@ pub(crate) async fn world_handler(
     if method == Method::OPTIONS {
         return options_response(WORLD_ALLOW);
     }
-    pipeline::run(method, path, headers, body, &state, req_id).await
+    let raw_query = pipeline::RawQuery::from_uri(&uri);
+    pipeline::run(method, path, raw_query, headers, body, &state, req_id).await
 }
 
 #[cfg(test)]
@@ -178,6 +180,26 @@ mod tests {
         );
         assert!(resp.headers().get("x-request-id").is_some());
         // HEAD body must be empty even though Content-Length says 11.
+        assert_eq!(response_text(resp).await, "");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn world_handler_options_ignores_malformed_timeline_query() {
+        let (engine, dir) = test_engine_for_server("world-handler-options-query");
+        let state = server_state_for_engine_for_tests(engine);
+        let app = build_app(state);
+
+        let req = HttpRequest::builder()
+            .method("OPTIONS")
+            .uri("/home/hello?timeline%ZZ=1")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(resp.headers().get(header::ALLOW).unwrap(), WORLD_ALLOW);
         assert_eq!(response_text(resp).await, "");
 
         let _ = std::fs::remove_dir_all(dir);


### PR DESCRIPTION
## Stack

Base: `stack/22r37-pipeline-context-split` / PR #353 (`deeb7d9`).

## Plan Link

Implements `design_notes/PLAN-http-timeline-dereference.md` §7 item 3: thread the HTTP request-target query string into the route/FSM as raw request-target data, while preserving route-level `OPTIONS` before any future query decoding/classification.

## What

- Adds `pipeline::RawQuery` as an opaque request-context carrier.
- Captures `Uri::query()` in `world_handler` after the `OPTIONS` short-circuit.
- Threads `RawQuery` through `Phase::Received`, `Phase::Authenticated`, and `Phase::PathValidated`.
- Drops it before dispatch for now; no handler sees it in this layer.
- Adds tests for raw query preservation and malformed timeline-looking query on `OPTIONS`.

This layer intentionally does not classify, parse, percent-decode, validate, or act on timeline query parameters. The classifier/cap layer is next.

## Seal Shape

`RawQuery` is intentionally opaque in production:

- private tuple field
- derives only `Clone`
- no production `Debug`, `Display`, `PartialEq`, `Eq`, `AsRef`, `Deref`, or read accessor
- `as_deref()` and `absent()` are `#[cfg(test)]`
- production dead-code expectation is limited to `not(test)` because this layer only carries the field for the next classifier layer

## Budget

- Files: 3
- Raw diff: +106 / -6
- Production file sizes remain under the 500-line AGENTS budget:
  - `bin/src/server/pipeline.rs`: ~411 raw production lines before tests
  - `bin/src/server/pipeline/context.rs`: ~172 total lines
  - `bin/src/server/route.rs`: ~80 raw production lines before tests

## Validation

```powershell
cargo fmt --manifest-path bin\Cargo.toml -- --check
git diff --cached --check
cargo test --manifest-path bin\Cargo.toml validate_path_preserves_raw_query_for_later_classification --quiet
cargo test --manifest-path bin\Cargo.toml world_handler_options_ignores_malformed_timeline_query --quiet
cargo test --manifest-path bin\Cargo.toml query --quiet
cargo clippy --manifest-path bin\Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path bin\Cargo.toml --quiet
scripts\pre-push.ps1
```

Push hook reran the local gates and passed:

- core tests: 190 passed, 2 ignored
- core doctests: 17 passed
- bin tests: 112 passed
- version consistency: 8.3.0
- bundled SQLite check: libsqlite3-sys 0.38.0 / SQLite 3.53.1
- cargo audit: core/bin/ffi passed
- SDK smoke: passed
- header policy scanner: no drift
- whitespace check: passed

## Review Ledger

Initial blind round on raw-query plumbing:

- Plato the 5th, Popper/precondition lens: PASS, zero P0-P2. P3: later classifier must define duplicate-key, percent-decoding, malformed escape, and encoded-alias rules before observing query contents.
- Bohr the 5th, Noether/type-seal lens: found P2. `RawQuery` derived production `Debug`, allowing raw query contents to be formatted/logged.
- Epicurus the 5th, Bacon/QA lens: PASS, zero P0-P2. Confirmed plan linkage, base branch, budget, validation sufficiency.

Fixes applied:

- Removed production `Debug` from `RawQuery`.
- Removed `PartialEq/Eq` after a P3 observation that equality is also content-observing surface.
- Kept only `Clone`; added `cfg_attr(not(test), expect(dead_code, ...))` to document the staging-only unused field without hiding test-build reads.

Fresh clearing rounds:

- Banach, type-seal clearing: PASS, zero P0-P2. Confirmed no production `Debug`, no production accessor, only route mints `RawQuery`.
- Descartes, Popper clearing: PASS, zero P0-P2. Confirmed no equivalent leakage, no parser/decoder/classifier, raw query is dropped before dispatch.
- Ampere, final focused RawQuery trait-surface verifier: PASS, zero P0-P2 and zero P3. Confirmed no production `Debug`/`Display`/`PartialEq`/`Eq`/`AsRef`/`Deref`/accessor leak; `cfg_attr(not(test), expect(...))` is appropriate.