### PR TITLE
bin: wire HTTP timeline dereference

### DIFF
--- a/bin/src/core_bridge.rs
+++ b/bin/src/core_bridge.rs
@@ -45,4 +45,10 @@ pub(crate) mod engine_types {
     };
 }
 
+pub(crate) mod timeline {
+    #[cfg(test)]
+    pub(crate) use elastik_core::TimelineAddress;
+    pub(crate) use elastik_core::{TimelineBody, TimelineCoordinate, TimelineDereference};
+}
+
 pub(crate) use elastik_core::AuthGate;

--- a/bin/src/server/handler.rs
+++ b/bin/src/server/handler.rs
@@ -38,8 +38,11 @@ mod post;
 #[cfg(test)]
 #[path = "handler/tests.rs"]
 mod tests;
+#[path = "handler/timeline.rs"]
+mod timeline;
 pub(crate) use delete::execute_delete;
 pub(crate) use post::execute_post;
+pub(crate) use timeline::execute_timeline;
 
 use axum::{
     body::Bytes,

--- a/bin/src/server/handler/delete.rs
+++ b/bin/src/server/handler/delete.rs
@@ -346,7 +346,8 @@ mod tests {
             Phase::Received { .. }
             | Phase::Authenticated { .. }
             | Phase::PathValidated { .. }
-            | Phase::Dispatched { .. } => {
+            | Phase::Dispatched { .. }
+            | Phase::TimelineDispatched { .. } => {
                 panic!("execute_* returned a non-terminal Phase variant")
             }
         }

--- a/bin/src/server/handler/tests.rs
+++ b/bin/src/server/handler/tests.rs
@@ -72,7 +72,8 @@ fn unwrap_response(phase: Phase) -> Response {
         Phase::Received { .. }
         | Phase::Authenticated { .. }
         | Phase::PathValidated { .. }
-        | Phase::Dispatched { .. } => {
+        | Phase::Dispatched { .. }
+        | Phase::TimelineDispatched { .. } => {
             panic!("execute_* returned a non-terminal Phase variant")
         }
     }

--- a/bin/src/server/handler/timeline.rs
+++ b/bin/src/server/handler/timeline.rs
@@ -1,0 +1,201 @@
+use axum::{
+    http::{header, HeaderName, HeaderValue, StatusCode},
+    response::IntoResponse,
+};
+
+use crate::{
+    engine::EngineError,
+    engine_types::AccessTier,
+    server::{
+        audit_header_value, bad_request, decimal_header_value, insufficient_storage, server_error,
+        storage_temporarily_unavailable, to_header_map, unauthorized, ErrorReason, Phase,
+        ServerState, TraceCtx,
+    },
+    timeline::{TimelineBody, TimelineCoordinate, TimelineDereference},
+};
+
+pub(crate) async fn execute_timeline(
+    coordinate: TimelineCoordinate,
+    tier: AccessTier,
+    state: &ServerState,
+    trace: &TraceCtx,
+    head: bool,
+) -> Phase {
+    let engine = state.engine().clone();
+    let worker_coordinate = coordinate.clone();
+    let joined = tokio::task::spawn_blocking(move || {
+        engine.dereference_timeline_coordinate(&worker_coordinate, tier)
+    })
+    .await;
+
+    let result = match joined {
+        Ok(Ok(result)) => result,
+        Ok(Err(err)) => return timeline_engine_error_phase(err, head),
+        Err(_) => {
+            return timeline_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "timeline worker failed",
+                head,
+                ErrorReason::TimelineStorageRead,
+            )
+        }
+    };
+
+    trace.emit_aux_kv("timeline_world", coordinate.world().as_str());
+    match result {
+        TimelineDereference::Body(body) => {
+            trace.emit_aux_kv("body_size", &body.representation().body.len().to_string());
+            Phase::ExecutedRead(timeline_body_response(body, head))
+        }
+        other => {
+            let (status, message, reason) = match other {
+                TimelineDereference::GenMismatch(_) => (
+                    StatusCode::CONFLICT,
+                    "timeline generation mismatch",
+                    ErrorReason::TimelineGenMismatch,
+                ),
+                TimelineDereference::BodyHashMismatch(_) => (
+                    StatusCode::CONFLICT,
+                    "timeline body sha256 mismatch",
+                    ErrorReason::TimelineBodyHashMismatch,
+                ),
+                TimelineDereference::NonBodyEvent(_) => (
+                    StatusCode::NOT_FOUND,
+                    "timeline event has no body",
+                    ErrorReason::TimelineNonBodyEvent,
+                ),
+                TimelineDereference::MissingRow(_) => (
+                    StatusCode::NOT_FOUND,
+                    "timeline row not found",
+                    ErrorReason::TimelineMissingRow,
+                ),
+                TimelineDereference::UnprovenCoordinate(_) => (
+                    StatusCode::NOT_FOUND,
+                    "timeline coordinate not proven",
+                    ErrorReason::TimelineUnprovenCoordinate,
+                ),
+                TimelineDereference::Corrupt { .. } => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "timeline corruption",
+                    ErrorReason::TimelineCorrupt,
+                ),
+                _ => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "unknown timeline dereference result",
+                    ErrorReason::TimelineCorrupt,
+                ),
+            };
+            timeline_error(status, message, head, reason)
+        }
+    }
+}
+
+fn timeline_body_response(body: TimelineBody, head: bool) -> axum::response::Response {
+    let address = body.address();
+    let representation = body.representation();
+    let mut resp_headers = vec![
+        (
+            header::CONTENT_TYPE,
+            HeaderValue::from_str(&representation.content_type)
+                .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream")),
+        ),
+        (
+            header::CONTENT_LENGTH,
+            decimal_header_value(representation.body.len()),
+        ),
+    ];
+    crate::server::http::semantics::apply_meta_headers(&representation.headers, &mut resp_headers);
+    resp_headers.extend([
+        (
+            HeaderName::from_static("x-timeline-world"),
+            audit_header_value(address.world().as_str()),
+        ),
+        (
+            HeaderName::from_static("x-timeline-generation"),
+            audit_header_value(address.generation().as_str()),
+        ),
+        (
+            HeaderName::from_static("x-timeline-seq"),
+            HeaderValue::from_str(&address.seq().get().to_string())
+                .unwrap_or_else(|_| HeaderValue::from_static("invalid")),
+        ),
+        (
+            HeaderName::from_static("x-timeline-body-sha256"),
+            audit_header_value(address.body_sha256().as_str()),
+        ),
+    ]);
+
+    let body = if head {
+        Default::default()
+    } else {
+        representation.body.clone()
+    };
+    (StatusCode::OK, to_header_map(resp_headers), body).into_response()
+}
+
+fn timeline_engine_error_phase(err: EngineError, head: bool) -> Phase {
+    let (resp, reason) = match err {
+        EngineError::Auth(gate) => (
+            unauthorized("read requires read token"),
+            ErrorReason::Auth(gate),
+        ),
+        EngineError::TransientStorage | EngineError::ShuttingDown => (
+            storage_temporarily_unavailable(),
+            ErrorReason::TimelineStorageRead,
+        ),
+        EngineError::InsufficientStorage => {
+            (insufficient_storage(), ErrorReason::InsufficientStorage)
+        }
+        EngineError::InvalidMetadata { message } => {
+            (bad_request(message), ErrorReason::TimelineStorageRead)
+        }
+        EngineError::Storage | EngineError::InternalInvariant(_) => (
+            server_error("timeline storage failure".to_string()),
+            ErrorReason::TimelineStorageRead,
+        ),
+        _ => (
+            server_error("unexpected timeline read error".to_string()),
+            ErrorReason::TimelineStorageRead,
+        ),
+    };
+    Phase::Error {
+        resp: timeline_head_response(resp, head),
+        reason,
+    }
+}
+
+fn timeline_error(
+    status: StatusCode,
+    message: &'static str,
+    head: bool,
+    reason: ErrorReason,
+) -> Phase {
+    Phase::Error {
+        resp: timeline_text_response(status, message, head),
+        reason,
+    }
+}
+
+fn timeline_text_response(
+    status: StatusCode,
+    message: &str,
+    head: bool,
+) -> axum::response::Response {
+    let body = format!("{message}\n");
+    let headers = to_header_map(vec![
+        (
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+        ),
+        (header::CONTENT_LENGTH, decimal_header_value(body.len())),
+    ]);
+    (status, headers, if head { String::new() } else { body }).into_response()
+}
+
+fn timeline_head_response(resp: axum::response::Response, head: bool) -> axum::response::Response {
+    if !head {
+        return resp;
+    }
+    let (parts, _) = resp.into_parts();
+    axum::response::Response::from_parts(parts, axum::body::Body::empty())
+}

--- a/bin/src/server/http/semantics.rs
+++ b/bin/src/server/http/semantics.rs
@@ -13,9 +13,7 @@ use crate::{
     server::{to_header_map, unsatisfied_range_value},
 };
 
