### PR TITLE
sdk: add timeline coordinate reads

### DIFF
--- a/bin/src/server/http/README.md
+++ b/bin/src/server/http/README.md
@@ -93,6 +93,18 @@ timeline address for that exact world. They identify the historical write; they
 are not a body payload. A later `GET /home/task/a` reads the current value and
 may observe a newer write than the event that woke the client.
 
+Use the timeline coordinate to read that exact historical body:
+
+```text
+GET  /home/task/a?timeline=1&timeline-generation=<gen>&timeline-seq=<seq>&timeline-body-sha256=<sha256>
+HEAD /home/task/a?timeline=1&timeline-generation=<gen>&timeline-seq=<seq>&timeline-body-sha256=<sha256>
+```
+
+The path supplies the world. `timeline-world` is never accepted in the query.
+Historical `GET` responses return the full body. Historical `GET` and `HEAD`
+responses include `X-Timeline-*` proof headers. `HEAD` returns headers only.
+They do not emit current-world `ETag`, range, or monitor-link headers.
+
 ## `/proc/*`
 
 The binary exposes text-shaped `/proc/*` endpoints over HTTP. These are adapter

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -85,9 +85,40 @@ Observed lower-layer results:
 
 Required before marking upper stack layers ready:
 
+- GitHub CI green for #359 after the pushed repair.
+
+Completed after the current cascade:
+
 - top-of-stack local validation after the current `22r41` merge commit;
-- GitHub CI green for #359 after the pushed repair;
-- subagent QA rerun on the repaired artifact until no P0-P3 findings remain.
+- subagent QA rerun on the repaired artifact until no P0-P3 findings remained.
+
+Final local validation on `stack/22r41-sdk-timeline-coordinate`:
+
+- `cargo fmt --manifest-path core/Cargo.toml -- --check`
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path core/Cargo.toml`
+- `cargo fmt --manifest-path bin/Cargo.toml -- --check`
+- `cargo clippy --manifest-path bin/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path bin/Cargo.toml`
+- `cargo fmt --manifest-path ffi/Cargo.toml -- --check`
+- `cargo clippy --manifest-path ffi/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path ffi/Cargo.toml`
+- `python sdk/tests/test_tools.py`
+- `python sdk/tests/e2e_blackbox.py`
+- `git diff --check`
+- adjacent branch ancestry check from `22r19` through `22r41`
+- stale verifier grep across stack refs:
+  `git grep -n 'verify_world_connection' <branch> -- core/src`
+
+Observed final local results:
+
+- core: 197 passed, 2 ignored; doc tests 17 passed.
+- bin: 149 passed.
+- ffi: 23 passed; doc tests 0 passed/0 failed.
+- SDK tools: pass.
+- SDK e2e blackbox: 248 checks passed.
+- ancestry check: ok.
+- stale `verify_world_connection`: no matches in stack refs.
 
 ## Review Ledger
 
@@ -114,6 +145,15 @@ approvals and findings:
 - Nietzsche the 2nd, Ramanujan/Poincare: approve, no P0-P2 findings; noted
   duplicate patch-id history as the intentional cost of no-rebase/no-squash.
 
-This ledger does not claim the current post-cascade artifact is clear. The live
-source of truth after this commit is: local top validation, GitHub CI, and the
-fresh subagent QA round.
+Final QA round after the current cascade:
+
+- Sagan the 2nd, type-seal/invariant conservation: APPROVE, no P0-P3 findings.
+- Anscombe the 2nd, AGENTS/stack process QA: APPROVE, no P0-P3 findings.
+- Zeno the 2nd, precondition/HTTP semantics: found one P3 in
+  `Last-Event-ID` parsing. Fixed at `22r19` by using `HeaderMap::get_all`,
+  rejecting duplicates, rejecting empty/non-ASCII-decimal values, and removing
+  trimming. Targeted listen tests passed. Zeno re-reviewed and APPROVED with no
+  P0-P3 findings.
+
+This ledger does not claim GitHub CI is green. The live source of truth after
+push is GitHub CI, especially #359.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -523,8 +523,9 @@ Fixes added after that round:
   `u64` range. The test now parses the emitted id before replay and passes the
   original opaque cursor string as `Last-Event-ID`.
 - `22r20` through `22r41`: the `d039199` repair was propagated upward by merge
-  cascade. No rebase or squash was used. The final pushed `22r41` head after
-  the second cascade is `314d089`.
+  cascade. No rebase or squash was used. The final `22r41` merge head after
+  the second cascade was `314d089`; the later ledger closeout commit was
+  `6e8536a`.
 
 Local validation after the canonical cursor fix:
 
@@ -539,7 +540,8 @@ Local validation after the canonical cursor fix:
 Post-push state at the time this addendum was written:
 
 - `22r19`: `d039199`.
-- `22r41`: `314d089`.
+- `22r41` merge cascade head: `314d089`.
+- `22r41` ledger closeout commit: `6e8536a`.
 - GitHub CI had restarted and was still pending; this addendum does not claim
   remote CI is green.
 - A fresh independent review round was started against `d039199`/`314d089`.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -417,6 +417,16 @@ after push remains GitHub CI.
 
 ## FFI Dereference + Opaque Cursor Addendum
 
+Active skills checked in this round:
+
+- `stacked-pr`
+- `rust-type-seal-enforcement`
+- `http-type-seal-review`
+- `precondition-problem`
+- `monte-carlo-review`
+- `assign-scientist-reviewers`
+- `delegation-doctrine`
+
 Fresh review round after the local cascade repair:
 
 - Wegener the 2nd, Mencius/Locke type-seal review: CLEAN. Verified that raw

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -107,12 +107,23 @@ Additional repair work after the first ledger pass:
 - `22r24` and `22r26`: changed missing local timeline storage/read-cache `None`
   to `TimelineRead::Unproven`, not `Gone`. Physical absence is not delete-ledger
   proof.
+- `22r35`: kept read-cache DB path construction on a sealed
+  `ValidatedWorldPath` by adding `world::validated_world_db(...)`; the raw
+  string now appears only after the path helper for legacy cache-map keys and
+  metrics.
 - `22r40`: moved ordinary `OPTIONS` ahead of raw-query extraction so
   `OPTIONS /home/a?timeline%ZZ=1` remains ordinary world-route `OPTIONS`.
 - `22r19..22r41`: propagated the #359 bin-test contract fix upward by merge
   cascade, without rebasing or squashing. The cascade had no merge conflicts.
+- `22r35..22r41`: propagated the read-cache path-seal repair upward by merge
+  cascade, without rebasing or squashing. The cascade had no merge conflicts.
 - `22r21..22r41`: propagated the new fixes upward by merge cascade, without
   rebasing or squashing.
+- History note: the older `5e40d80` test-contract commit still appears in
+  upper branch history after the `94c40d1` downshift. They have the same patch
+  ID and no current tree diff in the adjacent stack layer. Keeping both is the
+  intentional cost of the no-rebase/no-squash repair policy, not a second
+  behavioral change.
 
 ## Validation Evidence
 
@@ -168,6 +179,9 @@ Layer-specific validation after the #359 CI repair:
   bin/Cargo.toml` passed, 145 tests.
 - `stack/22r41-sdk-timeline-coordinate`: `cargo test --manifest-path
   core/Cargo.toml` passed, 197 tests plus 17 doc tests; 2 ignored.
+- `stack/22r35-read-cache-ops-split`: after the read-cache path-seal repair,
+  core fmt, core clippy, and `cargo test --manifest-path core/Cargo.toml
+  read_cache` passed; read-cache filter observed 24 passed.
 
 Reported additional subagent spot checks from the repair round, not re-run by
 this ledger commit:
@@ -240,8 +254,22 @@ Current addendum review round:
 - Faraday the 2nd, QA/enforcement: code APPROVE, process not fully cleared.
   Confirmed no current code P0-P2 finding, but kept lower-stack process gates:
   #330-#335 should drain bottom-up, and #359 must be reviewed before #336+
-  leaves draft/repair mode.
+  leaves draft/repair mode. Follow-up process repair converted #344 and #345
+  back to draft so the visible upper stack again matches that gate.
+- Banach the 2nd, lens Popper/Bacon: APPROVE, no P0-P3 findings for the #359
+  CI repair. Retested exact commit `94c40d1` and confirmed the quota/proc
+  assertions still check the retained-CAS accounting contract rather than
+  weakening it.
+- Noether the 2nd, lens Mencius/Noether: APPROVE, no P0-P2 findings; reported a
+  P3 read-cache path-seal hygiene issue. Fixed in `22r35` by routing DB path
+  construction through `world::validated_world_db(...)`.
+- Nietzsche the 2nd, lens Ramanujan/Poincare: APPROVE, no P0-P2 findings; noted
+  the duplicate patch-id history entry and stale "ready to push" wording. This
+  ledger now records the duplicate-history reason and removes the stale push
+  wording.
 