-/// Entries are normalized to lowercase. A trailing `*` makes an
-/// entry a prefix match (e.g. `x-my-*` matches `x-my-anything`).
-/// Anything else is exact match.
+/// Lowercase exact matches plus trailing-`*` prefix matches.
 #[derive(Default, Clone)]
 pub(crate) struct HeaderAllowlist {
     exact: HashSet<String>,
@@ -23,19 +21,13 @@ pub(crate) struct HeaderAllowlist {
 }
 
 impl HeaderAllowlist {
-    /// Empty allowlist (default-deny custom headers). Used by
-    /// test fixtures and as the inert state for `ServerState` constructors
-    /// that don't read environment. The production startup path uses
-    /// `header_allowlist_from_env()` instead, which returns
-    /// an `empty()` for an unset env var anyway.
+    /// Empty allowlist for test fixtures and inert `ServerState` constructors.
     #[allow(dead_code)]
     pub(crate) fn empty() -> Self {
         Self::default()
     }
 
-    /// Parse a comma-separated list. Whitespace per entry is
-    /// trimmed; entries are lowercased. A trailing `*` denotes a
-    /// prefix match. Empty or `*`-only entries are skipped.
+    /// Parse comma-separated exact/prefix entries.
     pub(crate) fn parse(raw: &str) -> Self {
         let mut exact = HashSet::new();
         let mut prefixes: Vec<String> = Vec::new();
@@ -65,23 +57,14 @@ impl HeaderAllowlist {
     }
 }
 
-/// Parse `ELASTIK_PERSIST_HEADERS` into the user-configured
-/// allowlist (Layer 3 of the persist policy). Comma-separated;
-/// trailing `*` = prefix match. An unset, empty, or all-whitespace
-/// value yields `HeaderAllowlist::empty()`, which means "no custom
-/// headers beyond the built-in default-allow set."
+/// Parse `ELASTIK_PERSIST_HEADERS` into the user-configured allowlist.
 #[cfg_attr(test, allow(dead_code))]
 pub(crate) fn header_allowlist_from_env() -> HeaderAllowlist {
     let raw = std::env::var("ELASTIK_PERSIST_HEADERS").unwrap_or_default();
     HeaderAllowlist::parse(&raw)
 }
 
-/// Parse `ELASTIK_DENY_HEADERS` into the user-configured deny set
-/// (Layer 1.5 of the persist policy). Same matcher shape as
-/// `header_allowlist_from_env`; lets the operator subtract a header
-/// from the built-in `DEFAULT_PERSIST_HEADERS` allow set (e.g. "this
-/// deployment doesn't want `cache-control` round-tripping"). L1
-/// hard-deny still wins over this; this beats L2 default and L3 allow.
+/// Parse `ELASTIK_DENY_HEADERS` into the user-configured deny set.
 #[cfg_attr(test, allow(dead_code))]
 pub(crate) fn header_user_deny_from_env() -> HeaderAllowlist {
     let raw = std::env::var("ELASTIK_DENY_HEADERS").unwrap_or_default();
@@ -346,6 +329,9 @@ pub(crate) fn is_never_persisted_header(name_lower: &str) -> bool {
         // describe stored representation; all describe the request's
         // path through Cloudflare's edge.
         || name.starts_with("cf-")
+        // Timeline proof headers are minted by historical dereference, not by
+        // stored metadata. A persisted copy would make the proof ambiguous.
+        || name.starts_with("x-timeline-")
         || matches!(
             name,
             // Credentials and ambient identity must never come back as stored data.

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -237,7 +237,7 @@ mod tests {
             .subscribe(
                 &SubscribePattern::new("home/task/*"),
                 AccessTier::Read,
-                None,
+                SubscriptionResume::none(),
             )
             .expect("test subscription should be accepted");
         let world = ValidatedWorldPath::new("home/task/source").unwrap();

--- a/bin/src/server/pipeline.rs
+++ b/bin/src/server/pipeline.rs
@@ -453,7 +453,9 @@ pub(crate) async fn run(
 mod tests {
     use super::*;
     use crate::{
-        engine_types::{Preconditions, Representation, SubscribePattern, ValidatedWorldPath},
+        engine_types::{
+            Preconditions, Representation, SubscribePattern, SubscriptionResume, ValidatedWorldPath,
+        },
         server::test_support::{
             server_state_for_engine_for_tests, test_engine_for_server,
             test_engine_for_server_with_read_token, write_text_world_for_tests,
@@ -516,7 +518,11 @@ mod tests {
         tier: AccessTier,
     ) -> crate::timeline::TimelineAddress {
         let mut subscription = engine
-            .subscribe(&SubscribePattern::new(world), tier, None)
+            .subscribe(
+                &SubscribePattern::new(world),
+                tier,
+                SubscriptionResume::none(),
+            )
             .expect("test subscription should open");
         engine
             .replace(

--- a/bin/src/server/pipeline.rs
+++ b/bin/src/server/pipeline.rs
@@ -41,9 +41,11 @@
 
 mod context;
 mod query;
+mod timeline_mode;
 #[cfg(test)]
 use context::trace_enabled_for_tests;
 pub(crate) use context::{init_trace_from_env, RawQuery, RequestId, TraceCtx};
+pub(crate) use timeline_mode::{TimelineVerb, TIMELINE_ALLOW};
 
 use axum::{
     body::Bytes,
@@ -54,8 +56,12 @@ use axum::{
 use crate::{
     engine_types::{AccessTier, ValidatedWorldPath},
     server::{bad_request, method_not_allowed, path::canonicalize_path, ServerState, WORLD_ALLOW},
+    timeline::TimelineCoordinate,
     AuthGate,
 };
+
+use query::{TimelineQueryError, TimelineRequestMode};
+use timeline_mode::classify_timeline_request;
 
 // ─── Phase enum ──────────────────────────────────────────────────
 
@@ -101,6 +107,11 @@ pub(crate) enum Phase {
         body: Bytes,
         tier: AccessTier,
         world: ValidatedWorldPath,
+    },
+    TimelineDispatched {
+        verb: TimelineVerb,
+        coordinate: TimelineCoordinate,
+        tier: AccessTier,
     },
     /// GET / HEAD finished. No audit, no notify.
     ExecutedRead(Response),
@@ -151,6 +162,9 @@ pub(crate) enum ErrorReason {
     /// of literal strings defined in `path.rs`).
     PathInvalid(&'static str),
     MethodNotAllowed,
+    TimelineMethodNotAllowed,
+    TimelineRequestTargetTooLong,
+    TimelineQuery(TimelineQueryError),
     NotFound,
     PreconditionFailed,
     /// 416 — `Range` header asks for bytes outside the resource.
@@ -163,6 +177,13 @@ pub(crate) enum ErrorReason {
     QuotaExceeded,
     InsufficientStorage,
     StorageRead,
+    TimelineStorageRead,
+    TimelineGenMismatch,
+    TimelineBodyHashMismatch,
+    TimelineNonBodyEvent,
+    TimelineMissingRow,
+    TimelineUnprovenCoordinate,
+    TimelineCorrupt,
     StorageWriteAudit,
     /// 409 — `/proc/audit/verify` discovers an HMAC chain break.
     /// Reserved for the proc-side audit verifier (proc.rs); the
@@ -182,6 +203,7 @@ fn phase_summary(p: &Phase) -> String {
         Phase::Authenticated { tier, .. } => format!("Authenticated  tier={tier:?}"),
         Phase::PathValidated { world, .. } => format!("PathValidated  world={world}"),
         Phase::Dispatched { verb, .. } => format!("Dispatched     verb={verb:?}"),
+        Phase::TimelineDispatched { verb, .. } => format!("Timeline       verb={verb:?}"),
         Phase::ExecutedRead(resp) => format!("ExecutedRead   status={}", resp.status()),
         Phase::CommittedWrite(resp) => format!("CommittedWrite status={}", resp.status()),
         Phase::Done(resp) => format!("Done           status={}", resp.status()),
@@ -352,12 +374,12 @@ pub(crate) async fn run(
 
             Phase::PathValidated {
                 method,
-                raw_query: _raw_query,
+                raw_query,
                 headers,
                 body,
                 tier,
                 world,
-            } => dispatch(method, headers, body, tier, world),
+            } => classify_timeline_request(method, raw_query, headers, body, tier, world),
 
             Phase::Dispatched {
                 verb,
@@ -368,6 +390,21 @@ pub(crate) async fn run(
             } => {
                 crate::server::handler::execute(verb, headers, body, tier, world, state, &trace)
                     .await
+            }
+
+            Phase::TimelineDispatched {
+                verb,
+                coordinate,
+                tier,
+            } => {
+                crate::server::handler::execute_timeline(
+                    coordinate,
+                    tier,
+                    state,
+                    &trace,
+                    matches!(verb, TimelineVerb::Head),
+                )
+                .await
             }
 
             Phase::ExecutedRead(resp) | Phase::CommittedWrite(resp) => Phase::Done(resp),
@@ -394,6 +431,17 @@ pub(crate) async fn run(
     }
 }
 
+pub(crate) fn allow_for_options(path: &str, raw_query: RawQuery) -> &'static str {
+    let canonical = canonicalize_path(path);
+    let Ok(world) = ValidatedWorldPath::new(&canonical) else {
+        return WORLD_ALLOW;
+    };
+    match raw_query.classify_timeline_mode(&world) {
+        Ok(TimelineRequestMode::Timeline(_)) => TIMELINE_ALLOW,
+        Ok(TimelineRequestMode::Current) | Err(_) => WORLD_ALLOW,
+    }
+}
+
 // ─── Local response helpers ──────────────────────────────────────
 //
 // `method_not_allowed` for unsupported verbs uses the canonical helper
@@ -414,7 +462,7 @@ pub(crate) async fn run(
 mod tests {
     use super::*;
     use crate::{
-        engine_types::ValidatedWorldPath,
+        engine_types::{Preconditions, Representation, SubscribePattern, ValidatedWorldPath},
         server::test_support::{
             server_state_for_engine_for_tests, test_engine_for_server,
             test_engine_for_server_with_read_token, write_text_world_for_tests,
@@ -444,6 +492,88 @@ mod tests {
 
     fn bearer(token: &str) -> String {
         format!("{} {token}", "Bearer")
+    }
+
+    fn raw_query(raw: &str) -> RawQuery {
+        RawQuery::from_uri(&format!("/home/query?{raw}").parse().unwrap())
+    }
+
+    fn timeline_query(address: &crate::timeline::TimelineAddress) -> String {
+        timeline_query_parts(
+            address.generation().as_str(),
+            address.seq().get(),
+            address.body_sha256().as_str(),
+        )
+    }
+
+    fn encoded_timeline_keys(query: &str) -> String {
+        query.replace("timel", "time%6c")
+    }
+
+    fn timeline_query_parts(generation: &str, seq: i64, body_sha256: &str) -> String {
+        format!(
+            "timeline=1&timeline-generation={}&timeline-seq={}&timeline-body-sha256={}",
+            generation, seq, body_sha256
+        )
+    }
+
+    async fn write_body_and_capture_timeline_address_with_tier(
+        engine: &crate::engine::Engine,
+        world: &str,
+        body: &'static [u8],
+        headers: Vec<(String, String)>,
+        tier: AccessTier,
+    ) -> crate::timeline::TimelineAddress {
+        let mut subscription = engine
+            .subscribe(&SubscribePattern::new(world), tier, None)
+            .expect("test subscription should open");
+        engine
+            .replace(
+                &world_path(world),
+                Representation::new(Bytes::from_static(body), "text/plain", headers),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .expect("test write should succeed");
+        let event = subscription.recv().await.expect("test write event");
+        event
+            .timeline_address
+            .expect("durable write should carry timeline address")
+    }
+
+    async fn write_body_and_capture_timeline_address(
+        engine: &crate::engine::Engine,
+        world: &str,
+        body: &'static [u8],
+        headers: Vec<(String, String)>,
+    ) -> crate::timeline::TimelineAddress {
+        write_body_and_capture_timeline_address_with_tier(
+            engine,
+            world,
+            body,
+            headers,
+            AccessTier::Anon,
+        )
+        .await
+    }
+
+    async fn write_body_and_capture_timeline_query(
+        engine: &crate::engine::Engine,
+        world: &str,
+        body: &'static [u8],
+        headers: Vec<(String, String)>,
+    ) -> String {
+        let address = write_body_and_capture_timeline_address(engine, world, body, headers).await;
+        timeline_query(&address)
+    }
+
+    fn assert_current_body(engine: &crate::engine::Engine, world: &str, expected: &[u8]) {
+        let current = engine
+            .read(&world_path(world), AccessTier::Read)
+            .unwrap()
+            .expect("current body should exist");
+        assert_eq!(current.representation.body.as_ref(), expected);
     }
 
     // ── authenticate ───────────────────────────────────────────
@@ -1025,6 +1155,316 @@ mod tests {
             Some("bytes 1-3/6")
         );
         assert_eq!(response_text(resp).await, "bcd");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn pipeline_timeline_get_returns_historical_body_and_proof_headers() {
+        let (engine, dir) = test_engine_for_server("pipeline-timeline-get");
+        let query = write_body_and_capture_timeline_query(
+            &engine,
+            "home/timeline/http",
+            b"old",
+            vec![
+                ("content-language".to_string(), "en-GB".to_string()),
+                ("x-timeline-seq".to_string(), "999".to_string()),
+            ],
+        )
+        .await;
+        write_text_world_for_tests(&engine, "home/timeline/http", "new").await;
+        let state = server_state_for_engine_for_tests(engine.clone());
+        let mut headers = HeaderMap::new();
+        headers.insert(header::RANGE, HeaderValue::from_static("bytes=0-0"));
+        headers.insert(
+            header::IF_RANGE,
+            HeaderValue::from_static("\"hmac-current\""),
+        );
+        headers.insert(
+            header::IF_NONE_MATCH,
+            HeaderValue::from_static("\"hmac-current\""),
+        );
+
+        let resp = run(
+            Method::GET,
+            "/home/timeline/http".to_string(),
+            raw_query(&query),
+            headers,
+            Bytes::new(),
+            &state,
+            300,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get(header::CONTENT_LENGTH).unwrap(), "3");
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/plain"
+        );
+        assert_eq!(resp.headers().get("content-language").unwrap(), "en-GB");
+        assert_eq!(
+            resp.headers().get("x-timeline-world").unwrap(),
+            "home/timeline/http"
+        );
+        assert_eq!(resp.headers().get("x-timeline-seq").unwrap(), "1");
+        assert_eq!(resp.headers().get_all("x-timeline-seq").iter().count(), 1);
+        assert!(resp.headers().get(header::ETAG).is_none());
+        assert!(resp.headers().get(header::ACCEPT_RANGES).is_none());
+        assert!(resp.headers().get(header::CONTENT_RANGE).is_none());
+        assert_eq!(resp.headers().get_all(header::LINK).iter().count(), 0);
+        assert_eq!(response_text(resp).await, "old");
+
+        let current = engine
+            .read(&world_path("home/timeline/http"), AccessTier::Read)
+            .unwrap()
+            .expect("current body should exist");
+        assert_eq!(current.representation.body.as_ref(), b"new");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn pipeline_timeline_head_returns_headers_without_body() {
+        let (engine, dir) = test_engine_for_server("pipeline-timeline-head");
+        let query = write_body_and_capture_timeline_query(
+            &engine,
+            "home/timeline/head",
+            b"old",
+            Vec::new(),
+        )
+        .await;
+        write_text_world_for_tests(&engine, "home/timeline/head", "new").await;
+        let state = server_state_for_engine_for_tests(engine);
+
+        let resp = run(
+            Method::HEAD,
+            "/home/timeline/head".to_string(),
+            raw_query(&query),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            301,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get(header::CONTENT_LENGTH).unwrap(), "3");
+        assert_eq!(resp.headers().get("x-timeline-seq").unwrap(), "1");
+        assert!(resp.headers().get(header::ETAG).is_none());
+        assert_eq!(response_text(resp).await, "");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn pipeline_timeline_method_wall_prevents_current_mutation() {
+        let (engine, dir) = test_engine_for_server("pipeline-timeline-method-wall");
+        let query = write_body_and_capture_timeline_query(
+            &engine,
+            "home/timeline/wall",
+            b"old",
+            Vec::new(),
+        )
+        .await;
+        write_text_world_for_tests(&engine, "home/timeline/wall", "new").await;
+        let state = server_state_for_engine_for_tests(engine.clone());
+
+        for (idx, method) in [Method::PUT, Method::POST, Method::DELETE, Method::PATCH]
+            .into_iter()
+            .enumerate()
+        {
+            let request_query = if method == Method::PATCH {
+                encoded_timeline_keys(&query)
+            } else {
+                query.clone()
+            };
+            let resp = run(
+                method,
+                "/home/timeline/wall".to_string(),
+                raw_query(&request_query),
+                HeaderMap::new(),
+                Bytes::from_static(b"evil"),
+                &state,
+                302 + idx as u64,
+            )
+            .await;
+
+            assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+            assert_eq!(resp.headers().get(header::ALLOW).unwrap(), TIMELINE_ALLOW);
+            assert_current_body(&engine, "home/timeline/wall", b"new");
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn pipeline_timeline_get_honors_read_token_gate() {
+        let (engine, dir) =
+            test_engine_for_server_with_read_token("pipeline-timeline-auth", b"reader".to_vec());
+        let address = write_body_and_capture_timeline_address_with_tier(
+            &engine,
+            "home/timeline/auth",
+            b"secret",
+            Vec::new(),
+            AccessTier::Read,
+        )
+        .await;
+        let query = timeline_query(&address);
+        let state = server_state_for_engine_for_tests(engine);
+
+        let anon = run(
+            Method::GET,
+            "/home/timeline/auth".to_string(),
+            raw_query(&query),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            306,
+        )
+        .await;
+        assert_eq!(anon.status(), StatusCode::UNAUTHORIZED);
+
+        let bad = run(
+            Method::HEAD,
+            "/home/timeline/auth".to_string(),
+            raw_query(&query),
+            header_map_with_auth(&bearer("wrong")),
+            Bytes::new(),
+            &state,
+            307,
+        )
+        .await;
+        assert_eq!(bad.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response_text(bad).await, "");
+
+        let good = run(
+            Method::GET,
+            "/home/timeline/auth".to_string(),
+            raw_query(&query),
+            header_map_with_auth(&bearer("reader")),
+            Bytes::new(),
+            &state,
+            308,
+        )
+        .await;
+        assert_eq!(good.status(), StatusCode::OK);
+        assert_eq!(response_text(good).await, "secret");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn pipeline_timeline_head_errors_have_no_body() {
+        let (engine, dir) = test_engine_for_server("pipeline-timeline-head-errors");
+        let address = write_body_and_capture_timeline_address(
+            &engine,
+            "home/timeline/head-errors",
+            b"old",
+            Vec::new(),
+        )
+        .await;
+        let state = server_state_for_engine_for_tests(engine);
+
+        let missing_row = timeline_query_parts(
+            address.generation().as_str(),
+            99,
+            address.body_sha256().as_str(),
+        );
+        let missing = run(
+            Method::HEAD,
+            "/home/timeline/head-errors".to_string(),
+            raw_query(&missing_row),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            309,
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response_text(missing).await, "");
+
+        let wrong_generation = timeline_query_parts(
+            "fedcba9876543210fedcba9876543210",
+            address.seq().get(),
+            address.body_sha256().as_str(),
+        );
+        let gen_mismatch = run(
+            Method::HEAD,
+            "/home/timeline/head-errors".to_string(),
+            raw_query(&wrong_generation),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            310,
+        )
+        .await;
+        assert_eq!(gen_mismatch.status(), StatusCode::CONFLICT);
+        assert_eq!(response_text(gen_mismatch).await, "");
+
+        let wrong_hash = timeline_query_parts(
+            address.generation().as_str(),
+            address.seq().get(),
+            "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+        );
+        let hash_mismatch = run(
+            Method::HEAD,
+            "/home/timeline/head-errors".to_string(),
+            raw_query(&wrong_hash),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            311,
+        )
+        .await;
+        assert_eq!(hash_mismatch.status(), StatusCode::CONFLICT);
+        assert_eq!(response_text(hash_mismatch).await, "");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn pipeline_timeline_query_errors_are_closed_and_head_empty() {
+        let (engine, dir) = test_engine_for_server("pipeline-timeline-query-errors");
+        let state = server_state_for_engine_for_tests(engine);
+
+        let get = run(
+            Method::GET,
+            "/home/timeline/errors".to_string(),
+            raw_query("timeline-generation=abc"),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            303,
+        )
+        .await;
+        assert_eq!(get.status(), StatusCode::BAD_REQUEST);
+
+        let head = run(
+            Method::HEAD,
+            "/home/timeline/errors".to_string(),
+            raw_query("timeline-generation=abc"),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            304,
+        )
+        .await;
+        assert_eq!(head.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response_text(head).await, "");
+
+        let huge = format!("{}x", "a=".repeat(4097));
+        let resp = run(
+            Method::GET,
+            "/home/timeline/errors".to_string(),
+            raw_query(&huge),
+            HeaderMap::new(),
+            Bytes::new(),
+            &state,
+            305,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::URI_TOO_LONG);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/bin/src/server/pipeline.rs
+++ b/bin/src/server/pipeline.rs
@@ -45,7 +45,9 @@ mod timeline_mode;
 #[cfg(test)]
 use context::trace_enabled_for_tests;
 pub(crate) use context::{init_trace_from_env, RawQuery, RequestId, TraceCtx};
-pub(crate) use timeline_mode::{TimelineVerb, TIMELINE_ALLOW};
+pub(crate) use timeline_mode::TimelineVerb;
+#[cfg(test)]
+use timeline_mode::TIMELINE_ALLOW;
 
 use axum::{
     body::Bytes,
@@ -428,17 +430,6 @@ pub(crate) async fn run(
         if !matches!(phase, Phase::Done(_) | Phase::Error { .. }) {
             trace.emit_phase(&phase);
         }
-    }
-}
-
-pub(crate) fn allow_for_options(path: &str, raw_query: RawQuery) -> &'static str {
-    let canonical = canonicalize_path(path);
-    let Ok(world) = ValidatedWorldPath::new(&canonical) else {
-        return WORLD_ALLOW;
-    };
-    match raw_query.classify_timeline_mode(&world) {
-        Ok(TimelineRequestMode::Timeline(_)) => TIMELINE_ALLOW,
-        Ok(TimelineRequestMode::Current) | Err(_) => WORLD_ALLOW,
     }
 }
 

--- a/bin/src/server/pipeline/context.rs
+++ b/bin/src/server/pipeline/context.rs
@@ -30,10 +30,6 @@ impl RawQuery {
         Self(uri.query().map(str::to_owned))
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into the pipeline in the classifier layer")
-    )]
     pub(crate) fn classify_timeline_mode(
         &self,
         world: &ValidatedWorldPath,

--- a/bin/src/server/pipeline/query.rs
+++ b/bin/src/server/pipeline/query.rs
@@ -37,7 +37,8 @@ struct TimelineFields {
     saw_unknown_timeline_field: bool,
     saw_timeline_world: bool,
     saw_unsupported_field: bool,
-    total_pairs: usize,
+    saw_pre_timeline_ordinary_field: bool,
+    timeline_pairs: usize,
 }
 
 pub(super) fn classify_raw_query(
@@ -53,21 +54,36 @@ pub(super) fn classify_raw_query(
 
     let mut fields = TimelineFields::default();
     for raw_pair in raw.split('&') {
-        fields.total_pairs += 1;
         let (raw_key, raw_value) = raw_pair.split_once('=').unwrap_or((raw_pair, ""));
-        let key = decode_query_component(raw_key)?;
-        let value = decode_query_component(raw_value)?;
+        let key = match decode_query_component(raw_key) {
+            Ok(key) => key,
+            Err(err)
+                if fields.saw_timeline_field
+                    || raw_key.starts_with("timeline")
+                    || raw_key_may_be_timeline(raw_key) =>
+            {
+                return Err(err);
+            }
+            Err(_) => {
+                fields.saw_pre_timeline_ordinary_field = true;
+                continue;
+            }
+        };
         let timeline_key = key == "timeline" || key.starts_with("timeline-");
 
+        if !fields.saw_timeline_field && !timeline_key {
+            fields.saw_pre_timeline_ordinary_field = true;
+        }
         if timeline_key {
             fields.saw_timeline_field = true;
-        }
-        if fields.saw_timeline_field && fields.total_pairs > TIMELINE_PAIR_LIMIT {
-            return Err(TimelineQueryError::TooManyTimelineFields);
+            fields.timeline_pairs += 1;
+        } else if fields.saw_timeline_field {
+            fields.saw_unsupported_field = true;
         }
 
         match key.as_str() {
             "timeline" => {
+                let value = decode_query_component(raw_value)?;
                 set_once(
                     &mut fields.mode,
                     value,
@@ -75,6 +91,7 @@ pub(super) fn classify_raw_query(
                 )?;
             }
             "timeline-generation" => {
+                let value = decode_query_component(raw_value)?;
                 set_once(
                     &mut fields.generation,
                     value,
@@ -82,6 +99,7 @@ pub(super) fn classify_raw_query(
                 )?;
             }
             "timeline-seq" => {
+                let value = decode_query_component(raw_value)?;
                 set_once(
                     &mut fields.seq,
                     value,
@@ -89,6 +107,7 @@ pub(super) fn classify_raw_query(
                 )?;
             }
             "timeline-body-sha256" => {
+                let value = decode_query_component(raw_value)?;
                 set_once(
                     &mut fields.body_sha256,
                     value,
@@ -100,9 +119,6 @@ pub(super) fn classify_raw_query(
             }
             other if other.starts_with("timeline-") => {
                 fields.saw_unknown_timeline_field = true;
-            }
-            _ if fields.saw_timeline_field => {
-                fields.saw_unsupported_field = true;
             }
             _ => {}
         }
@@ -123,6 +139,23 @@ fn set_once(
     Ok(())
 }
 
+fn raw_key_may_be_timeline(raw: &str) -> bool {
+    let mut pos = 0;
+    for byte in raw.bytes() {
+        if pos >= b"timeline".len() {
+            return byte == b'-' || byte == b'%';
+        }
+        if byte == b'%' {
+            return true;
+        }
+        if byte != b"timeline"[pos] {
+            return false;
+        }
+        pos += 1;
+    }
+    pos == b"timeline".len()
+}
+
 fn finish_classification(
     fields: TimelineFields,
     world: &ValidatedWorldPath,
@@ -137,17 +170,17 @@ fn finish_classification(
     if mode != "1" {
         return Err(TimelineQueryError::InvalidTimelineMode);
     }
-    if fields.total_pairs > TIMELINE_PAIR_LIMIT {
-        return Err(TimelineQueryError::TooManyTimelineFields);
-    }
     if fields.saw_timeline_world {
         return Err(TimelineQueryError::TimelineWorldComesFromPath);
     }
     if fields.saw_unknown_timeline_field {
         return Err(TimelineQueryError::UnknownTimelineCoordinateField);
     }
-    if fields.saw_unsupported_field {
+    if fields.saw_unsupported_field || fields.saw_pre_timeline_ordinary_field {
         return Err(TimelineQueryError::UnsupportedTimelineQueryField);
+    }
+    if fields.timeline_pairs > TIMELINE_PAIR_LIMIT {
+        return Err(TimelineQueryError::TooManyTimelineFields);
     }
 
     let generation = fields
@@ -251,6 +284,30 @@ mod tests {
     }
 
     #[test]
+    fn unrelated_malformed_value_stays_current_compatible() {
+        assert!(matches!(
+            classify("/home/config?x=%ZZ").unwrap(),
+            TimelineRequestMode::Current
+        ));
+    }
+
+    #[test]
+    fn unrelated_plain_malformed_key_stays_current_compatible() {
+        assert!(matches!(
+            classify("/home/config?x%ZZ=1").unwrap(),
+            TimelineRequestMode::Current
+        ));
+    }
+
+    #[test]
+    fn malformed_timeline_like_key_is_rejected() {
+        assert_eq!(
+            classify("/home/config?time%ZZline=1").unwrap_err(),
+            TimelineQueryError::MalformedPercentEncoding
+        );
+    }
+
+    #[test]
     fn duplicate_detection_happens_after_decoding() {
         let query = "timeline=1&timeline-generation=0123456789abcdef0123456789abcdef&timeline%2dgeneration=0123456789abcdef0123456789abcdef&timeline-seq=42";
         assert_eq!(
@@ -272,6 +329,15 @@ mod tests {
     }
 
     #[test]
+    fn encoded_timeline_stem_keys_are_classified() {
+        let query = good_query().replace("timel", "time%6c");
+        match classify(&format!("/home/config?{query}")).unwrap() {
+            TimelineRequestMode::Timeline(coordinate) => assert_eq!(coordinate.seq().get(), 42),
+            TimelineRequestMode::Current => panic!("encoded timeline keys must not be current"),
+        }
+    }
+
+    #[test]
     fn encoded_coordinate_keys_are_classified() {
         let query = good_query()
             .replace("timeline-generation", "timeline%2dgeneration")
@@ -287,11 +353,20 @@ mod tests {
     }
 
     #[test]
-    fn timeline_namespace_rejects_fifth_decoded_pair() {
+    fn timeline_namespace_rejects_extra_ordinary_pair_as_unsupported() {
         let query = format!("{}&x=1", good_query());
         assert_eq!(
             classify(&format!("/home/config?{query}")).unwrap_err(),
-            TimelineQueryError::TooManyTimelineFields
+            TimelineQueryError::UnsupportedTimelineQueryField
+        );
+    }
+
+    #[test]
+    fn timeline_world_error_is_not_masked_by_pair_cap() {
+        let query = format!("{}&timeline-world=home/other", good_query());
+        assert_eq!(
+            classify(&format!("/home/config?{query}")).unwrap_err(),
+            TimelineQueryError::TimelineWorldComesFromPath
         );
     }
 

--- a/bin/src/server/pipeline/timeline_mode.rs
+++ b/bin/src/server/pipeline/timeline_mode.rs
@@ -1,0 +1,86 @@
+use axum::{
+    body::{Body, Bytes},
+    http::{HeaderMap, Method},
+    response::Response,
+};
+
+use crate::{
+    engine_types::{AccessTier, ValidatedWorldPath},
+    server::{bad_request, method_not_allowed, uri_too_long},
+    timeline::TimelineCoordinate,
+};
+
+use super::{
+    dispatch, query, ErrorReason, Phase, RawQuery, TimelineQueryError, TimelineRequestMode,
+};
+
+pub(crate) const TIMELINE_ALLOW: &str = "GET, HEAD, OPTIONS";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum TimelineVerb {
+    Get,
+    Head,
+}
+
+pub(super) fn classify_timeline_request(
+    method: Method,
+    raw_query: RawQuery,
+    headers: HeaderMap,
+    body: Bytes,
+    tier: AccessTier,
+    world: ValidatedWorldPath,
+) -> Phase {
+    match raw_query.classify_timeline_mode(&world) {
+        Ok(TimelineRequestMode::Current) => dispatch(method, headers, body, tier, world),
+        Ok(TimelineRequestMode::Timeline(coordinate)) => {
+            dispatch_timeline(method, coordinate, tier)
+        }
+        Err(err) => timeline_query_error(method, err),
+    }
+}
+
+fn dispatch_timeline(method: Method, coordinate: TimelineCoordinate, tier: AccessTier) -> Phase {
+    let verb = match method {
+        Method::GET => TimelineVerb::Get,
+        Method::HEAD => TimelineVerb::Head,
+        _ => {
+            return Phase::Error {
+                resp: method_not_allowed(TIMELINE_ALLOW),
+                reason: ErrorReason::TimelineMethodNotAllowed,
+            };
+        }
+    };
+    Phase::TimelineDispatched {
+        verb,
+        coordinate,
+        tier,
+    }
+}
+
+fn timeline_query_error(method: Method, err: TimelineQueryError) -> Phase {
+    let (resp, reason) = match err {
+        TimelineQueryError::RawQueryTooLong => (
+            uri_too_long(&format!(
+                "timeline query exceeds {} bytes",
+                query::MAX_RAW_QUERY_BYTES
+            )),
+            ErrorReason::TimelineRequestTargetTooLong,
+        ),
+        other => {
+            let message = format!("invalid timeline query: {other:?}");
+            (bad_request(&message), ErrorReason::TimelineQuery(other))
+        }
+    };
+    Phase::Error {
+        resp: empty_body_for_head(method, resp),
+        reason,
+    }
+}
+
+fn empty_body_for_head(method: Method, resp: Response) -> Response {
+    if method != Method::HEAD {
+        return resp;
+    }
+    let (parts, _) = resp.into_parts();
+    Response::from_parts(parts, Body::empty())
+}

--- a/bin/src/server/proc.rs
+++ b/bin/src/server/proc.rs
@@ -455,7 +455,8 @@ mod tests {
             Phase::Received { .. }
             | Phase::Authenticated { .. }
             | Phase::PathValidated { .. }
-            | Phase::Dispatched { .. } => {
+            | Phase::Dispatched { .. }
+            | Phase::TimelineDispatched { .. } => {
                 panic!("execute_* returned a non-terminal Phase variant")
             }
         }

--- a/bin/src/server/response.rs
+++ b/bin/src/server/response.rs
@@ -74,6 +74,15 @@ pub(crate) fn bad_request(msg: &str) -> Response {
         .into_response()
 }
 
+pub(crate) fn uri_too_long(msg: &str) -> Response {
+    (
+        StatusCode::URI_TOO_LONG,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        format!("uri too long: {msg}\n"),
+    )
+        .into_response()
+}
+
 pub(crate) fn payload_too_large(max_bytes: usize) -> Response {
     (
         StatusCode::PAYLOAD_TOO_LARGE,

--- a/bin/src/server/route.rs
+++ b/bin/src/server/route.rs
@@ -72,10 +72,7 @@ pub(crate) async fn world_handler(
     // request extensions -- same id stamped on `x-request-id` so
     // trace output and response header agree.
     if method == Method::OPTIONS {
-        return options_response(pipeline::allow_for_options(
-            &path,
-            pipeline::RawQuery::from_uri(&uri),
-        ));
+        return options_response(crate::server::WORLD_ALLOW);
     }
     let raw_query = pipeline::RawQuery::from_uri(&uri);
     pipeline::run(method, path, raw_query, headers, body, &state, req_id).await
@@ -218,11 +215,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn world_handler_options_narrows_allow_for_valid_timeline_query() {
+    async fn world_handler_options_ignores_timeline_and_malformed_query() {
         let (engine, dir) = test_engine_for_server("world-handler-options-valid-timeline");
         let state = server_state_for_engine_for_tests(engine);
         let app = build_app(state);
-        let query = concat!(
+        let valid_timeline_query = concat!(
             "timeline=1&",
             "timeline-generation=0123456789abcdef0123456789abcdef&",
             "timeline-seq=1&",
@@ -230,20 +227,21 @@ mod tests {
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         )
         .replace("timel", "time%6c");
+        for query in [valid_timeline_query.as_str(), "timeline%ZZ=1"] {
+            let req = HttpRequest::builder()
+                .method("OPTIONS")
+                .uri(format!("/home/hello?{query}"))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
 
-        let req = HttpRequest::builder()
-            .method("OPTIONS")
-            .uri(format!("/home/hello?{query}"))
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-
-        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-        assert_eq!(
-            resp.headers().get(header::ALLOW).unwrap(),
-            crate::server::pipeline::TIMELINE_ALLOW
-        );
-        assert_eq!(response_text(resp).await, "");
+            assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+            assert_eq!(
+                resp.headers().get(header::ALLOW).unwrap(),
+                crate::server::WORLD_ALLOW
+            );
+            assert_eq!(response_text(resp).await, "");
+        }
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/bin/src/server/route.rs
+++ b/bin/src/server/route.rs
@@ -19,7 +19,7 @@ use axum::{
 
 use crate::server::{
     listen, options_response, pipeline, proc_audit_verify, proc_df, proc_du, proc_pool,
-    proc_reserved, proc_version, proc_worlds, root_hint, ServerState, WORLD_ALLOW,
+    proc_reserved, proc_version, proc_worlds, root_hint, ServerState,
 };
 
 #[cfg(feature = "mqtt")]
@@ -72,7 +72,10 @@ pub(crate) async fn world_handler(
     // request extensions -- same id stamped on `x-request-id` so
     // trace output and response header agree.
     if method == Method::OPTIONS {
-        return options_response(WORLD_ALLOW);
+        return options_response(pipeline::allow_for_options(
+            &path,
+            pipeline::RawQuery::from_uri(&uri),
+        ));
     }
     let raw_query = pipeline::RawQuery::from_uri(&uri);
     pipeline::run(method, path, raw_query, headers, body, &state, req_id).await
@@ -191,16 +194,76 @@ mod tests {
         let state = server_state_for_engine_for_tests(engine);
         let app = build_app(state);
 
+        for uri in [
+            "/home/hello?timeline%ZZ=1",
+            "/home/hello?timeline=1",
+            "/home/hello?timeline-generation=abc",
+        ] {
+            let req = HttpRequest::builder()
+                .method("OPTIONS")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+
+            assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+            assert_eq!(
+                resp.headers().get(header::ALLOW).unwrap(),
+                crate::server::WORLD_ALLOW
+            );
+            assert_eq!(response_text(resp).await, "");
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn world_handler_options_narrows_allow_for_valid_timeline_query() {
+        let (engine, dir) = test_engine_for_server("world-handler-options-valid-timeline");
+        let state = server_state_for_engine_for_tests(engine);
+        let app = build_app(state);
+        let query = concat!(
+            "timeline=1&",
+            "timeline-generation=0123456789abcdef0123456789abcdef&",
+            "timeline-seq=1&",
+            "timeline-body-sha256=",
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        .replace("timel", "time%6c");
+
         let req = HttpRequest::builder()
             .method("OPTIONS")
-            .uri("/home/hello?timeline%ZZ=1")
+            .uri(format!("/home/hello?{query}"))
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
 
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-        assert_eq!(resp.headers().get(header::ALLOW).unwrap(), WORLD_ALLOW);
+        assert_eq!(
+            resp.headers().get(header::ALLOW).unwrap(),
+            crate::server::pipeline::TIMELINE_ALLOW
+        );
         assert_eq!(response_text(resp).await, "");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn timeline_path_is_still_an_ordinary_home_world() {
+        let (engine, dir) = test_engine_for_server("timeline-path-is-world");
+        write_text_world_for_tests(&engine, "home/timeline/foo", "ordinary").await;
+        let state = server_state_for_engine_for_tests(engine);
+        let app = build_app(state);
+
+        let req = HttpRequest::builder()
+            .method("GET")
+            .uri("/timeline/foo")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_text(resp).await, "ordinary");
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/core/src/audit/timeline_address.rs
+++ b/core/src/audit/timeline_address.rs
@@ -8,21 +8,14 @@ use crate::{
     event::AuditEventKind,
     read_cache::TrackedReadConnection,
     timeline::{
-        BodySha256, TimelineAddress, TimelineAddressLookup, TimelineCoordinate, TimelineCorruption,
-        TimelineRead, TimelineSeq,
+        BodySha256, TimelineAddress, TimelineAddressLookup, TimelineCorruption, TimelineRead,
+        TimelineSeq,
     },
     world_generation::WorldGeneration,
     world_schema,
 };
 
 pub(crate) struct VerifiedBodyEvent {
-    world: ValidatedWorldPath,
-    gen: WorldGeneration,
-    seq: TimelineSeq,
-    body_sha256: BodySha256,
-}
-
-pub(super) struct VerifiedCoordinateBodyEvent {
     world: ValidatedWorldPath,
     gen: WorldGeneration,
     seq: TimelineSeq,
@@ -61,33 +54,11 @@ impl VerifiedBodyEvent {
     }
 }
 
-impl VerifiedCoordinateBodyEvent {
-    pub(super) fn new(
-        coordinate: &TimelineCoordinate,
-        gen: WorldGeneration,
-        body_sha256: BodySha256,
-    ) -> Option<Self> {
-        if coordinate.generation() != &gen || coordinate.body_sha256() != &body_sha256 {
-            return None;
-        }
-        Some(Self {
-            world: coordinate.world().clone(),
-            gen,
-            seq: coordinate.seq(),
-            body_sha256,
-        })
-    }
-}
-
 pub(super) fn timeline_address_from_verified_coordinate_body_event(
-    event: VerifiedCoordinateBodyEvent,
+    event: super::timeline_dereference::VerifiedCoordinateBodyEvent,
 ) -> TimelineAddress {
-    TimelineAddress::from_verified_body_event(VerifiedBodyEvent::new(
-        event.world,
-        event.gen,
-        event.seq,
-        event.body_sha256,
-    ))
+    let (world, gen, seq, body_sha256) = event.into_parts();
+    TimelineAddress::from_verified_body_event(VerifiedBodyEvent::new(world, gen, seq, body_sha256))
 }
 
 pub(crate) struct VerifiedBodyHead {

--- a/core/src/audit/timeline_dereference.rs
+++ b/core/src/audit/timeline_dereference.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use rusqlite::{params, OptionalExtension};
 
 use crate::{
-    engine_types::{AuditHmacKey, Representation},
+    engine_types::{AuditHmacKey, Representation, ValidatedWorldPath},
     event::AuditEventKind,
     read_cache::TrackedReadConnection,
     timeline::{
@@ -27,6 +27,37 @@ struct TimelineEventSnapshot {
     size: i64,
     content_type: String,
     headers: Vec<(String, String)>,
+}
+
+pub(super) struct VerifiedCoordinateBodyEvent {
+    world: ValidatedWorldPath,
+    gen: WorldGeneration,
+    seq: TimelineSeq,
+    body_sha256: BodySha256,
+}
+
+impl VerifiedCoordinateBodyEvent {
+    fn new(
+        coordinate: &TimelineCoordinate,
+        gen: WorldGeneration,
+        body_sha256: BodySha256,
+    ) -> Option<Self> {
+        if coordinate.generation() != &gen || coordinate.body_sha256() != &body_sha256 {
+            return None;
+        }
+        Some(Self {
+            world: coordinate.world().clone(),
+            gen,
+            seq: coordinate.seq(),
+            body_sha256,
+        })
+    }
+
+    pub(super) fn into_parts(
+        self,
+    ) -> (ValidatedWorldPath, WorldGeneration, TimelineSeq, BodySha256) {
+        (self.world, self.gen, self.seq, self.body_sha256)
+    }
 }
 
 pub(crate) fn dereference_timeline_coordinate_via_conn(
@@ -133,10 +164,15 @@ fn dereference_snapshot(
         );
     }
 
+    let Some(event) = VerifiedCoordinateBodyEvent::new(coordinate, gen, body_sha256) else {
+        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
+    };
+    let address =
+        super::timeline_address::timeline_address_from_verified_coordinate_body_event(event);
     let Some(body) = tx
         .query_row(
             "SELECT body FROM cas_bodies WHERE body_sha256=?1",
-            params![coordinate.body_sha256().as_str()],
+            params![address.body_sha256().as_str()],
             |r| r.get::<_, Vec<u8>>(0),
         )
         .optional()?
@@ -150,13 +186,6 @@ fn dereference_snapshot(
         return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
     }
 
-    let Some(event) =
-        super::timeline_address::VerifiedCoordinateBodyEvent::new(coordinate, gen, body_sha256)
-    else {
-        return Ok(corrupt(coordinate, TimelineCorruption::InvalidEventShape));
-    };
-    let address =
-        super::timeline_address::timeline_address_from_verified_coordinate_body_event(event);
     match TimelineRead::body(
         address,
         Representation::new(Bytes::from(body), row.content_type, row.headers),
@@ -718,6 +747,47 @@ mod tests {
         match dereference(&engine, &missing) {
             TimelineDereference::MissingRow(proof) => assert_eq!(proof.requested(), &missing),
             _ => panic!("expected missing row"),
+        }
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn coordinate_resolver_returns_generation_mismatch_after_chain_verification() {
+        let root = temp_root("generation-mismatch");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(key())
+            .build()
+            .unwrap();
+        let world = ValidatedWorldPath::new("home/timeline-generation").unwrap();
+
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"value"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let actual = coordinate_for_event(&engine, &world, 1);
+        let requested = TimelineCoordinate::from_wire_parts(
+            world.as_str(),
+            "fedcba9876543210fedcba9876543210",
+            actual.seq().get(),
+            actual.body_sha256().as_str(),
+        )
+        .unwrap();
+
+        match dereference(&engine, &requested) {
+            TimelineDereference::GenMismatch(proof) => {
+                assert_eq!(proof.requested(), &requested);
+                assert_eq!(proof.actual(), actual.generation());
+            }
+            _ => panic!("expected generation mismatch"),
         }
 
         drop(engine);

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -10,6 +10,7 @@ use std::collections::VecDeque;
 use bytes::Bytes;
 
 use crate::{
+    audit::timeline_dereference::TimelineDereference,
     auth,
     delete_ops::{self, DeleteRequest, DeleteTraceHooks},
     engine::{Engine, EngineError},
@@ -22,7 +23,7 @@ use crate::{
         WriteResult,
     },
     etag, event,
-    timeline::{TimelineAddress, TimelineRead},
+    timeline::{TimelineAddress, TimelineCoordinate, TimelineRead},
     world_ops, world_read_ops, AuthGate, Core,
 };
 
@@ -71,6 +72,16 @@ impl<'a> EngineOps<'a> {
         let permit = world_read_ops::authorize_read(self.core, address.world(), tier)?;
         world_read_ops::read_timeline_body(self.core, &permit, address)
             .map_err(|err| read_error_to_engine(err, Some(address.world().as_str())))
+    }
+
+    pub(crate) fn dereference_timeline_coordinate(
+        &self,
+        coordinate: &TimelineCoordinate,
+        tier: auth::Tier,
+    ) -> Result<TimelineDereference, EngineError> {
+        let permit = world_read_ops::authorize_read(self.core, coordinate.world(), tier)?;
+        world_read_ops::dereference_timeline_coordinate(self.core, &permit, coordinate)
+            .map_err(|err| read_error_to_engine(err, Some(coordinate.world().as_str())))
     }
 
     pub(crate) async fn replace<H: world_ops::WriteTraceHooks + ?Sized>(
@@ -226,17 +237,37 @@ impl Engine {
     /// method never falls back to the current live body.
     ///
     /// # Errors
-    /// - [`EngineError::Auth`] if `tier` is below `Read`.
-    /// - [`EngineError::TransientStorage`] for SQLite `BUSY`/`LOCKED`.
-    /// - [`EngineError::InsufficientStorage`] for full-disk failures.
-    /// - [`EngineError::Storage`] for audit-chain corruption or other storage
-    ///   failures.
+    /// Returns [`EngineError::Auth`] for insufficient read tier, and the normal
+    /// storage-classified [`EngineError`] variants for SQLite/audit failures.
     pub fn read_timeline_body(
         &self,
         address: &TimelineAddress,
         tier: AccessTier,
     ) -> Result<TimelineRead, EngineError> {
         EngineOps::new(self.core()).read_timeline_body(address, tier.into())
+    }
+
+    /// Dereferences untrusted timeline wire syntax into a historical outcome.
+    ///
+    /// The coordinate's world is read-authorized first; the core resolver then
+    /// verifies the subject audit row before minting an internal
+    /// [`TimelineAddress`](crate::TimelineAddress). Missing proof remains
+    /// [`TimelineDereference::UnprovenCoordinate`]. This synchronous API has the
+    /// same blocking profile as [`Engine::read`] and never falls back to the
+    /// current live body.
+    ///
+    /// # Errors
+    /// - [`EngineError::Auth`] if `tier` is below `Read`.
+    /// - [`EngineError::TransientStorage`] for SQLite `BUSY`/`LOCKED`.
+    /// - [`EngineError::InsufficientStorage`] for full-disk failures.
+    /// - [`EngineError::Storage`] for audit-chain corruption or other storage
+    ///   failures.
+    pub fn dereference_timeline_coordinate(
+        &self,
+        coordinate: &TimelineCoordinate,
+        tier: AccessTier,
+    ) -> Result<TimelineDereference, EngineError> {
+        EngineOps::new(self.core()).dereference_timeline_coordinate(coordinate, tier.into())
     }
 
     /// Replaces a world with the provided representation.

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -238,6 +238,11 @@ impl TimelineBody {
     pub fn representation(&self) -> &Representation {
         &self.representation
     }
+
+    /// Consumes the timeline body and returns its stored representation.
+    pub fn into_representation(self) -> Representation {
+        self.representation
+    }
 }
 
 impl TimelineRead {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -920,18 +920,6 @@ mod tests {
                 .clone()
                 .expect("timeline body hash"),
         };
-        let historical = engine
-            .dereference_timeline_coordinate(first_coordinate.clone(), FfiAccessTier::Read)
-            .expect("timeline coordinate dereferences");
-        assert_eq!(historical.kind, FfiTimelineDereferenceKind::Body);
-        assert_eq!(
-            historical
-                .representation
-                .expect("historical representation")
-                .body,
-            b"first"
-        );
-        assert_eq!(historical.coordinate, Some(first_coordinate));
         let first_cursor = first_event.cursor;
         initial_subscription.close();
 
@@ -943,6 +931,18 @@ mod tests {
                 FfiAccessTier::Write,
             )
             .expect("second write succeeds");
+        let historical = engine
+            .dereference_timeline_coordinate(first_coordinate.clone(), FfiAccessTier::Read)
+            .expect("timeline coordinate dereferences after overwrite");
+        assert_eq!(historical.kind, FfiTimelineDereferenceKind::Body);
+        assert_eq!(
+            historical
+                .representation
+                .expect("historical representation")
+                .body,
+            b"first"
+        );
+        assert_eq!(historical.coordinate, Some(first_coordinate));
 
         let subscription = engine
             .subscribe(
@@ -980,19 +980,50 @@ mod tests {
     #[test]
     fn timeline_coordinate_rejects_raw_invalid_ffi_fields() {
         let engine = test_engine("timeline-invalid-coordinate");
-        let err = engine
-            .dereference_timeline_coordinate(
+        let good = FfiTimelineCoordinate {
+            world: "home/timeline".to_owned(),
+            generation: "0123456789abcdef0123456789abcdef".to_owned(),
+            seq: 1,
+            body_sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_owned(),
+        };
+        for (label, coordinate) in [
+            (
+                "memory world",
                 FfiTimelineCoordinate {
                     world: "tmp/not-durable".to_owned(),
-                    generation: "0123456789abcdef0123456789abcdef".to_owned(),
-                    seq: 1,
-                    body_sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-                        .to_owned(),
+                    ..good.clone()
                 },
-                FfiAccessTier::Read,
-            )
-            .expect_err("memory timeline coordinates must be rejected at FFI boundary");
-        assert!(matches!(err, FfiError::InvalidConfig { .. }));
+            ),
+            (
+                "uppercase generation",
+                FfiTimelineCoordinate {
+                    generation: "A123456789abcdef0123456789abcdef".to_owned(),
+                    ..good.clone()
+                },
+            ),
+            (
+                "zero sequence",
+                FfiTimelineCoordinate {
+                    seq: 0,
+                    ..good.clone()
+                },
+            ),
+            (
+                "bad body hash",
+                FfiTimelineCoordinate {
+                    body_sha256: "g123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_owned(),
+                    ..good.clone()
+                },
+            ),
+        ] {
+            match engine.dereference_timeline_coordinate(coordinate, FfiAccessTier::Read) {
+                Err(FfiError::InvalidConfig { .. }) => {}
+                Err(other) => panic!("{label} returned wrong error: {other:?}"),
+                Ok(_) => panic!("{label} should fail at FFI boundary"),
+            }
+        }
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -146,6 +146,23 @@ impl FfiEngine {
         Ok(self.engine.read(&world, tier.try_into()?)?.map(Into::into))
     }
 
+    /// Dereferences an exact historical timeline coordinate.
+    ///
+    /// Foreign callers pass raw coordinate fields at the ABI boundary. The FFI
+    /// adapter immediately validates them into the core `TimelineCoordinate`
+    /// proof before the Engine touches storage.
+    pub fn dereference_timeline_coordinate(
+        &self,
+        coordinate: FfiTimelineCoordinate,
+        tier: FfiAccessTier,
+    ) -> Result<FfiTimelineDereference, FfiError> {
+        let coordinate = coordinate.try_into_core()?;
+        Ok(self
+            .engine
+            .dereference_timeline_coordinate(&coordinate, tier.try_into()?)?
+            .into())
+    }
+
     /// Replaces a world with the provided representation.
     pub fn replace(
         &self,
@@ -890,7 +907,32 @@ mod tests {
             .expect("first write succeeds");
         let first = initial_subscription.next(1_000);
         assert_eq!(first.kind, FfiSubscriptionNextKind::Event);
-        let first_cursor = first.event.expect("first live event").cursor;
+        let first_event = first.event.expect("first live event");
+        let first_coordinate = FfiTimelineCoordinate {
+            world: first_event.timeline_world.clone().expect("timeline world"),
+            generation: first_event
+                .timeline_generation
+                .clone()
+                .expect("timeline generation"),
+            seq: first_event.timeline_seq.expect("timeline seq"),
+            body_sha256: first_event
+                .timeline_body_sha256
+                .clone()
+                .expect("timeline body hash"),
+        };
+        let historical = engine
+            .dereference_timeline_coordinate(first_coordinate.clone(), FfiAccessTier::Read)
+            .expect("timeline coordinate dereferences");
+        assert_eq!(historical.kind, FfiTimelineDereferenceKind::Body);
+        assert_eq!(
+            historical
+                .representation
+                .expect("historical representation")
+                .body,
+            b"first"
+        );
+        assert_eq!(historical.coordinate, Some(first_coordinate));
+        let first_cursor = first_event.cursor;
         initial_subscription.close();
 
         engine
@@ -933,6 +975,24 @@ mod tests {
         let event = live.event.expect("live event");
         assert_eq!(event.verb, FfiChangeVerb::Append);
         assert_eq!(event.path, "home/events/a");
+    }
+
+    #[test]
+    fn timeline_coordinate_rejects_raw_invalid_ffi_fields() {
+        let engine = test_engine("timeline-invalid-coordinate");
+        let err = engine
+            .dereference_timeline_coordinate(
+                FfiTimelineCoordinate {
+                    world: "tmp/not-durable".to_owned(),
+                    generation: "0123456789abcdef0123456789abcdef".to_owned(),
+                    seq: 1,
+                    body_sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_owned(),
+                },
+                FfiAccessTier::Read,
+            )
+            .expect_err("memory timeline coordinates must be rejected at FFI boundary");
+        assert!(matches!(err, FfiError::InvalidConfig { .. }));
     }
 
     #[test]

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, fmt};
 use elastik_core::{
     is_valid_token, AccessTier, AuditVerify, AuthGate, ChangeEvent, ChangeVerb, DeleteMetadata,
     DfSnapshot, EngineBuildError, EngineError, EtagMatcher, PoolSnapshot, Preconditions,
-    ReadResult, Representation, SubscriptionCursor, SubscriptionResume, WorldUsage, WriteKind,
+    ReadResult, Representation, SubscriptionCursor, SubscriptionResume, TimelineAddress,
+    TimelineCoordinate, TimelineCorruption, TimelineDereference, WorldUsage, WriteKind,
     WriteResult,
 };
 
@@ -121,6 +122,55 @@ pub struct FfiDeleteMetadata {
 pub struct FfiReadResult {
     pub representation: FfiRepresentation,
     pub etag: String,
+}
+
+/// Timeline coordinate DTO accepted at the FFI boundary.
+///
+/// This is raw wire data until the adapter converts it into the core
+/// `TimelineCoordinate` proof type.
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]
+pub struct FfiTimelineCoordinate {
+    pub world: String,
+    pub generation: String,
+    pub seq: i64,
+    pub body_sha256: String,
+}
+
+/// Historical dereference outcome returned by `FfiEngine`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiTimelineDereferenceKind {
+    Body,
+    GenMismatch,
+    BodyHashMismatch,
+    NonBodyEvent,
+    MissingRow,
+    Unproven,
+    Corrupt,
+    /// The Engine returned a timeline state this FFI binding does not yet
+    /// recognize. Treat as indeterminate and upgrade the binding.
+    Unknown,
+}
+
+/// Timeline corruption category exposed through FFI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum FfiTimelineCorruption {
+    MissingBodyForPresentRow,
+    BodyHashMismatch,
+    InvalidEventShape,
+    /// The Engine returned a corruption category this FFI binding does not yet
+    /// recognize. Treat as storage corruption and upgrade the binding.
+    Unknown,
+}
+
+/// Result of dereferencing a historical timeline coordinate through FFI.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct FfiTimelineDereference {
+    pub kind: FfiTimelineDereferenceKind,
+    pub representation: Option<FfiRepresentation>,
+    pub coordinate: Option<FfiTimelineCoordinate>,
+    pub actual_generation: Option<String>,
+    pub actual_body_sha256: Option<String>,
+    pub corruption: Option<FfiTimelineCorruption>,
 }
 
 /// Write result kind returned by Engine write verbs.
@@ -489,6 +539,126 @@ impl From<ReadResult> for FfiReadResult {
         Self {
             representation: value.representation.into(),
             etag: value.etag,
+        }
+    }
+}
+
+impl FfiTimelineCoordinate {
+    pub(crate) fn try_into_core(self) -> Result<TimelineCoordinate, FfiError> {
+        TimelineCoordinate::from_wire_parts(self.world, self.generation, self.seq, self.body_sha256)
+            .map_err(|err| FfiError::InvalidConfig {
+                message: format!("invalid timeline coordinate: {err}"),
+            })
+    }
+
+    fn from_timeline_coordinate(value: &TimelineCoordinate) -> Self {
+        Self {
+            world: value.world().to_string(),
+            generation: value.generation().as_str().to_owned(),
+            seq: value.seq().get(),
+            body_sha256: value.body_sha256().as_str().to_owned(),
+        }
+    }
+
+    fn from_timeline_address(value: &TimelineAddress) -> Self {
+        Self {
+            world: value.world().to_string(),
+            generation: value.generation().as_str().to_owned(),
+            seq: value.seq().get(),
+            body_sha256: value.body_sha256().as_str().to_owned(),
+        }
+    }
+}
+
+impl From<TimelineCorruption> for FfiTimelineCorruption {
+    fn from(value: TimelineCorruption) -> Self {
+        match value {
+            TimelineCorruption::MissingBodyForPresentRow => Self::MissingBodyForPresentRow,
+            TimelineCorruption::BodyHashMismatch => Self::BodyHashMismatch,
+            TimelineCorruption::InvalidEventShape => Self::InvalidEventShape,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<TimelineDereference> for FfiTimelineDereference {
+    fn from(value: TimelineDereference) -> Self {
+        match value {
+            TimelineDereference::Body(body) => {
+                let coordinate = FfiTimelineCoordinate::from_timeline_address(body.address());
+                Self {
+                    kind: FfiTimelineDereferenceKind::Body,
+                    representation: Some(body.into_representation().into()),
+                    coordinate: Some(coordinate),
+                    actual_generation: None,
+                    actual_body_sha256: None,
+                    corruption: None,
+                }
+            }
+            TimelineDereference::GenMismatch(proof) => Self {
+                kind: FfiTimelineDereferenceKind::GenMismatch,
+                representation: None,
+                coordinate: Some(FfiTimelineCoordinate::from_timeline_coordinate(
+                    proof.requested(),
+                )),
+                actual_generation: Some(proof.actual().as_str().to_owned()),
+                actual_body_sha256: None,
+                corruption: None,
+            },
+            TimelineDereference::BodyHashMismatch(proof) => Self {
+                kind: FfiTimelineDereferenceKind::BodyHashMismatch,
+                representation: None,
+                coordinate: Some(FfiTimelineCoordinate::from_timeline_coordinate(
+                    proof.requested(),
+                )),
+                actual_generation: None,
+                actual_body_sha256: Some(proof.actual_body_sha256().as_str().to_owned()),
+                corruption: None,
+            },
+            TimelineDereference::NonBodyEvent(proof) => Self {
+                kind: FfiTimelineDereferenceKind::NonBodyEvent,
+                representation: None,
+                coordinate: Some(FfiTimelineCoordinate::from_timeline_coordinate(
+                    proof.requested(),
+                )),
+                actual_generation: None,
+                actual_body_sha256: None,
+                corruption: None,
+            },
+            TimelineDereference::MissingRow(proof) => Self {
+                kind: FfiTimelineDereferenceKind::MissingRow,
+                representation: None,
+                coordinate: Some(FfiTimelineCoordinate::from_timeline_coordinate(
+                    proof.requested(),
+                )),
+                actual_generation: None,
+                actual_body_sha256: None,
+                corruption: None,
+            },
+            TimelineDereference::UnprovenCoordinate(coordinate) => Self {
+                kind: FfiTimelineDereferenceKind::Unproven,
+                representation: None,
+                coordinate: Some(FfiTimelineCoordinate::from_timeline_coordinate(&coordinate)),
+                actual_generation: None,
+                actual_body_sha256: None,
+                corruption: None,
+            },
+            TimelineDereference::Corrupt { coordinate, reason } => Self {
+                kind: FfiTimelineDereferenceKind::Corrupt,
+                representation: None,
+                coordinate: Some(FfiTimelineCoordinate::from_timeline_coordinate(&coordinate)),
+                actual_generation: None,
+                actual_body_sha256: None,
+                corruption: Some(reason.into()),
+            },
+            _ => Self {
+                kind: FfiTimelineDereferenceKind::Unknown,
+                representation: None,
+                coordinate: None,
+                actual_generation: None,
+                actual_body_sha256: None,
+                corruption: None,
+            },
         }
     }
 }

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -1725,6 +1725,8 @@ def _is_never_persisted_header(n: str) -> bool:
         or n.startswith("x-b3-")
         or n.startswith("x-amzn-")
         or n.startswith("cf-")
+        # Core-owned historical dereference proof headers.
+        or n.startswith("x-timeline-")
         or n in _NON_PERSISTED_RESPONSE_HEADERS
     )
 


### PR DESCRIPTION
## Stack

Depends on #355 (`stack/22r39-http-query-classifier`).

Base: `stack/22r39-http-query-classifier` @ `0fd1580`.
Head: `stack/22r40-http-timeline-query-wall` @ `cb1943f`.

The user waived stack depth only. File budget, production diff budget, type-seal checks, endpoint checks, tests, and subagent QA still apply.

## What changed

This layer wires the already-planned timeline coordinate contract through the HTTP adapter:

- adds GET/HEAD timeline dereference behind `mode=timeline`
- narrows valid timeline OPTIONS to `GET, HEAD, OPTIONS`
- walls off PUT/POST/DELETE/PATCH when timeline coordinates are present
- runs the historical SQLite dereference through `spawn_blocking`
- preserves read-token gating before dereference
- returns historical body bytes plus proof headers:
  - `x-timeline-world`
  - `x-timeline-generation`
  - `x-timeline-seq`
  - `x-timeline-body-sha256`
- denies persisted/replayed `x-timeline-*` metadata in both Rust and Python header policy mirrors
- keeps timeline path names ordinary worlds; timeline is query mode, not a route namespace

## Plan alignment

Matches the HTTP timeline query-wall layer of `design_notes/PLAN-http-timeline-dereference.md`:

- path validation happens before query-mode classification
- valid timeline coordinates dispatch to a separate read-only phase
- malformed or unsupported timeline query state fails closed instead of falling back to current-world reads
- missing promised CAS bytes remain corruption in v1; no `Expired`/`NeverRetained` outcome is invented in this layer

## Budget

Production additions: 496 / 500, including new files and excluding tests.

Largest changed production files:

- `core/src/engine_ops.rs`: 500 / 500 lines
- `bin/src/server/http/semantics.rs`: 498 / 500 lines
- `bin/src/server/pipeline.rs`: 460 / 500 lines
- `bin/src/server/handler/timeline.rs`: 201 lines
- `bin/src/server/pipeline/timeline_mode.rs`: 86 lines

## Type-seal / endpoint checks

- `VerifiedCoordinateBodyEvent` is resolver-local. The proof is minted only after chain verification and coordinate/event checks, then consumed by timeline address lookup.
- `Engine::dereference_timeline_coordinate` requires a `TimelineCoordinate`, not raw query strings.
- HTTP parsing produces coordinates only through the core constructor.
- The endpoint uses `spawn_blocking` around the blocking dereference path.
- Read auth is checked before dereference.
- Timeline proof headers are core-owned and cannot be persisted as representation metadata.

## Review ledger

Confirmed P0-P2 after fresh clearing: zero.

- Helmholtz / Popper: found encoded timeline keys could fall through as current reads. Fixed by decoding timeline keys before classification and adding encoded-key tests for parser, method wall, and OPTIONS narrowing.
- Bacon / Mencius + Noether: found proof could be minted too broadly. Fixed by moving `VerifiedCoordinateBodyEvent` into the resolver module with a private constructor.
- Galileo / Poincare + Locke + Harvey: confirmed timeline path uses `spawn_blocking`; flagged current-world sync read and current HEAD error-body parity as pre-existing debt, not introduced here.
- Copernicus / QA: enforced AGENTS.md budget and validation requirements; earlier over-budget state was reduced below 500 production additions and all changed production files are at or below 500 lines.
- Feynman clearing: zero confirmed P0-P2; only P3 future-wildcard fail-closed mapping remains.
- Avicenna clearing: zero confirmed P0-P2; independently confirmed production additions stay under 500 and max production file size is 500/500.

## Residual ledger

- `TimelineDereference` and `EngineError` wildcard mappings fail closed as 500; this is P3 future-variant hardening, not a current bypass.
- Malformed timeline query errors happen before auth, matching malformed-request behavior and leaking no world contents.
- `cargo check --no-default-features` still reports two pre-existing warnings outside this layer: `engine_error.rs` unused import and `auth::is_valid_token` dead code.

## Validation

Manual checks run after staging:

- `cargo fmt --manifest-path core/Cargo.toml -- --check`
- `cargo fmt --manifest-path bin/Cargo.toml -- --check`
- `python tools/header_policy_scan.py --offline`
- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path bin/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path core/Cargo.toml` — 191 passed, 2 ignored, 17 doctests passed
- `cargo test --manifest-path bin/Cargo.toml` — 145 passed
- `cargo check --manifest-path core/Cargo.toml --no-default-features` — pass with the two pre-existing warnings listed above
- `git diff --cached --check`

Pre-push hook also passed:

- Rust format
- Rust clippy
- Rust tests
- version consistency: 8.3.0
- bundled SQLite check: libsqlite3-sys 0.38.0 bundles SQLite 3.53.1
- `cargo audit` for core/bin/ffi locks
- Python SDK smoke
- header policy scanner and missing-baseline negative test
- JS syntax
- whitespace check