-The current code repair is ready to push when the current `HEAD` static checks
-remain clean. The upper implementation stack is not ready to mark non-draft
-until the lower process gates above are cleared.
+The repaired cascade is intended to remain pushed to origin with local and
+remote refs matching. GitHub CI status is the live source of truth after each
+push; queued checks are not treated as pass or failure. The upper implementation
+stack is not ready to mark non-draft until #359 is reviewed with green CI and
+the lower process gates above are cleared.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -1,0 +1,156 @@
+# Stack 22 Cascade Repair Ledger
+
+Status: final QA clearing round passed.
+
+This ledger records the repair of the forked Stack 22 cascade:
+`stack/22r19-audit-verify-world-target` through
+`stack/22r41-sdk-timeline-coordinate`.
+
+## Why The Depth Exception Applies
+
+AGENTS.md normally caps open cascade depth at 3-4 layers. This repair is being
+tracked under the Stack repair exception. The durable-ledger condition is
+cleared by the final QA round recorded below.
+
+- the user explicitly authorised an unlimited repair cascade for this stack;
+- the work repairs an already-existing fork caused by merging the lower stack
+  while `22r19..22r41` still pointed at the old `stack/21` head;
+- no new product feature scope was added during the repair;
+- each semantic fix was placed at the lowest affected layer and propagated
+  upward by merge cascade;
+- this file records branches, validation, reviewer lenses, QA findings, and the
+  fresh round that cleared P0-P2.
+
+The exception waives stack depth only. It does not waive type seals,
+validation, or Fleet Review Convergence.
+
+## Branch Scope
+
+The exact final `22r41` commit cannot be embedded in this file, because adding
+this file changes that commit. Validators must use `git rev-parse HEAD` on
+`stack/22r41-sdk-timeline-coordinate` for the exact artifact under review.
+
+Repair heads before adding this ledger:
+
+| Branch | Short head |
+|---|---|
+| `stack/22r19-audit-verify-world-target` | `c96f9cb22756` |
+| `stack/22r20-timeline-address-extraction` | `6e106660c64f` |
+| `stack/22r21-timeline-cas-deref` | `53b4bf4783dc` |
+| `stack/22r22-timeline-read-cache` | `82be0b6ccedb` |
+| `stack/22r23-public-timeline-contract` | `dff21472af26` |
+| `stack/22r24-public-timeline-resolver` | `03d3c440555b` |
+| `stack/22r25-subscription-types-module` | `119bfbd68d24` |
+| `stack/22r26-world-read-ops-module` | `fe9a31306123` |
+| `stack/22r27-change-event-timeline-address` | `58c1473d27b2` |
+| `stack/22r28-delete-subject-proof` | `6377e73f000d` |
+| `stack/22r29-sse-timeline-address` | `5a0eb7b08227` |
+| `stack/22r30-timeline-address-wire-parse` | `612936bdb804` |
+| `stack/22r31-http-timeline-deref-plan` | `e5823782f4e9` |
+| `stack/22r32-timeline-deref-result-type` | `a51f322a31bc` |
+| `stack/22r33-audit-header-split` | `dccc1a347255` |
+| `stack/22r34-timeline-deref-audit-home` | `193f8828b184` |
+| `stack/22r35-read-cache-ops-split` | `2c7d35fe6c07` |
+| `stack/22r36-timeline-coordinate-resolver` | `8d446eb2a953` |
+| `stack/22r37-pipeline-context-split` | `bf940636d558` |
+| `stack/22r38-http-raw-query-plumbing` | `0884d7337999` |
+| `stack/22r39-http-query-classifier` | `34c4268b1bfa` |
+| `stack/22r40-http-timeline-query-wall` | `b35e49dd1ca9` |
+| `stack/22r41-sdk-timeline-coordinate` | `050182ebce1f` |
+
+## Fixes Applied
+
+- `22r19`: merged current `stack/21-cas-schema` into the old `22r19` base and
+  kept audit verification bound to `ValidatedWorldPath`.
+- `22r19`: hardened `chain_head` against rowid-trusting rollback by keeping
+  `COUNT(*)` semantics and explicit tamper-test assertions.
+- `22r19`: added the AGENTS.md Stack repair exception so repo policy now has an
+  explicit repair-exception path; the user authorisation remains part of the
+  working conversation, not something this file alone can prove.
+- `22r20`: preserved generation-aware event HMAC verification while exposing
+  only read projections needed by HMAC sinks.
+- `22r23`: kept public timeline read projections public without exposing public
+  constructors for timeline addresses.
+- `22r26`: preserved the `world_read_ops` module split and kept read APIs on
+  `ValidatedWorldPath` / `ReadPermit`.
+- `22r35`: preserved the read-cache module split while carrying forward
+  `OpeningTransition` failure/drop as `Evicted`, not `Tombstone`.
+- `22r36`: moved the timeline-coordinate read-cache proof fix to the layer that
+  introduced coordinate dereference: `with_tracked_conn(data,
+  coordinate.world(), ...)`, not `coordinate.world().as_str()`.
+- `22r37..22r41`: propagated the repaired lower layers upward by merge cascade,
+  without rebasing or squashing.
+
+## Validation Evidence
+
+Local validation on the repaired stack tip before this ledger file:
+
+- `cargo fmt --manifest-path core/Cargo.toml -- --check`
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path core/Cargo.toml`
+- `git diff --check`
+- `rg -n "^(<<<<<<<|=======|>>>>>>>)" AGENTS.md core/src design_notes`
+- `rg -n "with_tracked_conn\([^\n]*as_str\(\)|read_world\([^&]|read_world\(.*as_str\(\)" core/src -g "*.rs"`; observed only the legitimate `read_world` call/definition matches, and no `with_tracked_conn(...as_str())` match.
+- adjacent ancestry check from `22r19` through `22r41`
+- `git merge-base --is-ancestor stack/21-cas-schema stack/22r19-audit-verify-world-target`
+- `git merge-base --is-ancestor stack/22r36-timeline-coordinate-resolver stack/22r41-sdk-timeline-coordinate`
+
+Observed core result: 193 passed, 2 ignored; doc tests 17 passed.
+
+Reported additional subagent spot checks from the repair round, not re-run by
+this ledger commit:
+
+- core timeline tests: 40 passed;
+- core read-cache tests: 24 passed;
+- core engine-subscribe tests: 3 passed;
+- core replay-after tests: 2 passed;
+- bin timeline tests: 21 passed;
+- bin listen tests: 4 passed.
+
+## Review Ledger
+
+Active skills checked:
+
+- `stacked-pr`
+- `delegation-doctrine`
+- `assign-scientist-reviewers`
+- `rust-type-seal-enforcement`
+- `precondition-problem`
+- `monte-carlo-review`
+- `http-type-seal-review`
+- `http-peer-protocol`
+
+Round 1 reviewers:
+
+- Herschel, lens Poincare/Bacon: stack topology QA. Result: no P0-P2 finding
+  for assigned Round 1 slice.
+- Kepler, lens Mencius/Noether: type-seal QA. Result: no P0-P2 finding for
+  assigned Round 1 slice.
+- Peirce, lens Popper/precondition/Bacon: timeline/precondition QA. Result:
+  no P0-P2 finding for assigned Round 1 slice.
+- Meitner, lens QA enforcement/Locke/Sagan: process QA. Result: not approved.
+
+Round 1 confirmed findings:
+
+- P1: Stack depth exception existed only in chat/PR wording, not in AGENTS.md.
+  Fix: add the AGENTS.md Stack repair exception at the lowest repaired layer
+  and cascade it upward.
+- P1: PR ledgers described stale remote heads, not the exact repaired local
+  artifact. Fix: add this durable stack repair ledger.
+- P2: one PR body had incomplete Fleet Review ledger shape. Fix: this
+  stack-wide ledger names lenses, skills, QA/enforcement, findings, fixes, and
+  validation evidence for the repaired artifact.
+- P3: platform-gated validation should be named when cited. Fix: do not claim
+  Windows unlink semantics are proven by Unix-only file-permission coverage.
+
+Final clearing round:
+
+- Hegel, lens QA enforcement/Locke/Sagan: process QA. Result: AGENTS/process
+  QA approve, no P0-P3 findings. Cleared the prior stack-depth, stale-ledger,
+  and incomplete-ledger findings against the updated AGENTS.md and this repair
+  ledger.
+- Dalton, lens Sagan/Dirac: ledger wording QA. Result: ledger wording QA
+  approve, no P0-P3 findings. Cleared the overclaim, user-authorisation,
+  raw-string-sweep, Round 1 wording, and reported-evidence wording risks.
+
+The stack is ready to push when the current `HEAD` static checks remain clean.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -463,6 +463,11 @@ Fixes added after that round:
   makes the SDK blackbox reject integer-only emitted SSE ids. Legacy decimal
   `Last-Event-ID` input remains intentionally covered by bin/core tests as
   compatibility, but emitted ids must be `epoch:seq`.
+- Local topology: the stale checked-out
+  `stack/22r42-sdk-reactor-timeline-plan` pointer was renamed to
+  `wip/sdk-reactor-timeline-plan` after confirming its committed head is fully
+  contained in `stack/22r41-sdk-timeline-coordinate`. Its dirty worktree files
+  were preserved and are not part of this stack push.
 
 Full local validation after those fixes on
 `stack/22r41-sdk-timeline-coordinate`:

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -486,3 +486,94 @@ Full local validation after those fixes on
 This addendum still does not claim GitHub CI is green. The local cascade is
 ahead of origin until pushed, and GitHub CI remains the post-push source of
 truth.
+
+## Canonical SSE Cursor Addendum
+
+Timestamp: 2026-06-15 00:43 +10:00.
+
+Active skills checked in this round:
+
+- `stacked-pr`
+- `rust-type-seal-enforcement`
+- `http-type-seal-review`
+- `precondition-problem`
+- `monte-carlo-review`
+- `assign-scientist-reviewers`
+- `delegation-doctrine`
+
+Fresh review after the first post-push cascade found one real P2:
+
+- Poincare the 3rd, Mencius/Popper precondition review: BLOCK. The SDK
+  blackbox helper no longer treated the entire SSE id as an integer, but it
+  still used Python `int(seq)` as the sequence parser. That accepted strings
+  such as `+42`, `0042`, whitespace-padded values, and negative-looking values
+  that the Rust contract rejects. The source-of-truth contract is
+  `<32 lowercase hex epoch>:<canonical decimal event id>`.
+- Hooke the 3rd, Hypatia/Locke QA: BLOCK. The ledger did not yet record a
+  fresh zero-P0-P2 round after the latest fixes, which violates the stack
+  repair evidence rule in `AGENTS.md`.
+- Faraday the 3rd, Poincare topology review: CLEAN P0-P2 for the first
+  cascade graph.
+
+Fixes added after that round:
+
+- `22r19`: `d039199 sdk: enforce canonical SSE cursor in blackbox`
+  tightens the SDK blackbox helper to require a 32-character lowercase hex
+  epoch, a non-empty ASCII-digit sequence, canonical decimal rendering, and
+  `u64` range. The test now parses the emitted id before replay and passes the
+  original opaque cursor string as `Last-Event-ID`.
+- `22r20` through `22r41`: the `d039199` repair was propagated upward by merge
+  cascade. No rebase or squash was used. The final pushed `22r41` head after
+  the second cascade is `314d089`.
+
+Local validation after the canonical cursor fix:
+
+- On `22r19`, `python sdk/tests/e2e_blackbox.py --no-build`: 234 checks passed.
+- On `22r41`, `python -m py_compile sdk/tests/e2e_blackbox.py`: passed.
+- On `22r41`, `git diff --check`: passed.
+- On `22r41`, `python sdk/tests/e2e_blackbox.py --no-build`: 249 checks
+  passed.
+- Pre-push fast gates passed while pushing `22r19` and again while pushing the
+  second `22r20` through `22r41` cascade.
+
+Post-push state at the time this addendum was written:
+
+- `22r19`: `d039199`.
+- `22r41`: `314d089`.
+- GitHub CI had restarted and was still pending; this addendum does not claim
+  remote CI is green.
+- A fresh independent review round was started against `d039199`/`314d089`.
+
+Fresh review outcome:
+
+- Hume the 3rd, Mencius/Popper precondition review: the previous SDK blackbox
+  P2 is fixed. Hume raised a new disputed P2 because HTTP still accepts bare
+  decimal `Last-Event-ID`.
+- Mendel the 3rd, Heisenberg/Locke verifier: FALSE POSITIVE. Newly emitted
+  SSE ids are canonical opaque `epoch:seq` cursors, while bare decimal
+  `Last-Event-ID` is an intentional legacy input syntax. Core maps it to
+  `SubscriptionResume::legacy_event_id`, whose replay plan is foreign/stale,
+  not current-process replay.
+- Franklin the 3rd, Popper/Bacon verifier: FALSE POSITIVE. Targeted tests
+  passed for canonical cursor parsing, legacy decimal foreign replay, stale
+  cursor reset, HTTP parse acceptance of current cursor plus legacy decimal,
+  non-canonical rejection, and SSE reset rebasing.
+- Confucius the 3rd, Poincare topology review: CLEAN P0-P2. Confirmed
+  `d039199` is an ancestor of every `22r20` through `22r41`, adjacent branches
+  remain merge-cascade contiguous, local refs match origin, and top head is
+  `314d089`.
+- Leibniz the 3rd, Bacon/Sagan evidence review: no P0-P2 findings. P3 only:
+  remote CI was still pending, and the ledger addendum was local evidence until
+  committed.
+- Schrodinger the 3rd, Hypatia/Locke QA: BLOCK at the time of review because
+  this fresh zero-P0-P2 outcome was not yet recorded and the ledger file was
+  still dirty.
+
+P3 fixed after that round:
+
+- `sdk-js/README.md` no longer shows an emitted SSE event id as `"42"`. The
+  event-shape example now uses `"0123456789abcdef0123456789abcdef:42"` for the
+  `id` field and keeps `"42"` only as the timeline sequence.
+
+The final substantive review state after adjudication is zero confirmed P0-P2.
+Remote GitHub CI remains the live post-push source of truth.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -110,7 +110,7 @@ Final local validation on `stack/22r41-sdk-timeline-coordinate`:
 - stale verifier grep across stack refs:
   `git grep -n 'verify_world_connection' <branch> -- core/src`
 
-Observed final local results:
+Observed local results before the follow-up cursor audit:
 
 - core: 197 passed, 2 ignored; doc tests 17 passed.
 - bin: 149 passed.
@@ -154,6 +154,58 @@ Final QA round after the current cascade:
   rejecting duplicates, rejecting empty/non-ASCII-decimal values, and removing
   trimming. Targeted listen tests passed. Zeno re-reviewed and APPROVED with no
   P0-P3 findings.
+
+Follow-up QA round after reopening the repaired stack:
+
+- Popper the 2nd, process/CI QA: BLOCK for upper-stack advancement. #359 was
+  green, but #344-#350 still had failing checks from stack layers that were not
+  independently compilable.
+- Fermat the 2nd, protocol/precondition QA: BLOCK. Found P1 stale/ahead
+  `Last-Event-ID` handling: a pre-restart cursor could become the live floor
+  and silently suppress new live events after the engine counter reset. Also
+  found P3 non-canonical decimal aliases such as `00042`.
+- Mencius the 2nd, type-seal/invariant QA: BLOCK on the same P3 canonical
+  cursor issue; no P0-P2 type-seal findings after the earlier repair.
+
+Fixes added after that round:
+
+- `SubscriptionRecvError::CursorAhead { since, newest }` now distinguishes a
+  cursor from another process id space from ordinary ring-buffer lag.
+- `replay_after` checks `last_issued_event_id` under the event-log lock and
+  queues `CursorAhead` with live floor `0` instead of trusting the client
+  cursor.
+- SSE renders `CursorAhead` as a `reset` event with `id: newest`, rebasing
+  browser `Last-Event-ID` state into the current process id space.
+- `Last-Event-ID` parsing now requires canonical decimal round-trip; `0` is
+  accepted, while `00` and `00042` are rejected.
+- Stack-local compile break in #344 was fixed by preserving
+  `ValidatedWorldPath` at the read-cache call site and by making the matching
+  test call `Core::read_world(&subject)`.
+
+Validation after those fixes on `stack/22r41-sdk-timeline-coordinate`:
+
+- focused core cursor tests: `replay_after*` plus
+  `engine_subscription_with_stale_cursor_signals_then_streams_live` passed.
+- focused bin cursor tests: `last_event_id` plus `sse_reset_event` passed.
+- `cargo fmt --manifest-path core/Cargo.toml --check`
+- `cargo fmt --manifest-path bin/Cargo.toml --check`
+- `cargo fmt --manifest-path ffi/Cargo.toml --check`
+- `cargo test --manifest-path core/Cargo.toml`: 199 passed, 2 ignored; doc
+  tests 17 passed.
+- `cargo test --manifest-path bin/Cargo.toml`: 150 passed.
+- `cargo test --manifest-path ffi/Cargo.toml`: 23 passed; doc tests 0
+  passed/0 failed.
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
+  -D clippy::undocumented_unsafe_blocks`
+- `cargo clippy --manifest-path bin/Cargo.toml -- -D warnings`
+- `cargo clippy --manifest-path ffi/Cargo.toml -- -D warnings`
+- `python sdk/tests/e2e_blackbox.py`: 248 checks passed.
+- `python sdk/tests/test_tools.py`: pass.
+- `python -m compileall -q sdk/src sdk/tests`: pass.
+- `python tools/version_consistency_check.py`: 8.3.0 ok.
+- `python tools/audit_chain_verify.py --self-test`: ok.
+- `python tools/header_policy_scan.py --self-test` and
+  `python tools/header_policy_scan.py --offline`: no drift.
 
 This ledger does not claim GitHub CI is green. The live source of truth after
 push is GitHub CI, especially #359.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -89,6 +89,11 @@ Additional repair work after the first ledger pass:
 - `22r19` hidden-base gap: opened PR #359 for
   `stack/22r19-audit-verify-world-target` against `stack/21-cas-schema`, so #336
   no longer rests on an untracked branch.
+- `22r19` hidden-base CI fix: #359 failed bin tests because CAS retained-body
+  accounting had changed the storage quota contract, but the matching bin test
+  assertions lived only in `22r20+`. Moved that test-contract fix down to
+  `22r19` (`bin: align quota tests with retained cas accounting`) and cascaded
+  it upward.
 - `22r21`: added `TimelineRead::NeverRetained`,
   `TimelineRead::AddressMismatch`, and `TimelineRead::Unproven` so absence and
   mismatch states keep their proof strength instead of collapsing into
@@ -104,6 +109,8 @@ Additional repair work after the first ledger pass:
   proof.
 - `22r40`: moved ordinary `OPTIONS` ahead of raw-query extraction so
   `OPTIONS /home/a?timeline%ZZ=1` remains ordinary world-route `OPTIONS`.
+- `22r19..22r41`: propagated the #359 bin-test contract fix upward by merge
+  cascade, without rebasing or squashing. The cascade had no merge conflicts.
 - `22r21..22r41`: propagated the new fixes upward by merge cascade, without
   rebasing or squashing.
 
@@ -146,6 +153,21 @@ Observed current-head results:
 - sdk tools: pass.
 - sdk e2e blackbox: 248 checks passed.
 - ffi: 23 passed; doc tests 0 passed/0 failed.
+
+Layer-specific validation after the #359 CI repair:
+
+- `stack/22r19-audit-verify-world-target`: `cargo test --manifest-path
+  bin/Cargo.toml` passed, 108 tests.
+- `stack/22r19-audit-verify-world-target`: `cargo test --manifest-path
+  core/Cargo.toml` passed, 157 tests plus 5 doc tests; 2 ignored.
+- `stack/22r19-audit-verify-world-target`: core/bin fmt and clippy checks
+  passed.
+- `stack/22r41-sdk-timeline-coordinate`: core/bin/ffi fmt passed after the
+  repair cascade.
+- `stack/22r41-sdk-timeline-coordinate`: `cargo test --manifest-path
+  bin/Cargo.toml` passed, 145 tests.
+- `stack/22r41-sdk-timeline-coordinate`: `cargo test --manifest-path
+  core/Cargo.toml` passed, 197 tests plus 17 doc tests; 2 ignored.
 
 Reported additional subagent spot checks from the repair round, not re-run by
 this ledger commit:

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -269,3 +269,57 @@ Full local validation after those fixes on `stack/22r41-sdk-timeline-coordinate`
 - `python tools/header_policy_scan.py --offline --report
   header-policy-report.md`: no drift; temporary report removed.
 - `git diff --check`: pass.
+
+Additional QA round after pushing those fixes:
+
+- Lorentz the 2nd, Popper/Bacon: BLOCK. Confirmed FFI cursor repair was clean,
+  but found P3 `Core::delete_world_blocking(&str)` still left the physical
+  delete helper unsealed.
+- Poincare the 2nd, Mencius/Noether: BLOCK. Found the same P3 and also found
+  P3 `#[cfg(test)] pub(crate) fn write_world(...)` did not carry the
+  `test_only_` bypass name.
+- Godel the 2nd, process QA: PENDING. Current-head CI was pending with no
+  current failures; ledger and stack topology were honest but not converged.
+
+Fixes added after that round:
+
+- `Core::delete_world_blocking` now requires `&ValidatedWorldPath`, and
+  `delete_ops` passes the delete permit's sealed world into the physical delete
+  step.
+- The direct test fixture writer is now named `test_only_write_world`, and
+  upper stack delete tests were updated at their first introducing layer
+  (`22r28`).
+
+Focused validation after those fixes:
+
+- source scan for `delete_world_blocking(&self, world: &str)`,
+  `delete_world_blocking(world_name)`, `pub(crate) fn write_world`, and
+  `.write_world(`: no matches.
+- `cargo fmt --manifest-path core/Cargo.toml --check`
+- `cargo test --manifest-path core/Cargo.toml delete_ops -- --nocapture`:
+  6 passed.
+- `cargo test --manifest-path core/Cargo.toml store -- --nocapture`: 5 passed.
+
+Full local validation after those fixes on `stack/22r41-sdk-timeline-coordinate`:
+
+- `cargo fmt --manifest-path core/Cargo.toml --check`
+- `cargo fmt --manifest-path bin/Cargo.toml --check`
+- `cargo fmt --manifest-path ffi/Cargo.toml --check`
+- `cargo test --manifest-path core/Cargo.toml`: 199 passed, 2 ignored; doc
+  tests 17 passed.
+- `cargo test --manifest-path bin/Cargo.toml`: 150 passed.
+- `cargo test --manifest-path ffi/Cargo.toml`: 24 passed; doc tests 0
+  passed/0 failed.
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
+  -D clippy::undocumented_unsafe_blocks`
+- `cargo clippy --manifest-path bin/Cargo.toml -- -D warnings`
+- `cargo clippy --manifest-path ffi/Cargo.toml -- -D warnings`
+- `python sdk/tests/e2e_blackbox.py`: 248 checks passed.
+- `python sdk/tests/test_tools.py`: pass.
+- `python -m compileall -q sdk/src sdk/tests`: pass.
+- `python tools/version_consistency_check.py`: 8.3.0 ok.
+- `python tools/audit_chain_verify.py --self-test`: ok.
+- `python tools/header_policy_scan.py --self-test`: ok.
+- `python tools/header_policy_scan.py --offline --report
+  header-policy-report.md`: no drift; temporary report removed.
+- `git diff --check`: pass.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -87,10 +87,10 @@ Required before marking upper stack layers ready:
 
 - GitHub CI green for #359 after the pushed repair.
 
-Completed after the current cascade:
+Still required after the current cascade:
 
 - top-of-stack local validation after the current `22r41` merge commit;
-- subagent QA rerun on the repaired artifact until no P0-P3 findings remained.
+- subagent QA rerun on the repaired artifact until no P0-P3 findings remain.
 
 Final local validation on `stack/22r41-sdk-timeline-coordinate`:
 
@@ -209,3 +209,63 @@ Validation after those fixes on `stack/22r41-sdk-timeline-coordinate`:
 
 This ledger does not claim GitHub CI is green. The live source of truth after
 push is GitHub CI, especially #359.
+
+Additional QA round after the cursor repair:
+
+- Huygens the 2nd, Popper/Bacon: BLOCK. Found P2 FFI cursor-ahead handling:
+  `SubscriptionRecvError::CursorAhead` was explicit but mapped to terminal
+  `Unknown`, so an FFI subscriber using a stale cursor would lose the live
+  stream after the first reset signal.
+- Hume the 2nd, Mencius/Noether: BLOCK. Confirmed the same P2 and found P3
+  tombstone lifecycle APIs still accepted raw `&str` world names.
+- Gauss the 2nd, process/CI QA: PENDING, no current-head bad checks after
+  deduping stale cancelled checks; live CI remained pending.
+
+Fixes added after that round:
+
+- FFI now exposes `FfiSubscriptionNextKind::CursorAhead` plus `since` and
+  `newest` fields on `FfiSubscriptionNext`.
+- FFI treats `CursorAhead` as non-terminal, so the subscription pump remains
+  live and later matching writes are still delivered.
+- Core tombstone lifecycle APIs now require `&ValidatedWorldPath` at the
+  `Core` and `ReadCache` boundaries.
+- The stack-local timeline read-cache tombstone test was repaired at its
+  first introducing layer (`22r22`) instead of only at the tip.
+
+Focused validation after those fixes:
+
+- `cargo fmt --manifest-path core/Cargo.toml --check`
+- `cargo fmt --manifest-path ffi/Cargo.toml --check`
+- `cargo test --manifest-path core/Cargo.toml read_cache -- --nocapture`:
+  24 passed.
+- `cargo test --manifest-path core/Cargo.toml tombstone -- --nocapture`:
+  4 passed.
+- `cargo test --manifest-path ffi/Cargo.toml
+  subscription_next_reports_cursor_ahead_then_keeps_live_stream_open --
+  --nocapture`: 1 passed.
+- `cargo test --manifest-path ffi/Cargo.toml subscription_next --
+  --nocapture`: 4 passed.
+
+Full local validation after those fixes on `stack/22r41-sdk-timeline-coordinate`:
+
+- `cargo fmt --manifest-path core/Cargo.toml --check`
+- `cargo fmt --manifest-path bin/Cargo.toml --check`
+- `cargo fmt --manifest-path ffi/Cargo.toml --check`
+- `cargo test --manifest-path core/Cargo.toml`: 199 passed, 2 ignored; doc
+  tests 17 passed.
+- `cargo test --manifest-path bin/Cargo.toml`: 150 passed.
+- `cargo test --manifest-path ffi/Cargo.toml`: 24 passed; doc tests 0
+  passed/0 failed.
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings
+  -D clippy::undocumented_unsafe_blocks`
+- `cargo clippy --manifest-path bin/Cargo.toml -- -D warnings`
+- `cargo clippy --manifest-path ffi/Cargo.toml -- -D warnings`
+- `python sdk/tests/e2e_blackbox.py`: 248 checks passed.
+- `python sdk/tests/test_tools.py`: pass.
+- `python -m compileall -q sdk/src sdk/tests`: pass.
+- `python tools/version_consistency_check.py`: 8.3.0 ok.
+- `python tools/audit_chain_verify.py --self-test`: ok.
+- `python tools/header_policy_scan.py --self-test`: ok.
+- `python tools/header_policy_scan.py --offline --report
+  header-policy-report.md`: no drift; temporary report removed.
+- `git diff --check`: pass.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -414,3 +414,60 @@ Focused validation:
 
 This addendum still does not claim GitHub CI is green. The live source of truth
 after push remains GitHub CI.
+
+## FFI Dereference + Opaque Cursor Addendum
+
+Fresh review round after the local cascade repair:
+
+- Wegener the 2nd, Mencius/Locke type-seal review: CLEAN. Verified that raw
+  FFI timeline coordinate fields stop at the adapter boundary, are immediately
+  converted with `TimelineCoordinate::from_wire_parts`, then pass through
+  read auth, `ReadPermit`, read-cache tracking, audit-chain verification, and
+  proof-bearing `TimelineDereference` outcomes. No P0-P3 authority leaks.
+- Turing the 2nd, Popper/Bacon falsification review: BLOCK. Found P1 SDK
+  blackbox still accepted integer-only SSE ids; P2 FFI dereference test read
+  the coordinate before overwriting the world; P3 FFI invalid-coordinate test
+  covered only the memory-world case. Also noted that decimal
+  `Last-Event-ID` is still intentionally accepted as a legacy resume input,
+  so the correct claim is: newly emitted SSE ids are opaque `epoch:seq`
+  cursors, while legacy decimal resume input remains compatibility syntax and
+  is treated as a foreign/stale cursor by core replay planning.
+- Cicero the 3rd, AGENTS/skills process QA: BLOCK. Found that the current
+  local head lacked ledger evidence for `f7fbf67` and the latest validation.
+  Found no code/process P2 apart from stale ledger evidence.
+- Kierkegaard the 2nd, Noether/Poincare topology review: local graph clean.
+  Confirmed `22r19` through `22r41` form a contiguous merge cascade and
+  `22r41` contains local `22r40`, `f11d172`, and `f7fbf67`. Noted that origin
+  is stale until the local cascade is pushed, and that the local-only
+  `stack/22r42-sdk-reactor-timeline-plan` pointer should not be pushed as part
+  of this repair.
+
+Fixes added after that round:
+
+- `22r40`: `4996418 Strengthen FFI timeline dereference tests`
+  moves the FFI historical dereference assertion after a later append to the
+  same world, so a current-body fallback would fail, and expands raw coordinate
+  rejection coverage to memory worlds, uppercase generation, zero sequence, and
+  malformed body hash.
+- `22r41`: `c99ffbe Require opaque SSE cursor ids in SDK blackbox`
+  makes the SDK blackbox reject integer-only emitted SSE ids. Legacy decimal
+  `Last-Event-ID` input remains intentionally covered by bin/core tests as
+  compatibility, but emitted ids must be `epoch:seq`.
+
+Full local validation after those fixes on
+`stack/22r41-sdk-timeline-coordinate`:
+
+- `cargo test --manifest-path core/Cargo.toml --features unstable-engine`:
+  201 passed, 2 ignored; doc tests 17 passed.
+- `cargo test --manifest-path bin/Cargo.toml --features unstable-engine`:
+  150 passed.
+- `cargo test --manifest-path ffi/Cargo.toml`: 25 passed; doc tests 0
+  passed/0 failed.
+- `python sdk/tests/test_tools.py`: pass.
+- `python sdk/tests/e2e_blackbox.py`: 249 checks passed with a real release
+  build, including opaque cursor replay and historical timeline reads after
+  overwrite.
+
+This addendum still does not claim GitHub CI is green. The local cascade is
+ahead of origin until pushed, and GitHub CI remains the post-push source of
+truth.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -1,6 +1,7 @@
 # Stack 22 Cascade Repair Ledger
 
-Status: final QA clearing round passed.
+Status: current code QA clearing round passed; lower-stack drain remains a
+separate process gate before upper stack layers should be marked ready.
 
 This ledger records the repair of the forked Stack 22 cascade:
 `stack/22r19-audit-verify-world-target` through
@@ -81,6 +82,31 @@ Repair heads before adding this ledger:
 - `22r37..22r41`: propagated the repaired lower layers upward by merge cascade,
   without rebasing or squashing.
 
+## Current Repair Addendum
+
+Additional repair work after the first ledger pass:
+
+- `22r19` hidden-base gap: opened PR #359 for
+  `stack/22r19-audit-verify-world-target` against `stack/21-cas-schema`, so #336
+  no longer rests on an untracked branch.
+- `22r21`: added `TimelineRead::NeverRetained`,
+  `TimelineRead::AddressMismatch`, and `TimelineRead::Unproven` so absence and
+  mismatch states keep their proof strength instead of collapsing into
+  `Expired`, `Gone`, or generic corruption.
+- `22r21`: changed missing CAS body handling: pre-retention rows become
+  `NeverRetained`; rows at or after the retention floor become
+  `Corrupt(MissingBodyForPresentRow)`. No missing CAS row is currently promoted
+  to `Expired` without pruning proof.
+- `22r21`: annotated the touched production `expect("hmac key")` with a local
+  HMAC/AuditHmacKey invariant and `#[allow(clippy::expect_used)]`.
+- `22r24` and `22r26`: changed missing local timeline storage/read-cache `None`
+  to `TimelineRead::Unproven`, not `Gone`. Physical absence is not delete-ledger
+  proof.
+- `22r40`: moved ordinary `OPTIONS` ahead of raw-query extraction so
+  `OPTIONS /home/a?timeline%ZZ=1` remains ordinary world-route `OPTIONS`.
+- `22r21..22r41`: propagated the new fixes upward by merge cascade, without
+  rebasing or squashing.
+
 ## Validation Evidence
 
 Local validation on the repaired stack tip before this ledger file:
@@ -96,6 +122,30 @@ Local validation on the repaired stack tip before this ledger file:
 - `git merge-base --is-ancestor stack/22r36-timeline-coordinate-resolver stack/22r41-sdk-timeline-coordinate`
 
 Observed core result: 193 passed, 2 ignored; doc tests 17 passed.
+
+Current-head validation on `stack/22r41-sdk-timeline-coordinate` after the
+addendum repairs:
+
+- `git diff --check`
+- `cargo fmt --manifest-path core/Cargo.toml -- --check`
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path core/Cargo.toml`
+- `cargo fmt --manifest-path bin/Cargo.toml -- --check`
+- `cargo clippy --manifest-path bin/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path bin/Cargo.toml`
+- `python sdk/tests/test_tools.py`
+- `python sdk/tests/e2e_blackbox.py`
+- `cargo fmt --manifest-path ffi/Cargo.toml -- --check`
+- `cargo clippy --manifest-path ffi/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path ffi/Cargo.toml`
+
+Observed current-head results:
+
+- core: 197 passed, 2 ignored; doc tests 17 passed.
+- bin: 145 passed.
+- sdk tools: pass.
+- sdk e2e blackbox: 248 checks passed.
+- ffi: 23 passed; doc tests 0 passed/0 failed.
 
 Reported additional subagent spot checks from the repair round, not re-run by
 this ledger commit:
@@ -153,4 +203,23 @@ Final clearing round:
   approve, no P0-P3 findings. Cleared the overclaim, user-authorisation,
   raw-string-sweep, Round 1 wording, and reported-evidence wording risks.
 
-The stack is ready to push when the current `HEAD` static checks remain clean.
+Current addendum review round:
+
+- Aquinas the 2nd, lens Popper/precondition: APPROVE, no P0-P2 findings.
+  Confirmed missing CAS bodies no longer become `Expired` without proof, missing
+  subject storage becomes `Unproven`, and `OPTIONS` short-circuits before query
+  decoding.
+- Bacon the 2nd, lens Noether/Mencius: APPROVE, no P0-P2 findings. Confirmed
+  type seals remain intact, `event_hmac` has the required invariant/allow, and
+  HTTP/SDK boundaries do not treat raw coordinates as proof.
+- Ramanujan the 2nd, lens Euclid/HTTP topology: APPROVE, no P0-P2 findings.
+  Confirmed `OPTIONS` ignores timeline query shape while GET/HEAD still fail
+  malformed timeline queries at the query boundary.
+- Faraday the 2nd, QA/enforcement: code APPROVE, process not fully cleared.
+  Confirmed no current code P0-P2 finding, but kept lower-stack process gates:
+  #330-#335 should drain bottom-up, and #359 must be reviewed before #336+
+  leaves draft/repair mode.
+
+The current code repair is ready to push when the current `HEAD` static checks
+remain clean. The upper implementation stack is not ready to mark non-draft
+until the lower process gates above are cleared.

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -618,7 +618,7 @@ Event shape:
 ```js
 {
     type:   "put" | "post" | "delete" | "lag" | "message" | "error",
-    id:     "42",
+    id:     "0123456789abcdef0123456789abcdef:42",
     path:   "/home/task/123",
     method: "PUT",
     etag:   "hmac-...",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -542,6 +542,15 @@ Handler rules:
 - `world` is still accepted as a compatibility alias for `path`.
 - `body` is a current `GET path` result at dispatch time. It is not a
   historical dereference of the SSE event's timeline fields.
+- When a handler needs the exact body named by the SSE event, build a
+  `TimelineCoordinate` from the event and dereference it explicitly:
+
+  ```python
+  coord = elastik.TimelineCoordinate.from_event(event)
+  old_body = e.get_timeline(coord)
+  old_meta = e.head_timeline(coord)
+  ```
+
 - You can do normal Python side effects inside the handler.
 - Advanced users may return `Reply`, `Archive`, `MoveTo`, or `Drop` action
   objects, but they are not required.
@@ -567,6 +576,8 @@ manual control.
 These are exported but not part of the beginner path:
 
 - `request()`: raw HTTP escape hatch.
+- `TimelineCoordinate.from_event(event)`, `get_timeline()`, and
+  `head_timeline()`: exact historical body dereference for `/listen/*` events.
 - `binary_info()`, `is_running()`, `default_url()`: launcher diagnostics.
 - `TrustedShellPool`: warm local shell process pool for trusted `@listen`
   handlers. It can execute arbitrary commands; do not feed it untrusted input.

--- a/sdk/src/elastik/__init__.py
+++ b/sdk/src/elastik/__init__.py
@@ -60,6 +60,12 @@ Handlers may either do side effects directly (normal Python) or return
 Action objects like Reply/Archive/MoveTo/Drop for declarative routing.
 `world` is accepted as an older name for the same value as `path`.
 
+For exact historical reads from `/listen/*`, parse the event's timeline fields
+and dereference that coordinate:
+
+    coord = elastik.TimelineCoordinate.from_event(event)
+    body = elastik.get_timeline(coord)
+
 Bundled binary lives at `elastik/_bin/elastik-core[.exe]` and is invoked
 as a child process. No FFI, no compile-on-install. Same shape as
 NumPy shipping precompiled C kernels.
@@ -86,6 +92,8 @@ from elastik.sdk import (
     Response,
     ServerError,
     Unauthorized,
+    TimelineCoordinate,
+    TimelineMeta,
     WorldMeta,
     WorldRef,
     WorldReader,
@@ -142,6 +150,7 @@ __all__ = [
     "Unauthorized", "Forbidden", "NotFound", "PreconditionFailed",
     "PayloadTooLarge", "InsufficientStorage", "ServerError",
     "Response",
+    "TimelineCoordinate", "TimelineMeta",
     "WorldMeta", "WorldRef", "WorldReader", "FakeElastik",
     # Reactor sugar
     "listen", "run", "clear_routes", "clear_lifecycle_hooks",
@@ -157,6 +166,7 @@ __all__ = [
     # Module-level convenience (NumPy-shaped)
     "put", "put_text", "put_json", "put_gzip", "put_csv", "put_struct",
     "post", "get", "get_cached", "get_gzip", "get_text", "get_json",
+    "get_timeline", "head_timeline",
     "get_csv", "get_struct", "head", "delete", "exists", "sizeof",
     "checksum", "is_audited", "verify", "diff", "preview", "copy",
     "ls", "tree", "rm", "mv", "du",
@@ -424,6 +434,16 @@ def get_json(
         if_range=if_range,
         headers=headers,
     )
+
+
+def get_timeline(coordinate: TimelineCoordinate) -> bytes:
+    """elastik.get_timeline(TimelineCoordinate.from_event(event)) -> bytes"""
+    return _client().get_timeline(coordinate)
+
+
+def head_timeline(coordinate: TimelineCoordinate) -> TimelineMeta:
+    """elastik.head_timeline(coordinate) -> historical response headers."""
+    return _client().head_timeline(coordinate)
 
 
 def get_gzip(path: str) -> bytes:

--- a/sdk/src/elastik/sdk.py
+++ b/sdk/src/elastik/sdk.py
@@ -18,6 +18,7 @@ import csv
 import difflib
 import fnmatch
 import gzip as gzip_mod
+import hashlib
 import io
 import struct
 import textwrap
@@ -25,7 +26,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import warnings
-from collections.abc import Iterable, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -47,6 +48,7 @@ _RESERVED_WORLD_NAMES = {
     "var",
     "var/log",
 }
+_MAX_TIMELINE_SEQ = 2**63 - 1
 _REPRESENTATION_KWARGS = {
     "content_type",
     "content_encoding",
@@ -295,6 +297,107 @@ WorldMeta = TypedDict(
     },
     total=False,
 )
+
+
+TimelineMeta = TypedDict(
+    "TimelineMeta",
+    {
+        "content-type": str,
+        "content-length": str,
+        "content-encoding": str,
+        "content-language": str,
+        "content-disposition": str,
+        "cache-control": str,
+        "x-timeline-world": str,
+        "x-timeline-generation": str,
+        "x-timeline-seq": str,
+        "x-timeline-body-sha256": str,
+    },
+    total=False,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineCoordinate:
+    """Wire coordinate for a historical body emitted by `/listen/*`.
+
+    This is syntax, not proof. The SDK validates shape and builds the
+    timeline query; the server still proves the coordinate against the audit
+    row before returning bytes.
+    """
+
+    world: str
+    generation: str
+    seq: int
+    body_sha256: str
+
+    def __post_init__(self) -> None:
+        world = _canonical_world_name(str(self.world))
+        _validate_world_name(world)
+        if world.split("/", 1)[0] in {"tmp", "dev", "sys"}:
+            raise ValueError("timeline coordinates require durable worlds")
+
+        generation = str(self.generation)
+        if not _is_lower_hex(generation, 32):
+            raise ValueError("timeline generation must be 32 lowercase hex characters")
+
+        if isinstance(self.seq, bool) or not isinstance(self.seq, (int, str)):
+            raise ValueError("timeline seq must be a positive integer")
+        try:
+            seq = int(self.seq)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("timeline seq must be a positive integer") from exc
+        if seq <= 0 or seq > _MAX_TIMELINE_SEQ:
+            raise ValueError("timeline seq must be a positive signed 64-bit integer")
+
+        body_sha256 = str(self.body_sha256)
+        if not _is_lower_hex(body_sha256, 64):
+            raise ValueError("timeline body sha256 must be 64 lowercase hex characters")
+
+        object.__setattr__(self, "world", world)
+        object.__setattr__(self, "generation", generation)
+        object.__setattr__(self, "seq", seq)
+        object.__setattr__(self, "body_sha256", body_sha256)
+
+    @classmethod
+    def from_parts(
+        cls,
+        world: str,
+        generation: str,
+        seq: int | str,
+        body_sha256: str,
+    ) -> "TimelineCoordinate":
+        """Build a coordinate from explicit wire fields."""
+        return cls(world, generation, seq, body_sha256)
+
+    @classmethod
+    def from_event(cls, event: Mapping[str, str]) -> "TimelineCoordinate":
+        """Build a coordinate from an SDK `/listen/*` event dict."""
+        missing = [
+            name
+            for name in (
+                "path",
+                "timeline-world",
+                "timeline-generation",
+                "timeline-seq",
+                "timeline-body-sha256",
+            )
+            if not event.get(name)
+        ]
+        if missing:
+            raise ValueError("event is missing timeline fields: " + ", ".join(missing))
+
+        coordinate = cls.from_parts(
+            event["timeline-world"],
+            event["timeline-generation"],
+            event["timeline-seq"],
+            event["timeline-body-sha256"],
+        )
+        path_world = _canonical_world_name(event["path"])
+        _validate_world_name(path_world)
+        if path_world != coordinate.world:
+            raise ValueError("event path does not match timeline world")
+        return coordinate
 
 
 class ElastikError(Exception):
@@ -808,6 +911,26 @@ class Elastik(MutableMapping[str, bytes]):
             return None
         return json.loads(text)
 
+    def get_timeline(self, coordinate: TimelineCoordinate) -> bytes:
+        """GET the historical body named by a `/listen/*` timeline coordinate."""
+        _require_timeline_coordinate(coordinate, "get_timeline")
+        target = _timeline_request_target(coordinate)
+        resp = self._timeline_request("GET", coordinate)
+        if resp.status >= 400:
+            _raise_for_response(resp, "GET", target)
+        _validate_timeline_response(resp, coordinate, "GET", target, verify_body=True)
+        return resp.body
+
+    def head_timeline(self, coordinate: TimelineCoordinate) -> TimelineMeta:
+        """HEAD the historical representation named by a timeline coordinate."""
+        _require_timeline_coordinate(coordinate, "head_timeline")
+        target = _timeline_request_target(coordinate)
+        resp = self._timeline_request("HEAD", coordinate)
+        if resp.status >= 400:
+            _raise_for_response(resp, "HEAD", target)
+        _validate_timeline_response(resp, coordinate, "HEAD", target)
+        return resp.headers  # type: ignore[return-value]
+
     def get_gzip(self, path: str) -> bytes:
         """GET and gzip-decompress the body."""
         body = self.get(path)
@@ -1180,6 +1303,8 @@ class Elastik(MutableMapping[str, bytes]):
         The body is never embedded in the stream. Timeline fields are
         historical coordinates for durable body writes; GET/HEAD with the
         path reads the current value, not necessarily the signalled value.
+        Use TimelineCoordinate.from_event(event) plus get_timeline() when
+        the handler needs the exact body named by the event.
         """
         url = self.url + "/listen/" + _quote_listen_pattern(pattern)
         h = {}
@@ -1323,7 +1448,20 @@ class Elastik(MutableMapping[str, bytes]):
         headers: dict[str, str] | None = None,
     ) -> Response:
         """Raw HTTP escape hatch for methods plus headers that pass wire checks."""
-        url = self.url + _quote_path(path)
+        return self._request_url(method, self.url + _quote_path(path), path, body, headers)
+
+    def _timeline_request(self, method: str, coordinate: TimelineCoordinate) -> Response:
+        target = _timeline_request_target(coordinate)
+        return self._request_url(method, self.url + target, target, None, None)
+
+    def _request_url(
+        self,
+        method: str,
+        url: str,
+        debug_path: str,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Response:
         h = dict(headers or {})
         _reject_wire_headers(h)
         if self.bearer_token:
@@ -1341,12 +1479,12 @@ class Elastik(MutableMapping[str, bytes]):
                 _log.debug(
                     "%s %s -> %d %dB %.1fms",
                     method,
-                    path,
+                    debug_path,
                     response.status,
                     len(response.body),
                     elapsed_ms,
                 )
-                self._debug_after_response(method, path, h, response, elapsed_ms)
+                self._debug_after_response(method, debug_path, h, response, elapsed_ms)
                 return response
         except urllib.error.HTTPError as e:
             response = Response(
@@ -1358,12 +1496,12 @@ class Elastik(MutableMapping[str, bytes]):
             _log.debug(
                 "%s %s -> %d %dB %.1fms",
                 method,
-                path,
+                debug_path,
                 response.status,
                 len(response.body),
                 elapsed_ms,
             )
-            self._debug_after_response(method, path, h, response, elapsed_ms)
+            self._debug_after_response(method, debug_path, h, response, elapsed_ms)
             return response
 
     def _raw(
@@ -1829,6 +1967,74 @@ def _etag_value(value: str | None) -> str | None:
     if v.startswith('"') and v.endswith('"'):
         return v
     return f'"{v}"'
+
+
+def _timeline_request_target(coordinate: TimelineCoordinate) -> str:
+    query = urllib.parse.urlencode(
+        (
+            ("timeline", "1"),
+            ("timeline-generation", coordinate.generation),
+            ("timeline-seq", str(coordinate.seq)),
+            ("timeline-body-sha256", coordinate.body_sha256),
+        )
+    )
+    return _quote_path(coordinate.world) + "?" + query
+
+
+def _require_timeline_coordinate(value: TimelineCoordinate, method: str) -> None:
+    if not isinstance(value, TimelineCoordinate):
+        raise TypeError(
+            f"{method}() requires TimelineCoordinate; "
+            "use TimelineCoordinate.from_event(event)"
+        )
+
+
+def _validate_timeline_response(
+    resp: Response,
+    coordinate: TimelineCoordinate,
+    method: str,
+    target: str,
+    *,
+    verify_body: bool = False,
+) -> None:
+    if resp.status != 200:
+        message = b"timeline response status must be 200\n"
+        raise ServerError(
+            500,
+            message,
+            method=method,
+            path=target,
+            headers=resp.headers,
+        )
+    expected = {
+        "x-timeline-world": coordinate.world,
+        "x-timeline-generation": coordinate.generation,
+        "x-timeline-seq": str(coordinate.seq),
+        "x-timeline-body-sha256": coordinate.body_sha256,
+    }
+    for name, value in expected.items():
+        if resp.headers.get(name) != value:
+            message = f"timeline proof header {name} mismatch\n".encode("utf-8")
+            raise ServerError(
+                500,
+                message,
+                method=method,
+                path=target,
+                headers=resp.headers,
+            )
+    if verify_body and hashlib.sha256(resp.body).hexdigest() != coordinate.body_sha256:
+        message = b"timeline body sha256 mismatch\n"
+        raise ServerError(
+            500,
+            message,
+            method=method,
+            path=target,
+            headers=resp.headers,
+        )
+
+
+def _is_lower_hex(value: str, expected_len: int) -> bool:
+    return len(value) == expected_len and all(ch in "0123456789abcdef" for ch in value)
 
 
 def _is_debug_path(path: str) -> bool:

--- a/sdk/src/elastik/testing.py
+++ b/sdk/src/elastik/testing.py
@@ -14,6 +14,8 @@ from elastik.sdk import (
     HeaderAllowlist,
     NotFound,
     Response,
+    TimelineCoordinate,
+    TimelineMeta,
     WorldMeta,
     _body_bytes,
     _canonical_world_name,
@@ -151,6 +153,26 @@ class FakeElastik(Elastik):
             return dict(self._store[world][1])  # type: ignore[return-value]
         except KeyError:
             raise NotFound(404, b"not found", method="HEAD", path=path) from None
+
+    def get_timeline(self, coordinate: TimelineCoordinate) -> bytes:
+        if not isinstance(coordinate, TimelineCoordinate):
+            raise TypeError(
+                "get_timeline() requires TimelineCoordinate; "
+                "use TimelineCoordinate.from_event(event)"
+            )
+        raise NotImplementedError(
+            "FakeElastik does not retain audit timeline bodies; use black-box tests"
+        )
+
+    def head_timeline(self, coordinate: TimelineCoordinate) -> TimelineMeta:
+        if not isinstance(coordinate, TimelineCoordinate):
+            raise TypeError(
+                "head_timeline() requires TimelineCoordinate; "
+                "use TimelineCoordinate.from_event(event)"
+            )
+        raise NotImplementedError(
+            "FakeElastik does not retain audit timeline bodies; use black-box tests"
+        )
 
     def verify(self, path: str) -> bool:
         self.head(path)

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -139,7 +139,7 @@ def main() -> int:
     sys.path.insert(0, str(SDK_SRC))
     import elastik
     from elastik import _spawn
-    from elastik.sdk import Elastik
+    from elastik.sdk import Elastik, TimelineCoordinate
 
     check = Check()
     saved_tokens = {
@@ -1339,6 +1339,22 @@ def main() -> int:
             check(
                 "-append-secret" not in append_ev.get("data", ""),
                 "append SSE event does not embed body",
+            )
+            append_coord = TimelineCoordinate.from_event(append_ev)
+            writer.put("/home/sdk/listen/a", b"current-after-append")
+            check(
+                reader.get_timeline(append_coord) == b"payload-append-secret",
+                "SDK timeline GET returns signalled historical body after overwrite",
+            )
+            timeline_head = reader.head_timeline(append_coord)
+            check(
+                timeline_head.get("x-timeline-seq") == append_ev.get("timeline-seq"),
+                "SDK timeline HEAD returns proof headers",
+            )
+            check("etag" not in timeline_head, "SDK timeline HEAD does not expose current ETag")
+            check(
+                reader.get("/home/sdk/listen/a") == b"current-after-append",
+                "current GET still returns current body after timeline read",
             )
 
             elastik.clear_routes()

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -105,7 +105,7 @@ def world_url(base: str, path: str) -> str:
 
 def sse_cursor_parts(raw: str) -> tuple[str, int]:
     if ":" not in raw:
-        return "", int(raw)
+        raise AssertionError(f"SSE id must be an opaque epoch cursor: {raw!r}")
     epoch, seq = raw.split(":", 1)
     if len(epoch) != 32 or any(ch not in "0123456789abcdef" for ch in epoch):
         raise AssertionError(f"invalid SSE cursor epoch: {raw!r}")

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -103,6 +103,15 @@ def world_url(base: str, path: str) -> str:
     return base.rstrip("/") + "/" + urllib.parse.quote(path.lstrip("/"), safe="/")
 
 
+def sse_cursor_parts(raw: str) -> tuple[str, int]:
+    if ":" not in raw:
+        return "", int(raw)
+    epoch, seq = raw.split(":", 1)
+    if len(epoch) != 32 or any(ch not in "0123456789abcdef" for ch in epoch):
+        raise AssertionError(f"invalid SSE cursor epoch: {raw!r}")
+    return epoch, int(seq)
+
+
 def expect_error(fn, status: int, check: Check, name: str) -> None:
     import elastik
 
@@ -1308,7 +1317,10 @@ def main() -> int:
             check(replay_done.wait(5), "Last-Event-ID replays missed SSE event")
             replay = replay_events[0]
             check(replay.get("path") == "/home/sdk/listen/b", "replayed SSE event path")
-            check(int(replay.get("id", "0")) > int(ev.get("id", "0")), "replayed SSE id advances")
+            ev_epoch, ev_seq = sse_cursor_parts(ev.get("id", "0"))
+            replay_epoch, replay_seq = sse_cursor_parts(replay.get("id", "0"))
+            check(replay_epoch == ev_epoch, "replayed SSE cursor keeps listen epoch")
+            check(replay_seq > ev_seq, "replayed SSE cursor advances")
 
             append_events: list[dict[str, str]] = []
             append_done = threading.Event()

--- a/sdk/tests/test_tools.py
+++ b/sdk/tests/test_tools.py
@@ -7,6 +7,7 @@ import shlex
 import socket
 import sys
 import time
+import hashlib
 from pathlib import Path
 
 
@@ -14,13 +15,18 @@ ROOT = Path(__file__).resolve().parents[2]
 SDK_SRC = ROOT / "sdk" / "src"
 sys.path.insert(0, str(SDK_SRC))
 
+import elastik as elastik_module  # noqa: E402
 from elastik.sdk import (  # noqa: E402
+    Elastik,
     InsufficientStorage,
     Response,
+    ServerError,
+    TimelineCoordinate,
     _NON_PERSISTED_RESPONSE_HEADERS,
     _quote_path,
     _raise_for_response,
 )
+from elastik.testing import FakeElastik  # noqa: E402
 from elastik._coap_client import _path_segments  # noqa: E402
 from elastik._coap_client import get as coap_get  # noqa: E402
 from elastik.tools import ShellPoolError, TrustedShellPool  # noqa: E402
@@ -114,6 +120,162 @@ def check_507_maps_to_insufficient_storage() -> None:
     raise AssertionError("507 did not raise InsufficientStorage")
 
 
+def check_timeline_coordinate_validation() -> None:
+    event = {
+        "path": "/home/timeline/sdk",
+        "id": "999",
+        "etag": "hmac-not-the-body-hash",
+        "timeline-world": "home/timeline/sdk",
+        "timeline-generation": "0" * 32,
+        "timeline-seq": "7",
+        "timeline-body-sha256": "a" * 64,
+    }
+    coord = TimelineCoordinate.from_event(event)
+    assert coord.world == "home/timeline/sdk"
+    assert coord.seq == 7
+
+    try:
+        TimelineCoordinate.from_parts("home/timeline/sdk", "0" * 32, 7.5, "a" * 64)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("float timeline seq was accepted")
+
+    for bad in (
+        {**event, "timeline-world": "home/other"},
+        {**event, "timeline-generation": "A" * 32},
+        {**event, "timeline-seq": "0"},
+        {**event, "timeline-seq": str(2**63)},
+        {key: value for key, value in event.items() if key != "path"},
+        {key: value for key, value in event.items() if key != "timeline-seq"},
+        {**event, "timeline-body-sha256": "g" * 64},
+        {**event, "timeline-world": "tmp/timeline/sdk", "path": "/tmp/timeline/sdk"},
+    ):
+        try:
+            TimelineCoordinate.from_event(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"invalid timeline event accepted: {bad!r}")
+
+
+def check_timeline_request_uses_query_not_path() -> None:
+    import urllib.request
+
+    seen: dict[str, str | list[str]] = {}
+    coord = TimelineCoordinate.from_parts(
+        "home/a b",
+        "0" * 32,
+        7,
+        hashlib.sha256(b"old").hexdigest(),
+    )
+
+    class FakeHTTPResponse:
+        def __init__(
+            self,
+            *,
+            bad_proof: bool = False,
+            bad_status: bool = False,
+            bad_body: bool = False,
+        ) -> None:
+            self.status = 206 if bad_status else 200
+            self.body = b"partial" if bad_body else b"old"
+            self.headers = {
+                "Content-Type": "text/plain",
+                "Content-Length": str(len(self.body)),
+                "X-Timeline-World": coord.world,
+                "X-Timeline-Generation": coord.generation,
+                "X-Timeline-Seq": "8" if bad_proof else str(coord.seq),
+                "X-Timeline-Body-Sha256": coord.body_sha256,
+            }
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return self.body
+
+    def fake_urlopen(req, timeout=30):  # noqa: ANN001
+        seen["url"] = req.full_url
+        methods = seen.setdefault("methods", [])
+        assert isinstance(methods, list)
+        methods.append(req.get_method())
+        seen["auth"] = req.headers.get("Authorization", "")
+        return FakeHTTPResponse(
+            bad_proof=seen.get("bad_proof") == "1",
+            bad_status=seen.get("bad_status") == "1",
+            bad_body=seen.get("bad_body") == "1",
+        )
+
+    prior = urllib.request.urlopen
+    urllib.request.urlopen = fake_urlopen
+    try:
+        client = Elastik("http://example.test", bearer_token="reader")
+        assert client.get_timeline(coord) == b"old"
+        assert seen["auth"] == "Bearer reader"
+        assert seen["url"].startswith("http://example.test/home/a%20b?")
+        assert "?timeline=1&timeline-generation=" in seen["url"]
+        assert "%3Ftimeline" not in seen["url"]
+        assert "timeline-world" not in seen["url"]
+
+        headers = client.head_timeline(coord)
+        assert headers["x-timeline-seq"] == "7"
+        assert seen["methods"] == ["GET", "HEAD"]
+
+        assert "get_timeline" in elastik_module.__all__
+        assert "head_timeline" in elastik_module.__all__
+        elastik_module._set_default(client)
+        try:
+            assert elastik_module.get_timeline(coord) == b"old"
+            assert elastik_module.head_timeline(coord)["x-timeline-seq"] == "7"
+            assert seen["methods"] == ["GET", "HEAD", "GET", "HEAD"]
+        finally:
+            elastik_module._default_client = None
+
+        try:
+            FakeElastik().get_timeline(coord)
+        except NotImplementedError:
+            pass
+        else:
+            raise AssertionError("FakeElastik timeline helper should be explicit unsupported")
+        try:
+            FakeElastik().get_timeline("home/a b")  # type: ignore[arg-type]
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("FakeElastik accepted a raw timeline coordinate")
+
+        seen["bad_proof"] = "1"
+        try:
+            client.get_timeline(coord)
+        except ServerError as exc:
+            assert "x-timeline-seq mismatch" in str(exc), exc
+        else:
+            raise AssertionError("timeline proof header mismatch was accepted")
+        seen.pop("bad_proof")
+
+        seen["bad_status"] = "1"
+        try:
+            client.head_timeline(coord)
+        except ServerError as exc:
+            assert "status must be 200" in str(exc), exc
+        else:
+            raise AssertionError("timeline non-200 success was accepted")
+        seen.pop("bad_status")
+
+        seen["bad_body"] = "1"
+        try:
+            client.get_timeline(coord)
+        except ServerError as exc:
+            assert "body sha256 mismatch" in str(exc), exc
+        else:
+            raise AssertionError("timeline body hash mismatch was accepted")
+    finally:
+        urllib.request.urlopen = prior
+
+
 def main() -> int:
     check_header_blacklist_parity()
     check_coap_unreachable_is_timeout()
@@ -121,6 +283,8 @@ def main() -> int:
     check_proc_paths_are_sdk_allowed()
     check_encoded_dot_segments_are_rejected()
     check_507_maps_to_insufficient_storage()
+    check_timeline_coordinate_validation()
+    check_timeline_request_uses_query_not_path()
 
     with TrustedShellPool(size=1, timeout=2) as pool:
         r = pool.run("echo elastik-ready", check=True)


### PR DESCRIPTION
Depends on #356.

## What

Adds the Python SDK helper layer for HTTP timeline dereference after the raw HTTP route is proven:

- `TimelineCoordinate` and `TimelineMeta` in the SDK.
- `Elastik.get_timeline(coord)` and `Elastik.head_timeline(coord)`.
- module-level `elastik.get_timeline(coord)` / `elastik.head_timeline(coord)` exports.
- explicit `FakeElastik` unsupported timeline methods so unit tests do not pretend the fake retains audit timeline bodies.
- SDK and HTTP README wording for exact historical dereference.

## Contract

This implements `design_notes/PLAN-http-timeline-dereference.md` §7 item 6: "Add SDK helpers only after the raw HTTP route is proven."

The SDK coordinate is syntax only, not a server proof. The helper validates local wire shape, builds the `?timeline=1&timeline-generation=...&timeline-seq=...&timeline-body-sha256=...` query, and then requires the server response to prove the same coordinate through `X-Timeline-*` headers. `GET` additionally hashes the returned body and fails closed if the bytes do not match `timeline-body-sha256`.

No reactor default behaviour changes in this layer. Handler `body` is still a current read; exact historical reads require explicit `TimelineCoordinate.from_event(event)` plus `get_timeline()`.

## Diff Budget

Base/prior layer: `stack/22r40-http-timeline-query-wall` / PR #356 @ `cb1943f`.

Production SDK code: `254` additions / `6` deletions:

```text
20  0 sdk/src/elastik/__init__.py
212 6 sdk/src/elastik/sdk.py
22  0 sdk/src/elastik/testing.py
```

Docs: `23` additions / `0` deletions. Tests: `181` additions / `1` deletion. Total diff: `458` additions / `7` deletions.

## Validation

Ran locally:

```powershell
python -m py_compile sdk/src/elastik/sdk.py sdk/src/elastik/__init__.py sdk/src/elastik/testing.py sdk/tests/test_tools.py sdk/tests/e2e_blackbox.py
python -m compileall -q sdk/src sdk/tests
python sdk/tests/test_tools.py
python sdk/tests/e2e_blackbox.py --no-build
python tools/header_policy_scan.py --offline
cargo test --manifest-path bin/Cargo.toml pipeline_timeline
cargo fmt --manifest-path bin/Cargo.toml -- --check
git diff --check
```

Results:

- `PASS sdk tools`
- `PASS sdk e2e blackbox: 248 checks`
- header policy drift: none
- Rust pipeline timeline tests: 6 passed
- fmt and whitespace checks clean

Pre-push also passed the repo hook fast gates:

- Rust format
- Rust clippy
- Rust tests: core `191 passed`, bin `145 passed`, doctests `17 passed`
- version consistency: `8.3.0`
- bundled SQLite check: `libsqlite3-sys 0.38.0 bundles SQLite 3.53.1`
- `cargo audit` for core/bin/ffi locks
- Python SDK smoke
- header policy scanner self-test
- header-policy missing-baseline negative test
- JS syntax
- whitespace check

## Review Ledger

Plan review, before implementation:

- Fermat / Bacon-QA: split reactor migration; SDK helper layer is plan-covered.
- Arendt / Poincare-Harvey: current reactor remains B-signal/C-read race; keep migration out of this PR.
- Hooke / Mencius-Noether: require sealed Python coordinate, no raw four-arg helper.
- Volta / Popper-Precondition: query construction must avoid `%3Ftimeline`; path supplies world; no id/etag confusion.

Implementation review round:

- McClintock / Mencius-Noether: no P0-P2. P3s fixed: `from_event()` now requires `path`; `FakeElastik` mirrors the type guard before unsupported errors.
- Locke / Popper: no P0-P2. P3s fixed: SDK now validates `X-Timeline-*` response proof headers; seq is bounded to positive signed i64.
- Newton / Sagan-Bacon: P2s fixed: module-level helpers are tested; `head_timeline()` test proves HEAD method. P3s fixed: SDK README documents timeline helpers; HTTP README no longer says HEAD returns a body.
- Zeno / QA-enforcement: prior P1 was process-only: no durable ledger existed before PR creation. This PR body is the required ledger.

Fresh review round after fixes:

- Dirac / Bacon-QA: no confirmed P0-P2 in pre-PR state. Confirmed base #356 @ `cb1943f`, plan §7 item 6, production budget under 500, and required PR ledger contents.
- Carson / Popper-Precondition: no P0-P2. P3 found: SDK trusted proof headers without enforcing `200` or local GET body hash. Fixed.
- Jason / Mencius-Noether: P2 found: SDK accepted any `<400` timeline response with matching proof headers. Fixed by requiring status `200` before trusting body/meta.
- Faraday / Popper-Mencius fresh clearing verifier: zero P0-P2 after the fix. Verified non-200 timeline success is rejected, GET body hash mismatch is rejected, HEAD does not hash its empty body, normal 200 GET/HEAD still pass.

Confirmed P0-P2 remaining: zero.

## Notes

`FakeElastik` remains explicitly unsupported for timeline body retention. Use black-box tests or a real core instance for historical dereference behaviour.