### PR TITLE
stack 22: expose audit verification base

### DIFF
--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -108,7 +108,7 @@ jobs:
           subscription = engine.subscribe(
               "home/*",
               e.FfiAccessTier.READ,
-              e.FfiSubscriptionResume(after_event_id=None),
+              e.FfiSubscriptionResume(after_cursor=None, after_event_id=None),
           )
           engine.append("home/ffi", b" world", none, e.FfiAccessTier.WRITE)
           event = subscription.next(5_000)

--- a/.github/workflows/ffi-artifacts.yml
+++ b/.github/workflows/ffi-artifacts.yml
@@ -105,7 +105,11 @@ jobs:
           assert read is not None
           assert read.representation.body == b"hello"
 
-          subscription = engine.subscribe("home/*", e.FfiAccessTier.READ, None)
+          subscription = engine.subscribe(
+              "home/*",
+              e.FfiAccessTier.READ,
+              e.FfiSubscriptionResume(after_event_id=None),
+          )
           engine.append("home/ffi", b" world", none, e.FfiAccessTier.WRITE)
           event = subscription.next(5_000)
           assert event.kind == e.FfiSubscriptionNextKind.EVENT, event.kind

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,11 @@ jobs:
           read = engine.read("home/ffi", e.FfiAccessTier.READ)
           assert read is not None
           assert read.representation.body == b"release"
-          subscription = engine.subscribe("home/*", e.FfiAccessTier.READ, None)
+          subscription = engine.subscribe(
+              "home/*",
+              e.FfiAccessTier.READ,
+              e.FfiSubscriptionResume(after_event_id=None),
+          )
           engine.append("home/ffi", b" asset", none, e.FfiAccessTier.WRITE)
           event = subscription.next(5_000)
           assert event.kind == e.FfiSubscriptionNextKind.EVENT, event.kind

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
           subscription = engine.subscribe(
               "home/*",
               e.FfiAccessTier.READ,
-              e.FfiSubscriptionResume(after_event_id=None),
+              e.FfiSubscriptionResume(after_cursor=None, after_event_id=None),
           )
           engine.append("home/ffi", b" asset", none, e.FfiAccessTier.WRITE)
           event = subscription.next(5_000)

--- a/bin/src/core_bridge.rs
+++ b/bin/src/core_bridge.rs
@@ -41,7 +41,7 @@ pub(crate) mod engine_types {
     pub(crate) use elastik_core::{
         parse_etag_matchers, AccessTier, AuditHmacKey, ChangeEvent, ChangeVerb, EtagMatcher,
         InvalidHmacKey, Preconditions, Representation, SubscribePattern, SubscriptionRecvError,
-        ValidatedWorldPath, WriteKind,
+        SubscriptionResume, ValidatedWorldPath, WriteKind,
     };
 }
 

--- a/bin/src/core_bridge.rs
+++ b/bin/src/core_bridge.rs
@@ -40,8 +40,8 @@ pub(crate) mod engine_types {
     pub(crate) use elastik_core::WriteResult;
     pub(crate) use elastik_core::{
         parse_etag_matchers, AccessTier, AuditHmacKey, ChangeEvent, ChangeVerb, EtagMatcher,
-        InvalidHmacKey, Preconditions, Representation, SubscribePattern, SubscriptionRecvError,
-        SubscriptionResume, ValidatedWorldPath, WriteKind,
+        InvalidHmacKey, Preconditions, Representation, SubscribePattern, SubscriptionCursor,
+        SubscriptionRecvError, SubscriptionResume, ValidatedWorldPath, WriteKind,
     };
 }
 

--- a/bin/src/server/coap.rs
+++ b/bin/src/server/coap.rs
@@ -14,7 +14,10 @@ use tokio::sync::Semaphore;
 use crate::{
     engine::{Engine, ShutdownToken},
     engine_trace::EngineWriteTraceHooks,
-    engine_types::{AccessTier, Preconditions, Representation, ValidatedWorldPath, WriteKind},
+    engine_types::{
+        AccessTier, Preconditions, Representation, SubscriptionResume, ValidatedWorldPath,
+        WriteKind,
+    },
     server::{coap_errors, path::canonicalize_path},
 };
 
@@ -744,7 +747,7 @@ mod tests {
             .subscribe(
                 &crate::engine_types::SubscribePattern::new("home/*"),
                 AccessTier::Read,
-                None,
+                SubscriptionResume::none(),
             )
             .expect("test subscription should open");
         let http_state = server_state_for_engine_for_tests(engine.clone());

--- a/bin/src/server/coap.rs
+++ b/bin/src/server/coap.rs
@@ -14,10 +14,7 @@ use tokio::sync::Semaphore;
 use crate::{
     engine::{Engine, ShutdownToken},
     engine_trace::EngineWriteTraceHooks,
-    engine_types::{
-        AccessTier, Preconditions, Representation, SubscriptionResume, ValidatedWorldPath,
-        WriteKind,
-    },
+    engine_types::{AccessTier, Preconditions, Representation, ValidatedWorldPath, WriteKind},
     server::{coap_errors, path::canonicalize_path},
 };
 
@@ -747,7 +744,7 @@ mod tests {
             .subscribe(
                 &crate::engine_types::SubscribePattern::new("home/*"),
                 AccessTier::Read,
-                SubscriptionResume::none(),
+                crate::engine_types::SubscriptionResume::none(),
             )
             .expect("test subscription should open");
         let http_state = server_state_for_engine_for_tests(engine.clone());

--- a/bin/src/server/handler/tests.rs
+++ b/bin/src/server/handler/tests.rs
@@ -702,7 +702,7 @@ async fn post_audit_uses_existing_representation_metadata() {
 
 #[tokio::test]
 async fn durable_storage_quota_returns_507_without_writing() {
-    let (engine, dir) = test_engine_for_server_with_storage_quota("storage-quota", 4);
+    let (engine, dir) = test_engine_for_server_with_storage_quota("storage-quota", 8);
     let headers = HeaderMap::new();
 
     let first = unwrap_response(
@@ -730,9 +730,9 @@ async fn durable_storage_quota_returns_507_without_writing() {
         .await,
     );
     assert_eq!(over.status(), StatusCode::INSUFFICIENT_STORAGE);
-    assert_eq!(over.headers().get("x-storage-usage").unwrap(), "4");
-    assert_eq!(over.headers().get("x-storage-quota").unwrap(), "4");
-    assert_eq!(over.headers().get("x-storage-needed").unwrap(), "1");
+    assert_eq!(over.headers().get("x-storage-usage").unwrap(), "8");
+    assert_eq!(over.headers().get("x-storage-quota").unwrap(), "8");
+    assert_eq!(over.headers().get("x-storage-needed").unwrap(), "2");
     assert!(engine
         .read(&world_path("home/b"), AccessTier::Read)
         .unwrap()
@@ -750,9 +750,9 @@ async fn durable_storage_quota_returns_507_without_writing() {
         .await,
     );
     assert_eq!(append.status(), StatusCode::INSUFFICIENT_STORAGE);
-    assert_eq!(append.headers().get("x-storage-usage").unwrap(), "4");
-    assert_eq!(append.headers().get("x-storage-quota").unwrap(), "4");
-    assert_eq!(append.headers().get("x-storage-needed").unwrap(), "1");
+    assert_eq!(append.headers().get("x-storage-usage").unwrap(), "8");
+    assert_eq!(append.headers().get("x-storage-quota").unwrap(), "8");
+    assert_eq!(append.headers().get("x-storage-needed").unwrap(), "6");
     assert_eq!(
         engine
             .read(&world_path("home/a"), AccessTier::Read)
@@ -813,8 +813,11 @@ async fn concurrent_puts_to_distinct_worlds_do_not_overshoot_quota() {
     }
 
     let used = engine.df(AccessTier::Read).unwrap().storage_used;
-    let counted = accepted * body_len;
-    assert_eq!(used, counted, "counter must equal sum of accepted bodies");
+    let counted = accepted * body_len * 2;
+    assert_eq!(
+        used, counted,
+        "counter must equal accepted live bodies plus retained CAS bodies"
+    );
     assert![
         used <= quota,
         "counter must never exceed quota: {used} > {quota}"

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -11,7 +11,9 @@ use crate::{
     engine_types::{
         ChangeEvent as EngineChangeEvent, ChangeVerb, SubscribePattern, SubscriptionRecvError,
     },
-    server::{method_not_allowed, options_response, server_error, unauthorized, ServerState},
+    server::{
+        bad_request, method_not_allowed, options_response, server_error, unauthorized, ServerState,
+    },
 };
 
 pub(crate) const ALLOW: &str = "GET, OPTIONS";
@@ -36,10 +38,10 @@ pub(crate) async fn handler(
     }
     let tier = state.access_tier_from_headers(&headers);
     let pattern = SubscribePattern::new(&raw_pattern);
-    let last_event_id = headers
-        .get("last-event-id")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.trim().parse::<u64>().ok());
+    let last_event_id = match parse_last_event_id(&headers) {
+        Ok(last_event_id) => last_event_id,
+        Err(reason) => return bad_request(reason),
+    };
     let subscription = match state.engine().subscribe(&pattern, tier, last_event_id) {
         Ok(subscription) => subscription,
         Err(EngineError::Auth(_)) => return unauthorized("listen requires read token"),
@@ -95,6 +97,19 @@ pub(crate) async fn handler(
                 .text("keepalive"),
         )
         .into_response()
+}
+
+fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, &'static str> {
+    let Some(value) = headers.get("last-event-id") else {
+        return Ok(None);
+    };
+    let raw = value.to_str().map_err(|_| "invalid Last-Event-ID")?.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    raw.parse::<u64>()
+        .map(Some)
+        .map_err(|_| "invalid Last-Event-ID")
 }
 
 fn sse_change_event(change: EngineChangeEvent) -> Event {
@@ -186,6 +201,25 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(resp.headers().get(header::RETRY_AFTER).unwrap(), "1");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn handler_rejects_non_decimal_last_event_id() {
+        let (engine, dir) = test_engine_for_server("listen-invalid-last-event-id");
+        let mut headers = HeaderMap::new();
+        headers.insert("last-event-id", "audit:42".parse().unwrap());
+
+        let resp = handler(
+            State(server_state_for_engine_for_tests(engine)),
+            Method::GET,
+            headers,
+            AxPath("home/task/*".to_string()),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -10,6 +10,7 @@ use crate::{
     engine::EngineError,
     engine_types::{
         ChangeEvent as EngineChangeEvent, ChangeVerb, SubscribePattern, SubscriptionRecvError,
+        SubscriptionResume,
     },
     server::{
         bad_request, method_not_allowed, options_response, server_error, unauthorized, ServerState,
@@ -38,11 +39,11 @@ pub(crate) async fn handler(
     }
     let tier = state.access_tier_from_headers(&headers);
     let pattern = SubscribePattern::new(&raw_pattern);
-    let last_event_id = match parse_last_event_id(&headers) {
-        Ok(last_event_id) => last_event_id,
+    let resume = match parse_last_event_id(&headers) {
+        Ok(resume) => resume,
         Err(reason) => return bad_request(reason),
     };
-    let subscription = match state.engine().subscribe(&pattern, tier, last_event_id) {
+    let subscription = match state.engine().subscribe(&pattern, tier, resume) {
         Ok(subscription) => subscription,
         Err(EngineError::Auth(_)) => return unauthorized("listen requires read token"),
         Err(EngineError::SubscriptionLimit) => {
@@ -102,10 +103,10 @@ pub(crate) async fn handler(
         .into_response()
 }
 
-fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, &'static str> {
+fn parse_last_event_id(headers: &HeaderMap) -> Result<SubscriptionResume, &'static str> {
     let mut values = headers.get_all("last-event-id").iter();
     let Some(value) = values.next() else {
-        return Ok(None);
+        return Ok(SubscriptionResume::none());
     };
     if values.next().is_some() {
         return Err("invalid Last-Event-ID");
@@ -119,7 +120,7 @@ fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, &'static str>
     if raw != parsed.to_string() {
         return Err("invalid Last-Event-ID");
     }
-    Ok(Some(parsed))
+    Ok(SubscriptionResume::after_event_id(parsed))
 }
 
 /// Frame emitted when a resume cursor belongs to a previous engine process.
@@ -160,7 +161,9 @@ fn change_method(verb: ChangeVerb) -> &'static str {
 mod tests {
     use super::*;
     use crate::{
-        engine_types::{AccessTier, Preconditions, Representation, ValidatedWorldPath},
+        engine_types::{
+            AccessTier, Preconditions, Representation, SubscriptionResume, ValidatedWorldPath,
+        },
         server::test_support::{
             server_state_for_engine_for_tests, test_engine_for_server,
             test_engine_for_server_with_listen_slots,
@@ -175,7 +178,7 @@ mod tests {
             .subscribe(
                 &SubscribePattern::new("home/task/*"),
                 AccessTier::Read,
-                None,
+                SubscriptionResume::none(),
             )
             .expect("test subscription should be accepted");
         let world = ValidatedWorldPath::new("home/task/a").unwrap();
@@ -209,7 +212,11 @@ mod tests {
     async fn handler_returns_503_when_listen_slots_are_full() {
         let (engine, dir) = test_engine_for_server_with_listen_slots("listen-slots-full", 1);
         let _held_slot = engine
-            .subscribe(&SubscribePattern::new("home/held"), AccessTier::Read, None)
+            .subscribe(
+                &SubscribePattern::new("home/held"),
+                AccessTier::Read,
+                SubscriptionResume::none(),
+            )
             .expect("first subscription should consume the only listen slot");
 
         let resp = handler(
@@ -266,10 +273,19 @@ mod tests {
     fn parse_last_event_id_accepts_single_ascii_decimal() {
         let mut headers = HeaderMap::new();
         headers.insert("last-event-id", "42".parse().unwrap());
-        assert_eq!(parse_last_event_id(&headers), Ok(Some(42)));
+        assert_eq!(
+            parse_last_event_id(&headers),
+            Ok(SubscriptionResume::after_event_id(42))
+        );
         headers.insert("last-event-id", "0".parse().unwrap());
-        assert_eq!(parse_last_event_id(&headers), Ok(Some(0)));
-        assert_eq!(parse_last_event_id(&HeaderMap::new()), Ok(None));
+        assert_eq!(
+            parse_last_event_id(&headers),
+            Ok(SubscriptionResume::after_event_id(0))
+        );
+        assert_eq!(
+            parse_last_event_id(&HeaderMap::new()),
+            Ok(SubscriptionResume::none())
+        );
     }
 
     #[test]

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -81,6 +81,9 @@ pub(crate) async fn handler(
                     .data(format!("missed: {skipped}"))),
                 subscription,
             )),
+            Err(SubscriptionRecvError::CursorAhead { since, newest }) => {
+                Some((Ok(sse_reset_event(since, newest)), subscription))
+            }
             Err(SubscriptionRecvError::Closed) => None,
             Err(_err) => {
                 #[cfg(feature = "unstable-engine")]
@@ -112,9 +115,22 @@ fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, &'static str>
         return Err("invalid Last-Event-ID");
     }
 
-    raw.parse::<u64>()
-        .map(Some)
-        .map_err(|_| "invalid Last-Event-ID")
+    let parsed = raw.parse::<u64>().map_err(|_| "invalid Last-Event-ID")?;
+    if raw != parsed.to_string() {
+        return Err("invalid Last-Event-ID");
+    }
+    Ok(Some(parsed))
+}
+
+/// Frame emitted when a resume cursor belongs to a previous engine process.
+///
+/// The `id` field deliberately rebases EventSource's automatic
+/// `Last-Event-ID` buffer to the newest id in this process.
+fn sse_reset_event(since: u64, newest: u64) -> Event {
+    Event::default()
+        .event("reset")
+        .id(newest.to_string())
+        .data(format!("since: {since}\nnewest: {newest}"))
 }
 
 fn sse_change_event(change: EngineChangeEvent) -> Event {
@@ -231,7 +247,7 @@ mod tests {
 
     #[test]
     fn parse_last_event_id_rejects_non_canonical_values() {
-        for value in ["", " 42", "42 ", "+42", "audit:42"] {
+        for value in ["", " 42", "42 ", "+42", "audit:42", "00", "00042"] {
             let mut headers = HeaderMap::new();
             headers.insert("last-event-id", value.parse().unwrap());
             assert_eq!(parse_last_event_id(&headers), Err("invalid Last-Event-ID"));
@@ -251,6 +267,17 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("last-event-id", "42".parse().unwrap());
         assert_eq!(parse_last_event_id(&headers), Ok(Some(42)));
+        headers.insert("last-event-id", "0".parse().unwrap());
+        assert_eq!(parse_last_event_id(&headers), Ok(Some(0)));
         assert_eq!(parse_last_event_id(&HeaderMap::new()), Ok(None));
+    }
+
+    #[test]
+    fn sse_reset_event_rebases_last_event_id() {
+        let wire = format!("{:?}", sse_reset_event(42, 7));
+        assert!(wire.contains("event: reset"), "{wire}");
+        assert!(wire.contains("id: 7"), "{wire}");
+        assert!(wire.contains("data: since: 42"), "{wire}");
+        assert!(wire.contains("data: newest: 7"), "{wire}");
     }
 }

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use crate::{
     engine::EngineError,
     engine_types::{
-        ChangeEvent as EngineChangeEvent, ChangeVerb, SubscribePattern, SubscriptionRecvError,
-        SubscriptionResume,
+        ChangeEvent as EngineChangeEvent, ChangeVerb, SubscribePattern, SubscriptionCursor,
+        SubscriptionRecvError, SubscriptionResume,
     },
     server::{
         bad_request, method_not_allowed, options_response, server_error, unauthorized, ServerState,
@@ -82,9 +82,11 @@ pub(crate) async fn handler(
                     .data(format!("missed: {skipped}"))),
                 subscription,
             )),
-            Err(SubscriptionRecvError::CursorAhead { since, newest }) => {
-                Some((Ok(sse_reset_event(since, newest)), subscription))
-            }
+            Err(SubscriptionRecvError::CursorAhead {
+                since,
+                newest,
+                reset,
+            }) => Some((Ok(sse_reset_event(since, newest, reset)), subscription)),
             Err(SubscriptionRecvError::Closed) => None,
             Err(_err) => {
                 #[cfg(feature = "unstable-engine")]
@@ -112,25 +114,31 @@ fn parse_last_event_id(headers: &HeaderMap) -> Result<SubscriptionResume, &'stat
         return Err("invalid Last-Event-ID");
     }
     let raw = value.to_str().map_err(|_| "invalid Last-Event-ID")?;
-    if raw.is_empty() || !raw.bytes().all(|b| b.is_ascii_digit()) {
+    if raw.is_empty() {
         return Err("invalid Last-Event-ID");
     }
 
-    let parsed = raw.parse::<u64>().map_err(|_| "invalid Last-Event-ID")?;
-    if raw != parsed.to_string() {
-        return Err("invalid Last-Event-ID");
+    if raw.bytes().all(|b| b.is_ascii_digit()) {
+        let parsed = raw.parse::<u64>().map_err(|_| "invalid Last-Event-ID")?;
+        if raw != parsed.to_string() {
+            return Err("invalid Last-Event-ID");
+        }
+        return Ok(SubscriptionResume::legacy_event_id(parsed));
     }
-    Ok(SubscriptionResume::after_event_id(parsed))
+
+    SubscriptionCursor::from_sse_id(raw)
+        .map(SubscriptionResume::after_cursor)
+        .map_err(|_| "invalid Last-Event-ID")
 }
 
 /// Frame emitted when a resume cursor belongs to a previous engine process.
 ///
 /// The `id` field deliberately rebases EventSource's automatic
 /// `Last-Event-ID` buffer to the newest id in this process.
-fn sse_reset_event(since: u64, newest: u64) -> Event {
+fn sse_reset_event(since: u64, newest: u64, reset: SubscriptionCursor) -> Event {
     Event::default()
         .event("reset")
-        .id(newest.to_string())
+        .id(reset.to_string())
         .data(format!("since: {since}\nnewest: {newest}"))
 }
 
@@ -143,7 +151,7 @@ fn sse_change_event(change: EngineChangeEvent) -> Event {
     }
     Event::default()
         .event(method.to_ascii_lowercase())
-        .id(change.id.to_string())
+        .id(change.cursor.to_string())
         .data(data)
 }
 
@@ -234,7 +242,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handler_rejects_non_decimal_last_event_id() {
+    async fn handler_rejects_malformed_last_event_id() {
         let (engine, dir) = test_engine_for_server("listen-invalid-last-event-id");
         let mut headers = HeaderMap::new();
         headers.insert("last-event-id", "audit:42".parse().unwrap());
@@ -254,7 +262,17 @@ mod tests {
 
     #[test]
     fn parse_last_event_id_rejects_non_canonical_values() {
-        for value in ["", " 42", "42 ", "+42", "audit:42", "00", "00042"] {
+        for value in [
+            "",
+            " 42",
+            "42 ",
+            "+42",
+            "audit:42",
+            "00",
+            "00042",
+            "0123456789abcdef0123456789abcdef:0042",
+            "0123456789abcdef0123456789abcdeF:42",
+        ] {
             let mut headers = HeaderMap::new();
             headers.insert("last-event-id", value.parse().unwrap());
             assert_eq!(parse_last_event_id(&headers), Err("invalid Last-Event-ID"));
@@ -270,17 +288,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_last_event_id_accepts_single_ascii_decimal() {
+    fn parse_last_event_id_accepts_current_cursor_and_legacy_decimal() {
+        let cursor = "0123456789abcdef0123456789abcdef:42";
         let mut headers = HeaderMap::new();
+        headers.insert("last-event-id", cursor.parse().unwrap());
+        assert_eq!(
+            parse_last_event_id(&headers),
+            Ok(SubscriptionResume::after_cursor(
+                SubscriptionCursor::from_sse_id(cursor).unwrap()
+            ))
+        );
         headers.insert("last-event-id", "42".parse().unwrap());
         assert_eq!(
             parse_last_event_id(&headers),
-            Ok(SubscriptionResume::after_event_id(42))
+            Ok(SubscriptionResume::legacy_event_id(42))
         );
         headers.insert("last-event-id", "0".parse().unwrap());
         assert_eq!(
             parse_last_event_id(&headers),
-            Ok(SubscriptionResume::after_event_id(0))
+            Ok(SubscriptionResume::legacy_event_id(0))
         );
         assert_eq!(
             parse_last_event_id(&HeaderMap::new()),
@@ -290,9 +316,13 @@ mod tests {
 
     #[test]
     fn sse_reset_event_rebases_last_event_id() {
-        let wire = format!("{:?}", sse_reset_event(42, 7));
+        let reset = SubscriptionCursor::from_sse_id("0123456789abcdef0123456789abcdef:7").unwrap();
+        let wire = format!("{:?}", sse_reset_event(42, 7, reset));
         assert!(wire.contains("event: reset"), "{wire}");
-        assert!(wire.contains("id: 7"), "{wire}");
+        assert!(
+            wire.contains("id: 0123456789abcdef0123456789abcdef:7"),
+            "{wire}"
+        );
         assert!(wire.contains("data: since: 42"), "{wire}");
         assert!(wire.contains("data: newest: 7"), "{wire}");
     }

--- a/bin/src/server/listen.rs
+++ b/bin/src/server/listen.rs
@@ -100,13 +100,18 @@ pub(crate) async fn handler(
 }
 
 fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, &'static str> {
-    let Some(value) = headers.get("last-event-id") else {
+    let mut values = headers.get_all("last-event-id").iter();
+    let Some(value) = values.next() else {
         return Ok(None);
     };
-    let raw = value.to_str().map_err(|_| "invalid Last-Event-ID")?.trim();
-    if raw.is_empty() {
-        return Ok(None);
+    if values.next().is_some() {
+        return Err("invalid Last-Event-ID");
     }
+    let raw = value.to_str().map_err(|_| "invalid Last-Event-ID")?;
+    if raw.is_empty() || !raw.bytes().all(|b| b.is_ascii_digit()) {
+        return Err("invalid Last-Event-ID");
+    }
+
     raw.parse::<u64>()
         .map(Some)
         .map_err(|_| "invalid Last-Event-ID")
@@ -222,5 +227,30 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn parse_last_event_id_rejects_non_canonical_values() {
+        for value in ["", " 42", "42 ", "+42", "audit:42"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("last-event-id", value.parse().unwrap());
+            assert_eq!(parse_last_event_id(&headers), Err("invalid Last-Event-ID"));
+        }
+    }
+
+    #[test]
+    fn parse_last_event_id_rejects_duplicate_values() {
+        let mut headers = HeaderMap::new();
+        headers.append("last-event-id", "1".parse().unwrap());
+        headers.append("last-event-id", "2".parse().unwrap());
+        assert_eq!(parse_last_event_id(&headers), Err("invalid Last-Event-ID"));
+    }
+
+    #[test]
+    fn parse_last_event_id_accepts_single_ascii_decimal() {
+        let mut headers = HeaderMap::new();
+        headers.insert("last-event-id", "42".parse().unwrap());
+        assert_eq!(parse_last_event_id(&headers), Ok(Some(42)));
+        assert_eq!(parse_last_event_id(&HeaderMap::new()), Ok(None));
     }
 }

--- a/bin/src/server/mqtt/mod.rs
+++ b/bin/src/server/mqtt/mod.rs
@@ -28,7 +28,7 @@ use tokio::{
 
 use crate::{
     engine::{Engine, ShutdownToken},
-    engine_types::AccessTier,
+    engine_types::{AccessTier, SubscriptionResume},
 };
 
 use self::{
@@ -929,7 +929,7 @@ mod tests {
             .subscribe(
                 &SubscribePattern::new("tmp/sensor/*"),
                 AccessTier::Read,
-                Some(0),
+                SubscriptionResume::after_event_id(0),
             )
             .unwrap();
         let (outbound, mut rx) = mpsc::channel(OUTBOUND_QUEUE);
@@ -1364,7 +1364,7 @@ mod tests {
             .subscribe(
                 &SubscribePattern::new("home/sensor/*"),
                 AccessTier::Read,
-                None,
+                SubscriptionResume::none(),
             )
             .unwrap();
         let world = ValidatedWorldPath::new("home/sensor/temp").unwrap();
@@ -1433,7 +1433,7 @@ mod tests {
             .subscribe(
                 &SubscribePattern::new("home/sensor/*"),
                 AccessTier::Read,
-                None,
+                SubscriptionResume::none(),
             )
             .unwrap();
         let world = ValidatedWorldPath::new("home/sensor/temp").unwrap();

--- a/bin/src/server/mqtt/session.rs
+++ b/bin/src/server/mqtt/session.rs
@@ -18,7 +18,7 @@ use crate::{
     engine::{Engine, EngineError},
     engine_types::{
         AccessTier, EngineSubscription, Preconditions, Representation, SubscriptionRecvError,
-        ValidatedWorldPath,
+        SubscriptionResume, ValidatedWorldPath,
     },
 };
 
@@ -367,7 +367,7 @@ impl MqttSession {
         for pattern in route.live_patterns() {
             let subscription = self
                 .engine
-                .subscribe(pattern, self.tier, None)
+                .subscribe(pattern, self.tier, SubscriptionResume::none())
                 .map_err(mqtt_reject_from_engine)?;
             subscriptions.push(subscription);
         }

--- a/bin/src/server/mqtt/session.rs
+++ b/bin/src/server/mqtt/session.rs
@@ -449,6 +449,13 @@ pub(super) async fn subscription_loop(
                 ));
                 continue;
             }
+            Err(SubscriptionRecvError::CursorAhead { since, newest }) => {
+                mqtt_warn(format_args!(
+                    "mqtt: subscription cursor {since} predates this engine id space \
+                     (newest issued id is {newest}); continuing live"
+                ));
+                continue;
+            }
             Err(SubscriptionRecvError::Closed) => break,
             #[allow(unreachable_patterns)]
             Err(_) => continue,

--- a/bin/src/server/mqtt/session.rs
+++ b/bin/src/server/mqtt/session.rs
@@ -449,7 +449,7 @@ pub(super) async fn subscription_loop(
                 ));
                 continue;
             }
-            Err(SubscriptionRecvError::CursorAhead { since, newest }) => {
+            Err(SubscriptionRecvError::CursorAhead { since, newest, .. }) => {
                 mqtt_warn(format_args!(
                     "mqtt: subscription cursor {since} predates this engine id space \
                      (newest issued id is {newest}); continuing live"

--- a/bin/src/server/proc.rs
+++ b/bin/src/server/proc.rs
@@ -717,7 +717,7 @@ mod tests {
 
     #[tokio::test]
     async fn proc_du_and_df_report_resource_usage() {
-        let (engine, dir) = test_engine_for_server_with_storage_quota("proc-du-df", 10);
+        let (engine, dir) = test_engine_for_server_with_storage_quota("proc-du-df", 16);
         engine
             .replace(
                 &world_path("home/hello"),
@@ -742,19 +742,19 @@ mod tests {
         let du = proc_du(State(state.clone()), Method::GET, headers.clone()).await;
         assert_eq!(du.status(), StatusCode::OK);
         let du_body = response_text(du).await;
-        assert!(du_body.contains("home/hello\t5\n"));
+        assert!(du_body.contains("home/hello\t10\n"));
         assert!(du_body.contains("tmp/scratch\t4\n"));
 
         let df = proc_df(State(state.clone()), Method::GET, headers.clone()).await;
         assert_eq!(df.status(), StatusCode::OK);
         let df_body = response_text(df).await;
-        assert!(df_body.contains("storage\t5\t10\t5\n"));
+        assert!(df_body.contains("storage\t10\t16\t6\n"));
         assert!(df_body.contains("memory\t4\t268435456\t268435452\n"));
         assert!(df_body.contains("worlds\t2\tunlimited\tunlimited\n"));
 
         let head = proc_du(State(state), Method::HEAD, headers).await;
         assert_eq!(head.status(), StatusCode::OK);
-        assert_eq!(head.headers().get(header::CONTENT_LENGTH).unwrap(), "27");
+        assert_eq!(head.headers().get(header::CONTENT_LENGTH).unwrap(), "28");
         assert_eq!(response_text(head).await, "");
 
         let _ = std::fs::remove_dir_all(dir);

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -7,8 +7,12 @@ use hmac::{Hmac, KeyInit, Mac};
 use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
-use crate::{engine_types::AuditHmacKey, event::AuditEventKind, world};
+use crate::{engine_types::AuditHmacKey, world};
 use std::{fmt, path::Path};
+
+mod append;
+
+pub(crate) use append::{append_tx, append_with_conn_existing, append_with_conn_genesis};
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
@@ -56,151 +60,6 @@ impl From<rusqlite::Error> for AuditError {
 enum EmptyChain {
     Allow,
     Reject,
-}
-
-/// Append a single row to the audit chain, reusing an already-open
-/// `Connection`. Cached writers (the ledger writer
-/// `Mutex<Option<Connection>>` on `Core`) call this directly so the
-/// hot delete path doesn't re-open `var/log/deletes` 2-3 times per
-/// operation. Per-write paths that don't cache a connection compose
-/// `world::open` + the explicit existing/genesis append entrypoint.
-#[allow(clippy::too_many_arguments)]
-pub fn append_with_conn_existing(
-    conn: &mut Connection,
-    event_type: AuditEventKind,
-    target: &str,
-    body_sha256: &str,
-    size: i64,
-    content_type: &str,
-    headers: &[(String, String)],
-    key: &AuditHmacKey,
-) -> AuditResult<String> {
-    append_with_conn_verified(
-        conn,
-        event_type,
-        target,
-        body_sha256,
-        size,
-        content_type,
-        headers,
-        key,
-        EmptyChain::Reject,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn append_with_conn_genesis(
-    conn: &mut Connection,
-    event_type: AuditEventKind,
-    target: &str,
-    body_sha256: &str,
-    size: i64,
-    content_type: &str,
-    headers: &[(String, String)],
-    key: &AuditHmacKey,
-) -> AuditResult<String> {
-    append_with_conn_verified(
-        conn,
-        event_type,
-        target,
-        body_sha256,
-        size,
-        content_type,
-        headers,
-        key,
-        EmptyChain::Allow,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn append_with_conn_verified(
-    conn: &mut Connection,
-    event_type: AuditEventKind,
-    target: &str,
-    body_sha256: &str,
-    size: i64,
-    content_type: &str,
-    headers: &[(String, String)],
-    key: &AuditHmacKey,
-    empty_chain: EmptyChain,
-) -> AuditResult<String> {
-    let tx = conn.transaction()?;
-    let audit_tx = verify_appendable_tx(&tx, key, empty_chain)?;
-    let h = append_tx(
-        &audit_tx,
-        event_type,
-        target,
-        body_sha256,
-        size,
-        content_type,
-        headers,
-    )?;
-    tx.commit()?;
-    Ok(h)
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn append_tx(
-    audit_tx: &VerifiedAuditTx<'_, '_, '_>,
-    event_type: AuditEventKind,
-    target: &str,
-    body_sha256: &str,
-    size: i64,
-    content_type: &str,
-    headers: &[(String, String)],
-) -> rusqlite::Result<String> {
-    let tx = audit_tx.tx;
-    let class = event_type.class();
-    debug_assert!(class.notifies, "audit rows are timeline-visible events");
-    debug_assert_eq!(class.body_bearing, class.retention_slot);
-    debug_assert_eq!(
-        class.body_bearing,
-        matches!(class.payload_home, crate::event::AuditPayloadHome::Cas)
-    );
-    let canonical = canonical_headers(headers);
-    let meta_sha256 = meta_sha256_canonical(content_type, &canonical);
-    let prev = tx
-        .query_row(
-            "SELECT hmac FROM events ORDER BY id DESC LIMIT 1",
-            [],
-            |r| r.get::<_, String>(0),
-        )
-        .optional()?
-        .unwrap_or_default();
-    let h = event_hmac(
-        audit_tx.key.as_slice(),
-        EventHmacInput {
-            prev: &prev,
-            event_type: event_type.as_str(),
-            target,
-            body_sha256,
-            size,
-            content_type,
-            meta_sha256: &meta_sha256,
-        },
-    );
-    tx.execute(
-        r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
-                              content_type, meta_sha256, hmac, prev_hmac)
-           VALUES(datetime('now'), ?, ?, ?, ?, ?, ?, ?, ?)"#,
-        rusqlite::params![
-            event_type.as_str(),
-            target,
-            body_sha256,
-            size,
-            content_type,
-            meta_sha256,
-            h,
-            prev
-        ],
-    )?;
-    let event_id = tx.last_insert_rowid();
-    let mut stmt =
-        tx.prepare("INSERT INTO event_headers(event_id, name, value) VALUES(?, ?, ?)")?;
-    for (name, value) in canonical {
-        stmt.execute(rusqlite::params![event_id, name, value])?;
-    }
-    Ok(h)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -755,6 +755,33 @@ mod tests {
     }
 
     #[test]
+    fn verify_connection_rejects_retention_floor_pointing_at_metadata_event() {
+        let mut c = test_connection();
+        let tx = c.transaction().unwrap();
+        let key = test_key();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        append_tx_inner(
+            &audit_tx,
+            AuditEventKind::DeleteIntent,
+            "home/a",
+            &BodySha256::for_body(b""),
+            0,
+            "",
+            &[],
+        )
+        .unwrap();
+        set_test_retention_floor(&tx, 1);
+        tx.commit().unwrap();
+
+        let report = verify_connection(&c, &key).unwrap();
+
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak { actual, .. }) if actual == "delete_intent"
+        ));
+    }
+
+    #[test]
     fn verify_connection_rejects_floor_raise_plus_deleted_old_cas_body() {
         let (core, dir) = test_core("audit-floor-raise-delete-cas");
         world::write_with_audit(

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -12,7 +12,11 @@ use std::{fmt, path::Path};
 
 mod append;
 
-pub(crate) use append::{append_body_tx_row, append_with_conn_existing, append_with_conn_genesis};
+#[cfg(test)]
+use append::test_only_append_tx_inner as append_tx_inner;
+pub(crate) use append::{
+    append_retained_body_tx_row, append_with_conn_existing, append_with_conn_genesis,
+};
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
@@ -398,7 +402,8 @@ pub fn latest_hmac(data_root: &Path, world_name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{event::BodyEventKind, test_support::test_core, timeline::BodySha256, world};
+    use crate::timeline::BodySha256;
+    use crate::{event::AuditEventKind, test_support::test_core, world};
     use rusqlite::Connection;
 
     fn test_connection() -> Connection {
@@ -512,9 +517,9 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        let row1 = append_body_tx_row(
+        let row1 = append_tx_inner(
             &audit_tx,
-            BodyEventKind::PUT,
+            AuditEventKind::Put,
             "home/a",
             &BodySha256::for_body(b"abc"),
             3,
@@ -522,9 +527,9 @@ mod tests {
             &[("x-meta-author".to_owned(), "ranger".to_owned())],
         )
         .unwrap();
-        let row2 = append_body_tx_row(
+        let row2 = append_tx_inner(
             &audit_tx,
-            BodyEventKind::APPEND,
+            AuditEventKind::Append,
             "home/a",
             &BodySha256::for_body(b"abcdef"),
             6,
@@ -603,9 +608,9 @@ mod tests {
             let tx = c.transaction().unwrap();
             let key = test_key();
             let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-            append_body_tx_row(
+            append_tx_inner(
                 &audit_tx,
-                BodyEventKind::PUT,
+                AuditEventKind::Put,
                 "home/a",
                 &BodySha256::for_body(b"abc"),
                 3,
@@ -641,9 +646,9 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        append_body_tx_row(
+        append_tx_inner(
             &audit_tx,
-            BodyEventKind::PUT,
+            AuditEventKind::Put,
             "home/a",
             &BodySha256::for_body(b"abc"),
             3,
@@ -689,9 +694,9 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        append_body_tx_row(
+        append_tx_inner(
             &audit_tx,
-            BodyEventKind::PUT,
+            AuditEventKind::Put,
             "home/a",
             &BodySha256::for_body(b"abc"),
             3,

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -4,7 +4,7 @@
 //! the write.
 
 use hmac::{Hmac, KeyInit, Mac};
-use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
+use rusqlite::{OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -23,6 +23,8 @@ use append::test_only_append_tx_inner as append_tx_inner;
 pub(crate) use append::{
     append_retained_body_tx_row, append_with_conn_existing, append_with_conn_genesis,
 };
+#[cfg(test)]
+use rusqlite::Connection;
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
@@ -35,6 +37,7 @@ pub(crate) const AUDIT_CHAIN_BROKEN_PREFIX: &str = "audit chain broken at event 
 pub struct VerifiedAuditTx<'tx, 'conn, 'key> {
     tx: &'tx Transaction<'conn>,
     key: &'key AuditHmacKey,
+    world: ValidatedWorldPath,
 }
 
 pub type AuditResult<T> = Result<T, AuditError>;
@@ -103,11 +106,12 @@ pub fn verify_all_worlds(data_root: &Path, key: &AuditHmacKey) -> AuditResult<()
 pub fn verify_world(data_root: &Path, world_name: &str, key: &AuditHmacKey) -> AuditResult<()> {
     let world_path = ValidatedWorldPath::new(world_name.to_owned())
         .map_err(|_| rusqlite::Error::InvalidQuery)?;
-    let Some(c) = world::open_existing(data_root, world_name)? else {
+    let Some(mut c) = world::open_existing_validated(data_root, &world_path)? else {
         return Ok(());
     };
-    require_intact(verify_world_connection(&c, &world_path, key)?)?;
-    if let Some(break_report) = live_body::verify_conn(&c)? {
+    let tx = c.transaction()?;
+    require_intact(verify_world_tx(&tx, &world_path, key)?)?;
+    if let Some(break_report) = live_body::verify_tx(&tx)? {
         return Err(AuditError::ChainBroken(break_report));
     }
     Ok(())
@@ -148,7 +152,17 @@ fn verify_appendable_tx<'tx, 'conn, 'key>(
     if let Some(break_report) = live_body::verify_tx(tx)? {
         return Err(AuditError::ChainBroken(break_report));
     }
-    Ok(VerifiedAuditTx { tx, key })
+    Ok(VerifiedAuditTx {
+        tx,
+        key,
+        world: world_name.clone(),
+    })
+}
+
+impl VerifiedAuditTx<'_, '_, '_> {
+    pub(crate) fn world(&self) -> &ValidatedWorldPath {
+        &self.world
+    }
 }
 
 struct EventRow {
@@ -224,11 +238,12 @@ pub fn verify_chain_via_conn(
     key: &AuditHmacKey,
 ) -> rusqlite::Result<VerifyReport> {
     let conn = tracked.as_mut_conn();
-    let report = verify_world_connection(conn, world_path, key)?;
+    let tx = conn.transaction()?;
+    let report = verify_world_tx(&tx, world_path, key)?;
     if matches!(report, VerifyReport::Broken(_)) {
         return Ok(report);
     }
-    if let Some(break_report) = live_body::verify_conn(conn)? {
+    if let Some(break_report) = live_body::verify_tx(&tx)? {
         return Ok(VerifyReport::Broken(break_report));
     }
     Ok(report)
@@ -241,13 +256,13 @@ fn verify_connection(c: &Connection, key: &AuditHmacKey) -> rusqlite::Result<Ver
     verify_statement(&mut stmt, key.as_slice(), false, &retention, None)
 }
 
-fn verify_world_connection(
-    c: &Connection,
+fn verify_world_tx(
+    tx: &Transaction<'_>,
     world_name: &ValidatedWorldPath,
     key: &AuditHmacKey,
 ) -> rusqlite::Result<VerifyReport> {
-    let retention = retention::load(c)?;
-    let mut stmt = c.prepare(AUDIT_SELECT)?;
+    let retention = retention::load(tx)?;
+    let mut stmt = tx.prepare(AUDIT_SELECT)?;
     verify_statement(
         &mut stmt,
         key.as_slice(),

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -12,7 +12,7 @@ use std::{fmt, path::Path};
 
 mod append;
 
-pub(crate) use append::{append_tx, append_with_conn_existing, append_with_conn_genesis};
+pub(crate) use append::{append_body_tx_row, append_with_conn_existing, append_with_conn_genesis};
 
 const AUDIT_SELECT: &str = r#"SELECT e.id, e.event_type, e.target, e.body_sha256, e.size,
                   e.content_type, e.meta_sha256, e.hmac, e.prev_hmac,
@@ -398,7 +398,7 @@ pub fn latest_hmac(data_root: &Path, world_name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{event::AuditEventKind, test_support::test_core, world};
+    use crate::{event::BodyEventKind, test_support::test_core, timeline::BodySha256, world};
     use rusqlite::Connection;
 
     fn test_connection() -> Connection {
@@ -512,21 +512,21 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        let h1 = append_tx(
+        let h1 = append_body_tx_row(
             &audit_tx,
-            AuditEventKind::Put,
+            BodyEventKind::PUT,
             "home/a",
-            "abc",
+            &BodySha256::for_body(b"abc"),
             3,
             "text/plain",
             &[("x-meta-author".to_owned(), "ranger".to_owned())],
         )
         .unwrap();
-        let h2 = append_tx(
+        let h2 = append_body_tx_row(
             &audit_tx,
-            AuditEventKind::Append,
+            BodyEventKind::APPEND,
             "home/a",
-            "def",
+            &BodySha256::for_body(b"abcdef"),
             6,
             "text/plain",
             &[],
@@ -599,11 +599,11 @@ mod tests {
             let tx = c.transaction().unwrap();
             let key = test_key();
             let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-            append_tx(
+            append_body_tx_row(
                 &audit_tx,
-                AuditEventKind::Put,
+                BodyEventKind::PUT,
                 "home/a",
-                "abc",
+                &BodySha256::for_body(b"abc"),
                 3,
                 "text/plain",
                 &[],
@@ -637,11 +637,11 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        append_tx(
+        append_body_tx_row(
             &audit_tx,
-            AuditEventKind::Put,
+            BodyEventKind::PUT,
             "home/a",
-            "abc",
+            &BodySha256::for_body(b"abc"),
             3,
             "text/plain",
             &[],
@@ -685,11 +685,11 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        append_tx(
+        append_body_tx_row(
             &audit_tx,
-            AuditEventKind::Put,
+            BodyEventKind::PUT,
             "home/a",
-            "abc",
+            &BodySha256::for_body(b"abc"),
             3,
             "text/plain",
             &[("x-meta-author".to_owned(), "ranger".to_owned())],

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -11,6 +11,7 @@ use crate::{engine_types::AuditHmacKey, timeline::TimelineSeq, world};
 use std::{collections::HashSet, fmt, path::Path};
 
 mod append;
+mod live_body;
 mod retention;
 
 #[cfg(test)]
@@ -99,7 +100,11 @@ pub fn verify_world(data_root: &Path, world_name: &str, key: &AuditHmacKey) -> A
     let Some(c) = world::open_existing(data_root, world_name)? else {
         return Ok(());
     };
-    require_intact(verify_connection(&c, key)?)
+    require_intact(verify_connection(&c, key)?)?;
+    if let Some(break_report) = live_body::verify_conn(&c)? {
+        return Err(AuditError::ChainBroken(break_report));
+    }
+    Ok(())
 }
 
 pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn, 'key>(
@@ -130,6 +135,9 @@ fn verify_appendable_tx<'tx, 'conn, 'key>(
         allow_empty,
         &retention,
     )?)?;
+    if let Some(break_report) = live_body::verify_tx(tx)? {
+        return Err(AuditError::ChainBroken(break_report));
+    }
     Ok(VerifiedAuditTx { tx, key })
 }
 
@@ -559,6 +567,36 @@ mod tests {
             .unwrap();
         assert_eq!(author, "ranger");
 
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_world_rejects_tampered_live_body() {
+        let (core, dir) = test_core("audit-live-body-tamper");
+        world::write_with_audit(
+            &core.data,
+            "home/live-body",
+            b"good",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/live-body")).unwrap();
+        c.execute(
+            "UPDATE stage_meta SET body=?1 WHERE id=1",
+            [b"bad".as_slice()],
+        )
+        .unwrap();
+        drop(c);
+
+        let err = verify_world(&core.data, "home/live-body", &core.hmac_key).unwrap_err();
+
+        assert!(matches!(
+            err,
+            AuditError::ChainBroken(VerifyBreak { actual, .. })
+                if actual.starts_with("live-body-sha256-")
+        ));
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -7,7 +7,11 @@ use hmac::{Hmac, KeyInit, Mac};
 use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
-use crate::{engine_types::AuditHmacKey, timeline::TimelineSeq, world};
+use crate::{
+    engine_types::{AuditHmacKey, ValidatedWorldPath},
+    timeline::TimelineSeq,
+    world,
+};
 use std::{collections::HashSet, fmt, path::Path};
 
 mod append;
@@ -97,10 +101,12 @@ pub fn verify_all_worlds(data_root: &Path, key: &AuditHmacKey) -> AuditResult<()
 }
 
 pub fn verify_world(data_root: &Path, world_name: &str, key: &AuditHmacKey) -> AuditResult<()> {
+    let world_path = ValidatedWorldPath::new(world_name.to_owned())
+        .map_err(|_| rusqlite::Error::InvalidQuery)?;
     let Some(c) = world::open_existing(data_root, world_name)? else {
         return Ok(());
     };
-    require_intact(verify_connection(&c, key)?)?;
+    require_intact(verify_world_connection(&c, &world_path, key)?)?;
     if let Some(break_report) = live_body::verify_conn(&c)? {
         return Err(AuditError::ChainBroken(break_report));
     }
@@ -109,20 +115,23 @@ pub fn verify_world(data_root: &Path, world_name: &str, key: &AuditHmacKey) -> A
 
 pub(crate) fn verify_appendable_tx_existing_checked<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
+    world_name: &ValidatedWorldPath,
     key: &'key AuditHmacKey,
 ) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
-    verify_appendable_tx(tx, key, EmptyChain::Reject)
+    verify_appendable_tx(tx, world_name, key, EmptyChain::Reject)
 }
 
 pub(crate) fn verify_appendable_tx_genesis_checked<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
+    world_name: &ValidatedWorldPath,
     key: &'key AuditHmacKey,
 ) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
-    verify_appendable_tx(tx, key, EmptyChain::Allow)
+    verify_appendable_tx(tx, world_name, key, EmptyChain::Allow)
 }
 
 fn verify_appendable_tx<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
+    world_name: &ValidatedWorldPath,
     key: &'key AuditHmacKey,
     empty_chain: EmptyChain,
 ) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
@@ -134,6 +143,7 @@ fn verify_appendable_tx<'tx, 'conn, 'key>(
         key.as_slice(),
         allow_empty,
         &retention,
+        Some(world_name.as_str()),
     )?)?;
     if let Some(break_report) = live_body::verify_tx(tx)? {
         return Err(AuditError::ChainBroken(break_report));
@@ -213,10 +223,13 @@ pub fn chain_head_via_conn(
 /// usual SlotState write guard.
 pub fn verify_chain_via_conn(
     tracked: &mut crate::read_cache::TrackedReadConnection,
+    world_name: &str,
     key: &AuditHmacKey,
 ) -> rusqlite::Result<VerifyReport> {
+    let world_path = ValidatedWorldPath::new(world_name.to_owned())
+        .map_err(|_| rusqlite::Error::InvalidQuery)?;
     let conn = tracked.as_mut_conn();
-    let report = verify_connection(conn, key)?;
+    let report = verify_world_connection(conn, &world_path, key)?;
     if matches!(report, VerifyReport::Broken(_)) {
         return Ok(report);
     }
@@ -226,10 +239,27 @@ pub fn verify_chain_via_conn(
     Ok(report)
 }
 
+#[cfg(test)]
 fn verify_connection(c: &Connection, key: &AuditHmacKey) -> rusqlite::Result<VerifyReport> {
     let retention = retention::load(c)?;
     let mut stmt = c.prepare(AUDIT_SELECT)?;
-    verify_statement(&mut stmt, key.as_slice(), false, &retention)
+    verify_statement(&mut stmt, key.as_slice(), false, &retention, None)
+}
+
+fn verify_world_connection(
+    c: &Connection,
+    world_name: &ValidatedWorldPath,
+    key: &AuditHmacKey,
+) -> rusqlite::Result<VerifyReport> {
+    let retention = retention::load(c)?;
+    let mut stmt = c.prepare(AUDIT_SELECT)?;
+    verify_statement(
+        &mut stmt,
+        key.as_slice(),
+        false,
+        &retention,
+        Some(world_name.as_str()),
+    )
 }
 
 fn verify_statement(
@@ -237,6 +267,7 @@ fn verify_statement(
     key: &[u8],
     allow_empty: bool,
     retention: &retention::CasRetentionState,
+    expected_target: Option<&str>,
 ) -> rusqlite::Result<VerifyReport> {
     let mut state = VerifyAccumulator {
         prev: String::new(),
@@ -264,7 +295,14 @@ fn verify_statement(
         };
         if current.as_ref().is_some_and(|event| event.id != row.id) {
             let event = current.take().expect("current event");
-            if let Some(break_report) = verify_event(&event, &headers, key, retention, &mut state) {
+            if let Some(break_report) = verify_event(
+                &event,
+                &headers,
+                key,
+                retention,
+                &mut state,
+                expected_target,
+            ) {
                 return Ok(VerifyReport::Broken(break_report));
             }
             headers.clear();
@@ -280,7 +318,14 @@ fn verify_statement(
     }
 
     if let Some(event) = current {
-        if let Some(break_report) = verify_event(&event, &headers, key, retention, &mut state) {
+        if let Some(break_report) = verify_event(
+            &event,
+            &headers,
+            key,
+            retention,
+            &mut state,
+            expected_target,
+        ) {
             return Ok(VerifyReport::Broken(break_report));
         }
     }
@@ -324,8 +369,18 @@ fn verify_event(
     key: &[u8],
     retention: &retention::CasRetentionState,
     state: &mut VerifyAccumulator,
+    expected_target: Option<&str>,
 ) -> Option<VerifyBreak> {
     let idx = state.events;
+    if matches!(row.event_type.as_str(), "put" | "append")
+        && expected_target.is_some_and(|target| target != row.target)
+    {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: format!("target-{}", expected_target.unwrap_or_default()),
+            actual: format!("target-{}", row.target),
+        });
+    }
     if !crate::auth::ct_eq(row.prev_hmac.as_bytes(), state.prev.as_bytes()) {
         return Some(VerifyBreak {
             break_at: idx,
@@ -696,7 +751,8 @@ mod tests {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        let audit_tx =
+            verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key).unwrap();
         append_tx_inner(
             &audit_tx,
             AuditEventKind::Put,
@@ -759,7 +815,8 @@ mod tests {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        let audit_tx =
+            verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key).unwrap();
         append_tx_inner(
             &audit_tx,
             AuditEventKind::DeleteIntent,
@@ -860,7 +917,8 @@ mod tests {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        let audit_tx =
+            verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key).unwrap();
         let row1 = append_tx_inner(
             &audit_tx,
             AuditEventKind::Put,
@@ -954,7 +1012,7 @@ mod tests {
 
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let err = match verify_appendable_tx_genesis_checked(&tx, &key) {
+        let err = match verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key) {
             Ok(_) => panic!("corrupt latest hmac must not be treated as an empty chain"),
             Err(e) => e,
         };
@@ -975,7 +1033,8 @@ mod tests {
         {
             let tx = c.transaction().unwrap();
             let key = test_key();
-            let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+            let audit_tx =
+                verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key).unwrap();
             append_tx_inner(
                 &audit_tx,
                 AuditEventKind::Put,
@@ -995,7 +1054,7 @@ mod tests {
 
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let err = match verify_appendable_tx_existing_checked(&tx, &key) {
+        let err = match verify_appendable_tx_existing_checked(&tx, &validated("home/a"), &key) {
             Ok(_) => panic!("tampered audit chain must not be appendable"),
             Err(err) => err,
         };
@@ -1015,7 +1074,8 @@ mod tests {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        let audit_tx =
+            verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key).unwrap();
         append_tx_inner(
             &audit_tx,
             AuditEventKind::Put,
@@ -1066,7 +1126,8 @@ mod tests {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
         let key = test_key();
-        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        let audit_tx =
+            verify_appendable_tx_genesis_checked(&tx, &validated("home/a"), &key).unwrap();
         append_tx_inner(
             &audit_tx,
             AuditEventKind::Put,

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -215,7 +215,15 @@ pub fn verify_chain_via_conn(
     tracked: &mut crate::read_cache::TrackedReadConnection,
     key: &AuditHmacKey,
 ) -> rusqlite::Result<VerifyReport> {
-    verify_connection(tracked.as_mut_conn(), key)
+    let conn = tracked.as_mut_conn();
+    let report = verify_connection(conn, key)?;
+    if matches!(report, VerifyReport::Broken(_)) {
+        return Ok(report);
+    }
+    if let Some(break_report) = live_body::verify_conn(conn)? {
+        return Ok(VerifyReport::Broken(break_report));
+    }
+    Ok(report)
 }
 
 fn verify_connection(c: &Connection, key: &AuditHmacKey) -> rusqlite::Result<VerifyReport> {

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -7,10 +7,11 @@ use hmac::{Hmac, KeyInit, Mac};
 use rusqlite::{Connection, OptionalExtension, Statement, Transaction};
 use sha2::{Digest, Sha256};
 
-use crate::{engine_types::AuditHmacKey, world};
-use std::{fmt, path::Path};
+use crate::{engine_types::AuditHmacKey, timeline::TimelineSeq, world};
+use std::{collections::HashSet, fmt, path::Path};
 
 mod append;
+mod retention;
 
 #[cfg(test)]
 use append::test_only_append_tx_inner as append_tx_inner;
@@ -120,9 +121,15 @@ fn verify_appendable_tx<'tx, 'conn, 'key>(
     key: &'key AuditHmacKey,
     empty_chain: EmptyChain,
 ) -> AuditResult<VerifiedAuditTx<'tx, 'conn, 'key>> {
+    let retention = retention::load(tx)?;
     let mut stmt = tx.prepare(AUDIT_SELECT)?;
     let allow_empty = matches!(empty_chain, EmptyChain::Allow);
-    require_intact(verify_statement(&mut stmt, key.as_slice(), allow_empty)?)?;
+    require_intact(verify_statement(
+        &mut stmt,
+        key.as_slice(),
+        allow_empty,
+        &retention,
+    )?)?;
     Ok(VerifiedAuditTx { tx, key })
 }
 
@@ -136,6 +143,15 @@ struct EventRow {
     meta_sha256: String,
     hmac: String,
     prev_hmac: String,
+}
+
+struct VerifyAccumulator {
+    prev: String,
+    genesis: String,
+    events: usize,
+    first_body_event: Option<TimelineSeq>,
+    saw_retention_floor: bool,
+    referenced_retained_bodies: HashSet<String>,
 }
 
 struct EventHmacInput<'a> {
@@ -195,18 +211,25 @@ pub fn verify_chain_via_conn(
 }
 
 fn verify_connection(c: &Connection, key: &AuditHmacKey) -> rusqlite::Result<VerifyReport> {
+    let retention = retention::load(c)?;
     let mut stmt = c.prepare(AUDIT_SELECT)?;
-    verify_statement(&mut stmt, key.as_slice(), false)
+    verify_statement(&mut stmt, key.as_slice(), false, &retention)
 }
 
 fn verify_statement(
     stmt: &mut Statement<'_>,
     key: &[u8],
     allow_empty: bool,
+    retention: &retention::CasRetentionState,
 ) -> rusqlite::Result<VerifyReport> {
-    let mut prev = String::new();
-    let mut genesis = String::new();
-    let mut events = 0usize;
+    let mut state = VerifyAccumulator {
+        prev: String::new(),
+        genesis: String::new(),
+        events: 0,
+        first_body_event: None,
+        saw_retention_floor: retention.floor_is_unset(),
+        referenced_retained_bodies: HashSet::new(),
+    };
     let mut rows = stmt.query([])?;
     let mut current: Option<EventRow> = None;
     let mut headers = Vec::new();
@@ -225,9 +248,7 @@ fn verify_statement(
         };
         if current.as_ref().is_some_and(|event| event.id != row.id) {
             let event = current.take().expect("current event");
-            if let Some(break_report) =
-                verify_event(&event, &headers, key, &mut prev, &mut genesis, &mut events)
-            {
+            if let Some(break_report) = verify_event(&event, &headers, key, retention, &mut state) {
                 return Ok(VerifyReport::Broken(break_report));
             }
             headers.clear();
@@ -243,14 +264,16 @@ fn verify_statement(
     }
 
     if let Some(event) = current {
-        if let Some(break_report) =
-            verify_event(&event, &headers, key, &mut prev, &mut genesis, &mut events)
-        {
+        if let Some(break_report) = verify_event(&event, &headers, key, retention, &mut state) {
             return Ok(VerifyReport::Broken(break_report));
         }
     }
 
-    if events == 0 {
+    if let Some(break_report) = retention::verify_completion(&state, retention) {
+        return Ok(VerifyReport::Broken(break_report));
+    }
+
+    if state.events == 0 {
         if allow_empty {
             return Ok(VerifyReport::Valid(VerifyOk {
                 events: 0,
@@ -266,9 +289,9 @@ fn verify_statement(
     }
 
     Ok(VerifyReport::Valid(VerifyOk {
-        events,
-        genesis: hmac_label(&genesis),
-        latest: hmac_label(&prev),
+        events: state.events,
+        genesis: hmac_label(&state.genesis),
+        latest: hmac_label(&state.prev),
     }))
 }
 
@@ -283,15 +306,14 @@ fn verify_event(
     row: &EventRow,
     headers: &[(String, String)],
     key: &[u8],
-    prev: &mut String,
-    genesis: &mut String,
-    events: &mut usize,
+    retention: &retention::CasRetentionState,
+    state: &mut VerifyAccumulator,
 ) -> Option<VerifyBreak> {
-    let idx = *events;
-    if !crate::auth::ct_eq(row.prev_hmac.as_bytes(), prev.as_bytes()) {
+    let idx = state.events;
+    if !crate::auth::ct_eq(row.prev_hmac.as_bytes(), state.prev.as_bytes()) {
         return Some(VerifyBreak {
             break_at: idx,
-            expected: hmac_label(prev),
+            expected: hmac_label(&state.prev),
             actual: hmac_label(&row.prev_hmac),
         });
     }
@@ -306,7 +328,7 @@ fn verify_event(
     let expected_hmac = event_hmac(
         key,
         EventHmacInput {
-            prev,
+            prev: &state.prev,
             event_type: &row.event_type,
             target: &row.target,
             body_sha256: &row.body_sha256,
@@ -322,11 +344,14 @@ fn verify_event(
             actual: hmac_label(&row.hmac),
         });
     }
-    if idx == 0 {
-        *genesis = row.hmac.clone();
+    if let Some(break_report) = retention::verify_retained_body(row, idx, retention, state) {
+        return Some(break_report);
     }
-    *prev = row.hmac.clone();
-    *events += 1;
+    if idx == 0 {
+        state.genesis = row.hmac.clone();
+    }
+    state.prev = row.hmac.clone();
+    state.events += 1;
     None
 }
 
@@ -427,6 +452,15 @@ mod tests {
                 name TEXT NOT NULL,
                 value TEXT NOT NULL
             );
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY,
+                body BLOB NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE cas_state(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                first_retained_seq INTEGER
+            );
+            INSERT INTO cas_state(id, first_retained_seq) VALUES(1, NULL);
             "#,
         )
         .unwrap();
@@ -435,6 +469,23 @@ mod tests {
 
     fn test_key() -> AuditHmacKey {
         AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
+    fn retain_test_body(tx: &Transaction<'_>, body: &[u8]) {
+        let body_sha256 = BodySha256::for_body(body);
+        tx.execute(
+            "INSERT OR IGNORE INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+            rusqlite::params![body_sha256.as_str(), body],
+        )
+        .unwrap();
+    }
+
+    fn set_test_retention_floor(tx: &Transaction<'_>, seq: i64) {
+        tx.execute(
+            "UPDATE cas_state SET first_retained_seq=?1 WHERE id=1",
+            rusqlite::params![seq],
+        )
+        .unwrap();
     }
 
     fn hmac_for_fields(event_type: &str, target: &str) -> String {
@@ -512,6 +563,221 @@ mod tests {
     }
 
     #[test]
+    fn verify_connection_rejects_missing_retained_cas_body() {
+        let (core, dir) = test_core("audit-missing-cas-body");
+        world::write_with_audit(
+            &core.data,
+            "home/missing-cas",
+            b"retained",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/missing-cas")).unwrap();
+        c.execute("DELETE FROM cas_bodies", []).unwrap();
+
+        let report = verify_connection(&c, &core.hmac_key).unwrap();
+
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak { actual, .. }) if actual == "missing-cas-body"
+        ));
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_connection_rejects_corrupt_retained_cas_body() {
+        let (core, dir) = test_core("audit-corrupt-cas-body");
+        world::write_with_audit(
+            &core.data,
+            "home/corrupt-cas",
+            b"retained",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/corrupt-cas")).unwrap();
+        c.execute("UPDATE cas_bodies SET body=?1", [b"tampered".as_slice()])
+            .unwrap();
+
+        let err = verify_connection(&c, &core.hmac_key).unwrap_err();
+
+        assert!(err.to_string().contains("does not match body_sha256"));
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_connection_rejects_unreferenced_cas_body() {
+        let (core, dir) = test_core("audit-unreferenced-cas-body");
+        world::write_with_audit(
+            &core.data,
+            "home/unreferenced-cas",
+            b"retained",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/unreferenced-cas")).unwrap();
+        let extra_hash = BodySha256::for_body(b"extra");
+        c.execute(
+            "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+            rusqlite::params![extra_hash.as_str(), b"extra".as_slice()],
+        )
+        .unwrap();
+
+        let report = verify_connection(&c, &core.hmac_key).unwrap();
+
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak { actual, .. }) if actual == "unreferenced-cas-body"
+        ));
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_connection_rejects_retained_cas_body_size_mismatch() {
+        let mut c = test_connection();
+        let tx = c.transaction().unwrap();
+        let key = test_key();
+        let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
+        append_tx_inner(
+            &audit_tx,
+            AuditEventKind::Put,
+            "home/a",
+            &BodySha256::for_body(b"abc"),
+            4,
+            "text/plain",
+            &[],
+        )
+        .unwrap();
+        retain_test_body(&tx, b"abc");
+        set_test_retention_floor(&tx, 1);
+        tx.commit().unwrap();
+
+        let report = verify_connection(&c, &key).unwrap();
+
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak { actual, .. }) if actual == "cas-body-size-3"
+        ));
+    }
+
+    #[test]
+    fn verify_connection_rejects_retention_floor_that_skips_body() {
+        let (core, dir) = test_core("audit-floor-skips-body");
+        world::write_with_audit(
+            &core.data,
+            "home/floor-skip",
+            b"one",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        world::write_with_audit(
+            &core.data,
+            "home/floor-skip",
+            b"two",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/floor-skip")).unwrap();
+        c.execute("UPDATE cas_state SET first_retained_seq=2 WHERE id=1", [])
+            .unwrap();
+
+        let report = verify_connection(&c, &core.hmac_key).unwrap();
+
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak { actual, .. }) if actual == "first_retained_seq-2"
+        ));
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_connection_rejects_floor_raise_plus_deleted_old_cas_body() {
+        let (core, dir) = test_core("audit-floor-raise-delete-cas");
+        world::write_with_audit(
+            &core.data,
+            "home/floor-raise-delete",
+            b"one",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        world::write_with_audit(
+            &core.data,
+            "home/floor-raise-delete",
+            b"two",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/floor-raise-delete")).unwrap();
+        let first_hash: String = c
+            .query_row("SELECT body_sha256 FROM events WHERE id=1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        c.execute(
+            "DELETE FROM cas_bodies WHERE body_sha256=?1",
+            [first_hash.as_str()],
+        )
+        .unwrap();
+        c.execute("UPDATE cas_state SET first_retained_seq=2 WHERE id=1", [])
+            .unwrap();
+
+        let report = verify_connection(&c, &core.hmac_key).unwrap();
+
+        assert!(matches!(
+            report,
+            VerifyReport::Broken(VerifyBreak { actual, .. }) if actual == "first_retained_seq-2"
+        ));
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_connection_rejects_null_floor_plus_deleted_cas_bodies() {
+        let (core, dir) = test_core("audit-null-floor-delete-cas");
+        world::write_with_audit(
+            &core.data,
+            "home/null-floor-delete",
+            b"one",
+            "text/plain",
+            &[],
+            &core.hmac_key,
+        )
+        .unwrap();
+        let c = Connection::open(world::world_db(&core.data, "home/null-floor-delete")).unwrap();
+        c.execute("DELETE FROM cas_bodies", []).unwrap();
+        c.execute(
+            "UPDATE cas_state SET first_retained_seq=NULL WHERE id=1",
+            [],
+        )
+        .unwrap();
+
+        let err = verify_connection(&c, &core.hmac_key).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("body-bearing events exist before first_retained_seq is set"));
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn verify_connection_accepts_intact_chain() {
         let mut c = test_connection();
         let tx = c.transaction().unwrap();
@@ -541,6 +807,9 @@ mod tests {
         assert_eq!(row2.id().get(), 2);
         let h1 = row1.hmac().to_owned();
         let h2 = row2.hmac().to_owned();
+        retain_test_body(&tx, b"abc");
+        retain_test_body(&tx, b"abcdef");
+        set_test_retention_floor(&tx, 1);
         tx.commit().unwrap();
 
         let report = verify_connection(&c, &key).unwrap();
@@ -576,11 +845,32 @@ mod tests {
                 name TEXT NOT NULL,
                 value TEXT NOT NULL
             );
-            INSERT INTO events(timestamp, event_type, target, body_sha256, size,
-                               content_type, meta_sha256, hmac, prev_hmac)
-            VALUES(datetime('now'), 'put', 'home/a', 'abc', 3,
-                   'text/plain', 'meta', x'ff', '');
+            CREATE TABLE cas_bodies(
+                body_sha256 TEXT NOT NULL PRIMARY KEY,
+                body BLOB NOT NULL
+            ) WITHOUT ROWID;
+            CREATE TABLE cas_state(
+                id INTEGER PRIMARY KEY CHECK(id=1),
+                first_retained_seq INTEGER
+            );
+            INSERT INTO cas_state(id, first_retained_seq) VALUES(1, NULL);
             "#,
+        )
+        .unwrap();
+        let body_sha256 = BodySha256::for_body(b"abc");
+        c.execute(
+            "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+            rusqlite::params![body_sha256.as_str(), b"abc".as_slice()],
+        )
+        .unwrap();
+        c.execute("UPDATE cas_state SET first_retained_seq=1 WHERE id=1", [])
+            .unwrap();
+        c.execute(
+            r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
+                                  content_type, meta_sha256, hmac, prev_hmac)
+               VALUES(datetime('now'), 'put', 'home/a', ?1, 3,
+                      'text/plain', 'meta', x'ff', '')"#,
+            rusqlite::params![body_sha256.as_str()],
         )
         .unwrap();
 
@@ -618,6 +908,8 @@ mod tests {
                 &[],
             )
             .unwrap();
+            retain_test_body(&tx, b"abc");
+            set_test_retention_floor(&tx, 1);
             tx.commit().unwrap();
         }
         c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
@@ -656,6 +948,8 @@ mod tests {
             &[],
         )
         .unwrap();
+        retain_test_body(&tx, b"abc");
+        set_test_retention_floor(&tx, 1);
         tx.commit().unwrap();
         c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
             .unwrap();
@@ -704,6 +998,8 @@ mod tests {
             &[("x-meta-author".to_owned(), "ranger".to_owned())],
         )
         .unwrap();
+        retain_test_body(&tx, b"abc");
+        set_test_retention_floor(&tx, 1);
         tx.commit().unwrap();
         c.execute(
             "UPDATE event_headers SET value='intruder' WHERE name='x-meta-author'",

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -443,6 +443,7 @@ pub fn latest_hmac(data_root: &Path, world_name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine_types::ValidatedWorldPath;
     use crate::timeline::BodySha256;
     use crate::{event::AuditEventKind, test_support::test_core, world};
     use rusqlite::Connection;
@@ -485,6 +486,10 @@ mod tests {
 
     fn test_key() -> AuditHmacKey {
         AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
+    fn validated(world: &str) -> ValidatedWorldPath {
+        ValidatedWorldPath::new(world).unwrap()
     }
 
     fn retain_test_body(tx: &Transaction<'_>, body: &[u8]) {
@@ -544,7 +549,7 @@ mod tests {
         let headers = vec![("x-meta-author".to_string(), "ranger".to_string())];
         let h = world::write_with_audit(
             &core.data,
-            "home/audit-meta",
+            &validated("home/audit-meta"),
             b"hello",
             "text/plain; charset=utf-8",
             &headers,
@@ -583,7 +588,7 @@ mod tests {
         let (core, dir) = test_core("audit-live-body-tamper");
         world::write_with_audit(
             &core.data,
-            "home/live-body",
+            &validated("home/live-body"),
             b"good",
             "text/plain",
             &[],
@@ -613,7 +618,7 @@ mod tests {
         let (core, dir) = test_core("audit-missing-cas-body");
         world::write_with_audit(
             &core.data,
-            "home/missing-cas",
+            &validated("home/missing-cas"),
             b"retained",
             "text/plain",
             &[],
@@ -638,7 +643,7 @@ mod tests {
         let (core, dir) = test_core("audit-corrupt-cas-body");
         world::write_with_audit(
             &core.data,
-            "home/corrupt-cas",
+            &validated("home/corrupt-cas"),
             b"retained",
             "text/plain",
             &[],
@@ -661,7 +666,7 @@ mod tests {
         let (core, dir) = test_core("audit-unreferenced-cas-body");
         world::write_with_audit(
             &core.data,
-            "home/unreferenced-cas",
+            &validated("home/unreferenced-cas"),
             b"retained",
             "text/plain",
             &[],
@@ -719,7 +724,7 @@ mod tests {
         let (core, dir) = test_core("audit-floor-skips-body");
         world::write_with_audit(
             &core.data,
-            "home/floor-skip",
+            &validated("home/floor-skip"),
             b"one",
             "text/plain",
             &[],
@@ -728,7 +733,7 @@ mod tests {
         .unwrap();
         world::write_with_audit(
             &core.data,
-            "home/floor-skip",
+            &validated("home/floor-skip"),
             b"two",
             "text/plain",
             &[],
@@ -754,7 +759,7 @@ mod tests {
         let (core, dir) = test_core("audit-floor-raise-delete-cas");
         world::write_with_audit(
             &core.data,
-            "home/floor-raise-delete",
+            &validated("home/floor-raise-delete"),
             b"one",
             "text/plain",
             &[],
@@ -763,7 +768,7 @@ mod tests {
         .unwrap();
         world::write_with_audit(
             &core.data,
-            "home/floor-raise-delete",
+            &validated("home/floor-raise-delete"),
             b"two",
             "text/plain",
             &[],
@@ -799,7 +804,7 @@ mod tests {
         let (core, dir) = test_core("audit-null-floor-delete-cas");
         world::write_with_audit(
             &core.data,
-            "home/null-floor-delete",
+            &validated("home/null-floor-delete"),
             b"one",
             "text/plain",
             &[],
@@ -1017,7 +1022,8 @@ mod tests {
             std::env::temp_dir().join(format!("elastik-audit-startup-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         let key = test_key();
-        world::write_with_audit(&root, "home/a", b"abc", "text/plain", &[], &key).unwrap();
+        world::write_with_audit(&root, &validated("home/a"), b"abc", "text/plain", &[], &key)
+            .unwrap();
         {
             let c = Connection::open(world::world_db(&root, "home/a")).unwrap();
             c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -512,7 +512,7 @@ mod tests {
         let tx = c.transaction().unwrap();
         let key = test_key();
         let audit_tx = verify_appendable_tx_genesis_checked(&tx, &key).unwrap();
-        let h1 = append_body_tx_row(
+        let row1 = append_body_tx_row(
             &audit_tx,
             BodyEventKind::PUT,
             "home/a",
@@ -522,7 +522,7 @@ mod tests {
             &[("x-meta-author".to_owned(), "ranger".to_owned())],
         )
         .unwrap();
-        let h2 = append_body_tx_row(
+        let row2 = append_body_tx_row(
             &audit_tx,
             BodyEventKind::APPEND,
             "home/a",
@@ -532,6 +532,10 @@ mod tests {
             &[],
         )
         .unwrap();
+        assert_eq!(row1.id().get(), 1);
+        assert_eq!(row2.id().get(), 2);
+        let h1 = row1.hmac().to_owned();
+        let h2 = row2.hmac().to_owned();
         tx.commit().unwrap();
 
         let report = verify_connection(&c, &key).unwrap();

--- a/core/src/audit.rs
+++ b/core/src/audit.rs
@@ -170,10 +170,10 @@ struct EventHmacInput<'a> {
 /// This is the unit of external anchoring (the O(1) subset of what
 /// `verify_chain_via_conn` reports as `latest`): a host that remembers the
 /// returned stamp can later prove tail truncation or rollback whenever the
-/// observed head is behind the anchored seq — which in-file verification
+/// observed head is behind the anchored seq -- which in-file verification
 /// structurally cannot. (A rolled-back or replaced chain re-grown past the
 /// anchor needs the at-seq divergence check, a later PR.) Returns
-/// `Ok(None)` for an empty chain (bootstrap-shape DB) — nothing to anchor
+/// `Ok(None)` for an empty chain (bootstrap-shape DB) -- nothing to anchor
 /// yet.
 ///
 /// Same type gate as `verify_chain_via_conn`: no bare-connection path, so

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -6,6 +6,7 @@ use crate::{
     engine_types::AuditHmacKey,
     event::{AuditEventKind, BodyEventKind, EventMetadataKind},
     timeline::{BodySha256, TimelineSeq},
+    world,
 };
 
 use super::{
@@ -18,7 +19,6 @@ pub(crate) struct AppendedAuditRow {
 }
 
 impl AppendedAuditRow {
-    #[allow(dead_code)]
     pub(crate) fn id(&self) -> TimelineSeq {
         self.id
     }
@@ -28,12 +28,6 @@ impl AppendedAuditRow {
     }
 }
 
-/// Append a single row to the audit chain, reusing an already-open
-/// `Connection`. Cached writers (the ledger writer
-/// `Mutex<Option<Connection>>` on `Core`) call this directly so the
-/// hot delete path doesn't re-open `var/log/deletes` 2-3 times per
-/// operation. Per-write paths that don't cache a connection compose
-/// `world::open` + the explicit existing/genesis append entrypoint.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn append_with_conn_existing(
     conn: &mut Connection,
@@ -110,21 +104,19 @@ fn append_with_conn_verified(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn append_body_tx_row(
+pub(crate) fn append_retained_body_tx_row(
     audit_tx: &VerifiedAuditTx<'_, '_, '_>,
     event_type: BodyEventKind,
-    target: &str,
-    body_sha256: &BodySha256,
-    size: i64,
+    retained: &world::RetainedCasBody,
     content_type: &str,
     headers: &[(String, String)],
 ) -> rusqlite::Result<AppendedAuditRow> {
     append_tx_inner(
         audit_tx,
         event_type.kind(),
-        target,
-        body_sha256,
-        size,
+        retained.target(),
+        retained.body_sha256(),
+        retained.size(),
         content_type,
         headers,
     )
@@ -193,4 +185,26 @@ fn append_tx_inner(
     }
     let id = TimelineSeq::new(event_id).map_err(|_| rusqlite::Error::InvalidQuery)?;
     Ok(AppendedAuditRow { id, hmac: h })
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn test_only_append_tx_inner(
+    audit_tx: &VerifiedAuditTx<'_, '_, '_>,
+    event_type: AuditEventKind,
+    target: &str,
+    body_sha256: &BodySha256,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+) -> rusqlite::Result<AppendedAuditRow> {
+    append_tx_inner(
+        audit_tx,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+    )
 }

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -2,7 +2,11 @@
 
 use rusqlite::{Connection, OptionalExtension};
 
-use crate::{engine_types::AuditHmacKey, event::AuditEventKind};
+use crate::{
+    engine_types::AuditHmacKey,
+    event::{AuditEventKind, BodyEventKind, EventMetadataKind},
+    timeline::BodySha256,
+};
 
 use super::{
     canonical_headers, event_hmac, AuditResult, EmptyChain, EventHmacInput, VerifiedAuditTx,
@@ -17,9 +21,9 @@ use super::{
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn append_with_conn_existing(
     conn: &mut Connection,
-    event_type: AuditEventKind,
+    event_type: EventMetadataKind,
     target: &str,
-    body_sha256: &str,
+    body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
@@ -41,9 +45,9 @@ pub(crate) fn append_with_conn_existing(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn append_with_conn_genesis(
     conn: &mut Connection,
-    event_type: AuditEventKind,
+    event_type: EventMetadataKind,
     target: &str,
-    body_sha256: &str,
+    body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
@@ -65,9 +69,9 @@ pub(crate) fn append_with_conn_genesis(
 #[allow(clippy::too_many_arguments)]
 fn append_with_conn_verified(
     conn: &mut Connection,
-    event_type: AuditEventKind,
+    event_type: EventMetadataKind,
     target: &str,
-    body_sha256: &str,
+    body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
@@ -76,9 +80,9 @@ fn append_with_conn_verified(
 ) -> AuditResult<String> {
     let tx = conn.transaction()?;
     let audit_tx = super::verify_appendable_tx(&tx, key, empty_chain)?;
-    let h = append_tx(
+    let h = append_tx_inner(
         &audit_tx,
-        event_type,
+        event_type.kind(),
         target,
         body_sha256,
         size,
@@ -90,11 +94,32 @@ fn append_with_conn_verified(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn append_tx(
+pub(crate) fn append_body_tx_row(
+    audit_tx: &VerifiedAuditTx<'_, '_, '_>,
+    event_type: BodyEventKind,
+    target: &str,
+    body_sha256: &BodySha256,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+) -> rusqlite::Result<String> {
+    append_tx_inner(
+        audit_tx,
+        event_type.kind(),
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_tx_inner(
     audit_tx: &VerifiedAuditTx<'_, '_, '_>,
     event_type: AuditEventKind,
     target: &str,
-    body_sha256: &str,
+    body_sha256: &BodySha256,
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
@@ -123,7 +148,7 @@ pub(crate) fn append_tx(
             prev: &prev,
             event_type: event_type.as_str(),
             target,
-            body_sha256,
+            body_sha256: body_sha256.as_str(),
             size,
             content_type,
             meta_sha256: &meta_sha256,
@@ -136,7 +161,7 @@ pub(crate) fn append_tx(
         rusqlite::params![
             event_type.as_str(),
             target,
-            body_sha256,
+            body_sha256.as_str(),
             size,
             content_type,
             meta_sha256,

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -114,7 +114,7 @@ pub(crate) fn append_retained_body_tx_row(
     append_tx_inner(
         audit_tx,
         event_type.kind(),
-        retained.target(),
+        retained.target().as_str(),
         retained.body_sha256(),
         retained.size(),
         content_type,

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -3,7 +3,7 @@
 use rusqlite::{Connection, OptionalExtension};
 
 use crate::{
-    engine_types::AuditHmacKey,
+    engine_types::{AuditHmacKey, ValidatedWorldPath},
     event::{AuditEventKind, BodyEventKind, EventMetadataKind},
     timeline::{BodySha256, TimelineSeq},
     world,
@@ -32,6 +32,7 @@ impl AppendedAuditRow {
 pub(crate) fn append_with_conn_existing(
     conn: &mut Connection,
     event_type: EventMetadataKind,
+    ledger_world: &ValidatedWorldPath,
     target: &str,
     body_sha256: &BodySha256,
     size: i64,
@@ -42,6 +43,7 @@ pub(crate) fn append_with_conn_existing(
     append_with_conn_verified(
         conn,
         event_type,
+        ledger_world,
         target,
         body_sha256,
         size,
@@ -56,6 +58,7 @@ pub(crate) fn append_with_conn_existing(
 pub(crate) fn append_with_conn_genesis(
     conn: &mut Connection,
     event_type: EventMetadataKind,
+    ledger_world: &ValidatedWorldPath,
     target: &str,
     body_sha256: &BodySha256,
     size: i64,
@@ -66,6 +69,7 @@ pub(crate) fn append_with_conn_genesis(
     append_with_conn_verified(
         conn,
         event_type,
+        ledger_world,
         target,
         body_sha256,
         size,
@@ -80,6 +84,7 @@ pub(crate) fn append_with_conn_genesis(
 fn append_with_conn_verified(
     conn: &mut Connection,
     event_type: EventMetadataKind,
+    ledger_world: &ValidatedWorldPath,
     target: &str,
     body_sha256: &BodySha256,
     size: i64,
@@ -89,7 +94,7 @@ fn append_with_conn_verified(
     empty_chain: EmptyChain,
 ) -> AuditResult<String> {
     let tx = conn.transaction()?;
-    let audit_tx = super::verify_appendable_tx(&tx, key, empty_chain)?;
+    let audit_tx = super::verify_appendable_tx(&tx, ledger_world, key, empty_chain)?;
     let row = append_tx_inner(
         &audit_tx,
         event_type.kind(),

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -1,0 +1,154 @@
+//! Audit-row append helpers.
+
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::{engine_types::AuditHmacKey, event::AuditEventKind};
+
+use super::{
+    canonical_headers, event_hmac, AuditResult, EmptyChain, EventHmacInput, VerifiedAuditTx,
+};
+
+/// Append a single row to the audit chain, reusing an already-open
+/// `Connection`. Cached writers (the ledger writer
+/// `Mutex<Option<Connection>>` on `Core`) call this directly so the
+/// hot delete path doesn't re-open `var/log/deletes` 2-3 times per
+/// operation. Per-write paths that don't cache a connection compose
+/// `world::open` + the explicit existing/genesis append entrypoint.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn append_with_conn_existing(
+    conn: &mut Connection,
+    event_type: AuditEventKind,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+    key: &AuditHmacKey,
+) -> AuditResult<String> {
+    append_with_conn_verified(
+        conn,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+        key,
+        EmptyChain::Reject,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn append_with_conn_genesis(
+    conn: &mut Connection,
+    event_type: AuditEventKind,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+    key: &AuditHmacKey,
+) -> AuditResult<String> {
+    append_with_conn_verified(
+        conn,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+        key,
+        EmptyChain::Allow,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_with_conn_verified(
+    conn: &mut Connection,
+    event_type: AuditEventKind,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+    key: &AuditHmacKey,
+    empty_chain: EmptyChain,
+) -> AuditResult<String> {
+    let tx = conn.transaction()?;
+    let audit_tx = super::verify_appendable_tx(&tx, key, empty_chain)?;
+    let h = append_tx(
+        &audit_tx,
+        event_type,
+        target,
+        body_sha256,
+        size,
+        content_type,
+        headers,
+    )?;
+    tx.commit()?;
+    Ok(h)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn append_tx(
+    audit_tx: &VerifiedAuditTx<'_, '_, '_>,
+    event_type: AuditEventKind,
+    target: &str,
+    body_sha256: &str,
+    size: i64,
+    content_type: &str,
+    headers: &[(String, String)],
+) -> rusqlite::Result<String> {
+    let tx = audit_tx.tx;
+    let class = event_type.class();
+    debug_assert!(class.notifies, "audit rows are timeline-visible events");
+    debug_assert_eq!(class.body_bearing, class.retention_slot);
+    debug_assert_eq!(
+        class.body_bearing,
+        matches!(class.payload_home, crate::event::AuditPayloadHome::Cas)
+    );
+    let canonical = canonical_headers(headers);
+    let meta_sha256 = super::meta_sha256_canonical(content_type, &canonical);
+    let prev = tx
+        .query_row(
+            "SELECT hmac FROM events ORDER BY id DESC LIMIT 1",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()?
+        .unwrap_or_default();
+    let h = event_hmac(
+        audit_tx.key.as_slice(),
+        EventHmacInput {
+            prev: &prev,
+            event_type: event_type.as_str(),
+            target,
+            body_sha256,
+            size,
+            content_type,
+            meta_sha256: &meta_sha256,
+        },
+    );
+    tx.execute(
+        r#"INSERT INTO events(timestamp, event_type, target, body_sha256, size,
+                              content_type, meta_sha256, hmac, prev_hmac)
+           VALUES(datetime('now'), ?, ?, ?, ?, ?, ?, ?, ?)"#,
+        rusqlite::params![
+            event_type.as_str(),
+            target,
+            body_sha256,
+            size,
+            content_type,
+            meta_sha256,
+            h,
+            prev
+        ],
+    )?;
+    let event_id = tx.last_insert_rowid();
+    let mut stmt =
+        tx.prepare("INSERT INTO event_headers(event_id, name, value) VALUES(?, ?, ?)")?;
+    for (name, value) in canonical {
+        stmt.execute(rusqlite::params![event_id, name, value])?;
+    }
+    Ok(h)
+}

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -5,12 +5,28 @@ use rusqlite::{Connection, OptionalExtension};
 use crate::{
     engine_types::AuditHmacKey,
     event::{AuditEventKind, BodyEventKind, EventMetadataKind},
-    timeline::BodySha256,
+    timeline::{BodySha256, TimelineSeq},
 };
 
 use super::{
     canonical_headers, event_hmac, AuditResult, EmptyChain, EventHmacInput, VerifiedAuditTx,
 };
+
+pub(crate) struct AppendedAuditRow {
+    id: TimelineSeq,
+    hmac: String,
+}
+
+impl AppendedAuditRow {
+    #[allow(dead_code)]
+    pub(crate) fn id(&self) -> TimelineSeq {
+        self.id
+    }
+
+    pub(crate) fn hmac(&self) -> &str {
+        &self.hmac
+    }
+}
 
 /// Append a single row to the audit chain, reusing an already-open
 /// `Connection`. Cached writers (the ledger writer
@@ -80,7 +96,7 @@ fn append_with_conn_verified(
 ) -> AuditResult<String> {
     let tx = conn.transaction()?;
     let audit_tx = super::verify_appendable_tx(&tx, key, empty_chain)?;
-    let h = append_tx_inner(
+    let row = append_tx_inner(
         &audit_tx,
         event_type.kind(),
         target,
@@ -90,7 +106,7 @@ fn append_with_conn_verified(
         headers,
     )?;
     tx.commit()?;
-    Ok(h)
+    Ok(row.hmac().to_owned())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -102,7 +118,7 @@ pub(crate) fn append_body_tx_row(
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
-) -> rusqlite::Result<String> {
+) -> rusqlite::Result<AppendedAuditRow> {
     append_tx_inner(
         audit_tx,
         event_type.kind(),
@@ -123,7 +139,7 @@ fn append_tx_inner(
     size: i64,
     content_type: &str,
     headers: &[(String, String)],
-) -> rusqlite::Result<String> {
+) -> rusqlite::Result<AppendedAuditRow> {
     let tx = audit_tx.tx;
     let class = event_type.class();
     debug_assert!(class.notifies, "audit rows are timeline-visible events");
@@ -175,5 +191,6 @@ fn append_tx_inner(
     for (name, value) in canonical {
         stmt.execute(rusqlite::params![event_id, name, value])?;
     }
-    Ok(h)
+    let id = TimelineSeq::new(event_id).map_err(|_| rusqlite::Error::InvalidQuery)?;
+    Ok(AppendedAuditRow { id, hmac: h })
 }

--- a/core/src/audit/append.rs
+++ b/core/src/audit/append.rs
@@ -116,6 +116,9 @@ pub(crate) fn append_retained_body_tx_row(
     content_type: &str,
     headers: &[(String, String)],
 ) -> rusqlite::Result<AppendedAuditRow> {
+    if retained.target() != audit_tx.world() {
+        return Err(rusqlite::Error::InvalidQuery);
+    }
     append_tx_inner(
         audit_tx,
         event_type.kind(),

--- a/core/src/audit/live_body.rs
+++ b/core/src/audit/live_body.rs
@@ -1,0 +1,114 @@
+//! Live body head verification for one world DB.
+
+use rusqlite::{Connection, OptionalExtension, Transaction};
+
+use crate::{event::AuditEventKind, timeline::BodySha256};
+
+use super::VerifyBreak;
+
+pub(super) fn verify_conn(c: &Connection) -> rusqlite::Result<Option<VerifyBreak>> {
+    if !has_stage_meta_conn(c)? {
+        return Ok(None);
+    }
+    let live_body = c.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
+        r.get::<_, Vec<u8>>(0)
+    })?;
+    let latest = latest_body_event_conn(c)?;
+    let event_count = event_count_conn(c)?;
+    Ok(live_body_head_break(live_body, latest, event_count))
+}
+
+pub(super) fn verify_tx(tx: &Transaction<'_>) -> rusqlite::Result<Option<VerifyBreak>> {
+    if !has_stage_meta_tx(tx)? {
+        return Ok(None);
+    }
+    let live_body = tx.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
+        r.get::<_, Vec<u8>>(0)
+    })?;
+    let latest = latest_body_event_tx(tx)?;
+    let event_count = event_count_tx(tx)?;
+    Ok(live_body_head_break(live_body, latest, event_count))
+}
+
+fn live_body_head_break(
+    live_body: Vec<u8>,
+    latest: Option<(i64, String, i64)>,
+    event_count: usize,
+) -> Option<VerifyBreak> {
+    let live_hash = BodySha256::for_body(&live_body);
+    let live_size = i64::try_from(live_body.len()).unwrap_or(i64::MAX);
+    let break_at = event_count.saturating_sub(1);
+    let Some((_id, body_sha256, size)) = latest else {
+        if live_body.is_empty() {
+            return None;
+        }
+        return Some(VerifyBreak {
+            break_at,
+            expected: "latest body-bearing event".to_owned(),
+            actual: format!("live-body-sha256-{}", live_hash.as_str()),
+        });
+    };
+    if body_sha256 != live_hash.as_str() {
+        return Some(VerifyBreak {
+            break_at,
+            expected: format!("live-body-sha256-{body_sha256}"),
+            actual: format!("live-body-sha256-{}", live_hash.as_str()),
+        });
+    }
+    if size != live_size {
+        return Some(VerifyBreak {
+            break_at,
+            expected: format!("live-body-size-{size}"),
+            actual: format!("live-body-size-{live_size}"),
+        });
+    }
+    None
+}
+
+fn has_stage_meta_conn(c: &Connection) -> rusqlite::Result<bool> {
+    c.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='stage_meta' LIMIT 1",
+        [],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn has_stage_meta_tx(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
+    tx.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='stage_meta' LIMIT 1",
+        [],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn latest_body_event_conn(c: &Connection) -> rusqlite::Result<Option<(i64, String, i64)>> {
+    c.query_row(
+        "SELECT id, body_sha256, size FROM events WHERE event_type IN (?1, ?2) ORDER BY id DESC LIMIT 1",
+        rusqlite::params![AuditEventKind::Put.as_str(), AuditEventKind::Append.as_str()],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+    )
+    .optional()
+}
+
+fn latest_body_event_tx(tx: &Transaction<'_>) -> rusqlite::Result<Option<(i64, String, i64)>> {
+    tx.query_row(
+        "SELECT id, body_sha256, size FROM events WHERE event_type IN (?1, ?2) ORDER BY id DESC LIMIT 1",
+        rusqlite::params![AuditEventKind::Put.as_str(), AuditEventKind::Append.as_str()],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+    )
+    .optional()
+}
+
+fn event_count_conn(c: &Connection) -> rusqlite::Result<usize> {
+    let count = c.query_row("SELECT COUNT(*) FROM events", [], |r| r.get::<_, i64>(0))?;
+    Ok(count.max(0) as usize)
+}
+
+fn event_count_tx(tx: &Transaction<'_>) -> rusqlite::Result<usize> {
+    let count = tx.query_row("SELECT COUNT(*) FROM events", [], |r| r.get::<_, i64>(0))?;
+    Ok(count.max(0) as usize)
+}

--- a/core/src/audit/live_body.rs
+++ b/core/src/audit/live_body.rs
@@ -1,22 +1,10 @@
 //! Live body head verification for one world DB.
 
-use rusqlite::{Connection, OptionalExtension, Transaction};
+use rusqlite::{OptionalExtension, Transaction};
 
 use crate::{event::AuditEventKind, timeline::BodySha256};
 
 use super::VerifyBreak;
-
-pub(super) fn verify_conn(c: &Connection) -> rusqlite::Result<Option<VerifyBreak>> {
-    if !has_stage_meta_conn(c)? {
-        return Ok(None);
-    }
-    let live_body = c.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
-        r.get::<_, Vec<u8>>(0)
-    })?;
-    let latest = latest_body_event_conn(c)?;
-    let event_count = event_count_conn(c)?;
-    Ok(live_body_head_break(live_body, latest, event_count))
-}
 
 pub(super) fn verify_tx(tx: &Transaction<'_>) -> rusqlite::Result<Option<VerifyBreak>> {
     if !has_stage_meta_tx(tx)? {
@@ -65,16 +53,6 @@ fn live_body_head_break(
     None
 }
 
-fn has_stage_meta_conn(c: &Connection) -> rusqlite::Result<bool> {
-    c.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='stage_meta' LIMIT 1",
-        [],
-        |_| Ok(()),
-    )
-    .optional()
-    .map(|row| row.is_some())
-}
-
 fn has_stage_meta_tx(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
     tx.query_row(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='stage_meta' LIMIT 1",
@@ -85,15 +63,6 @@ fn has_stage_meta_tx(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
     .map(|row| row.is_some())
 }
 
-fn latest_body_event_conn(c: &Connection) -> rusqlite::Result<Option<(i64, String, i64)>> {
-    c.query_row(
-        "SELECT id, body_sha256, size FROM events WHERE event_type IN (?1, ?2) ORDER BY id DESC LIMIT 1",
-        rusqlite::params![AuditEventKind::Put.as_str(), AuditEventKind::Append.as_str()],
-        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
-    )
-    .optional()
-}
-
 fn latest_body_event_tx(tx: &Transaction<'_>) -> rusqlite::Result<Option<(i64, String, i64)>> {
     tx.query_row(
         "SELECT id, body_sha256, size FROM events WHERE event_type IN (?1, ?2) ORDER BY id DESC LIMIT 1",
@@ -101,11 +70,6 @@ fn latest_body_event_tx(tx: &Transaction<'_>) -> rusqlite::Result<Option<(i64, S
         |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
     )
     .optional()
-}
-
-fn event_count_conn(c: &Connection) -> rusqlite::Result<usize> {
-    let count = c.query_row("SELECT COUNT(*) FROM events", [], |r| r.get::<_, i64>(0))?;
-    Ok(count.max(0) as usize)
 }
 
 fn event_count_tx(tx: &Transaction<'_>) -> rusqlite::Result<usize> {

--- a/core/src/audit/retention.rs
+++ b/core/src/audit/retention.rs
@@ -1,0 +1,194 @@
+//! CAS retained-body verification for the audit chain.
+
+use rusqlite::{ffi, Connection, OptionalExtension};
+use std::collections::HashMap;
+
+use crate::{
+    event::AuditEventKind,
+    timeline::{BodySha256, TimelineSeq},
+};
+
+use super::{EventRow, VerifyAccumulator, VerifyBreak};
+
+pub(super) struct CasRetentionState {
+    first_retained_seq: Option<TimelineSeq>,
+    bodies: HashMap<String, RetainedCasBodyInfo>,
+}
+
+impl CasRetentionState {
+    pub(super) fn floor_is_unset(&self) -> bool {
+        self.first_retained_seq.is_none()
+    }
+}
+
+struct RetainedCasBodyInfo {
+    len: i64,
+}
+
+pub(super) fn load(c: &Connection) -> rusqlite::Result<CasRetentionState> {
+    let first_retained_seq = c
+        .query_row(
+            "SELECT first_retained_seq FROM cas_state WHERE id=1",
+            [],
+            |r| r.get::<_, Option<i64>>(0),
+        )?
+        .map(|seq| TimelineSeq::new(seq).map_err(|_| corrupt_error("invalid first_retained_seq")))
+        .transpose()?;
+    let mut bodies = HashMap::new();
+    {
+        let mut stmt = c.prepare("SELECT body_sha256, body FROM cas_bodies")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?))
+        })?;
+        for row in rows {
+            let (body_sha256, body) = row?;
+            let computed = BodySha256::for_body(&body);
+            if computed.as_str() != body_sha256 {
+                return Err(corrupt_error("cas_bodies.body does not match body_sha256"));
+            }
+            let len = i64::try_from(body.len())
+                .map_err(|_| corrupt_error("cas_bodies.body length does not fit i64"))?;
+            bodies.insert(body_sha256, RetainedCasBodyInfo { len });
+        }
+    }
+    if first_retained_seq.is_none() && !bodies.is_empty() {
+        return Err(corrupt_error(
+            "cas_bodies rows exist before first_retained_seq is set",
+        ));
+    }
+    if first_retained_seq.is_none() && has_body_bearing_events(c)? {
+        return Err(corrupt_error(
+            "body-bearing events exist before first_retained_seq is set",
+        ));
+    }
+    Ok(CasRetentionState {
+        first_retained_seq,
+        bodies,
+    })
+}
+
+pub(super) fn verify_completion(
+    state: &VerifyAccumulator,
+    retention: &CasRetentionState,
+) -> Option<VerifyBreak> {
+    if !state.saw_retention_floor {
+        let Some(first_retained_seq) = retention.first_retained_seq else {
+            return Some(VerifyBreak {
+                break_at: state.events,
+                expected: "retention floor".to_owned(),
+                actual: "unset-retention-floor".to_owned(),
+            });
+        };
+        return Some(VerifyBreak {
+            break_at: state.events,
+            expected: format!(
+                "body-bearing event at first_retained_seq {}",
+                first_retained_seq.get()
+            ),
+            actual: "missing-retention-floor-event".to_owned(),
+        });
+    }
+    if state.referenced_retained_bodies.len() != retention.bodies.len() {
+        return Some(VerifyBreak {
+            break_at: state.events,
+            expected: "all CAS bodies referenced by retained events".to_owned(),
+            actual: "unreferenced-cas-body".to_owned(),
+        });
+    }
+    None
+}
+
+pub(super) fn verify_retained_body(
+    row: &EventRow,
+    idx: usize,
+    retention: &CasRetentionState,
+    state: &mut VerifyAccumulator,
+) -> Option<VerifyBreak> {
+    let floor = retention.first_retained_seq?;
+    let is_body_event = is_body_bearing_event_type(&row.event_type);
+    if is_body_event && state.first_body_event.is_none() {
+        let first_body_event = match TimelineSeq::new(row.id) {
+            Ok(seq) => seq,
+            Err(_) => {
+                return Some(VerifyBreak {
+                    break_at: idx,
+                    expected: "positive body-bearing event id".to_owned(),
+                    actual: format!("event-id-{}", row.id),
+                });
+            }
+        };
+        state.first_body_event = Some(first_body_event);
+        if first_body_event != floor {
+            return Some(VerifyBreak {
+                break_at: idx,
+                expected: format!("first_retained_seq-{}", first_body_event.get()),
+                actual: format!("first_retained_seq-{}", floor.get()),
+            });
+        }
+    }
+    if row.id == floor.get() && !is_body_event {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: format!("body-bearing event at first_retained_seq {}", floor.get()),
+            actual: row.event_type.clone(),
+        });
+    }
+    if row.id < floor.get() || !is_body_event {
+        return None;
+    }
+    if BodySha256::new(row.body_sha256.clone()).is_err() {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: "valid body_sha256".to_owned(),
+            actual: format!("body-sha256-{}", row.body_sha256),
+        });
+    }
+    let Some(retained) = retention.bodies.get(&row.body_sha256) else {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: format!("cas-body-{}", row.body_sha256),
+            actual: "missing-cas-body".to_owned(),
+        });
+    };
+    if retained.len != row.size {
+        return Some(VerifyBreak {
+            break_at: idx,
+            expected: format!("cas-body-size-{}", row.size),
+            actual: format!("cas-body-size-{}", retained.len),
+        });
+    }
+    if row.id == floor.get() {
+        state.saw_retention_floor = true;
+    }
+    state
+        .referenced_retained_bodies
+        .insert(row.body_sha256.clone());
+    None
+}
+
+fn has_body_bearing_events(c: &Connection) -> rusqlite::Result<bool> {
+    c.query_row(
+        "SELECT 1 FROM events WHERE event_type IN (?1, ?2) LIMIT 1",
+        rusqlite::params![
+            AuditEventKind::Put.as_str(),
+            AuditEventKind::Append.as_str()
+        ],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn is_body_bearing_event_type(event_type: &str) -> bool {
+    event_type == AuditEventKind::Put.as_str() || event_type == AuditEventKind::Append.as_str()
+}
+
+fn corrupt_error(reason: &str) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error {
+            code: ffi::ErrorCode::DatabaseCorrupt,
+            extended_code: ffi::SQLITE_CORRUPT,
+        },
+        Some(reason.to_owned()),
+    )
+}

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -15,8 +15,9 @@ use crate::{
     event::EventMetadataKind,
     store,
     timeline::BodySha256,
-    AuditAppendJob, AuthGate, BlockingSqliteError, Core, StorageFailureClass,
+    world, AuditAppendJob, AuthGate, BlockingSqliteError, Core, StorageFailureClass,
 };
+use rusqlite::ffi;
 
 pub(crate) struct DeleteRequest {
     pub(crate) preconditions: Preconditions,
@@ -110,6 +111,22 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     else {
         return Err(DeleteError::NotFound);
     };
+    let storage_len_before = if store::is_persistent(world_name) {
+        match world::storage_len(&core.data, world_name)
+            .map_err(|err| classify_storage_error("storage size", &permit.world, err))?
+        {
+            Some(len) => len,
+            None => {
+                return Err(classify_storage_error(
+                    "storage size",
+                    &permit.world,
+                    storage_len_missing_error(),
+                ));
+            }
+        }
+    } else {
+        stage.body.len()
+    };
     let body_sha256_before = BodySha256::for_body(&stage.body);
 
     if let Err(err) = core
@@ -150,7 +167,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     if store::is_persistent(world_name) {
         core.storage_body_bytes
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
-                Some(used.saturating_sub(stage.body.len()))
+                Some(used.saturating_sub(storage_len_before))
             })
             .ok();
         core.durable_world_count
@@ -215,6 +232,16 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
 
 fn ledger_hmac_key(core: &Core) -> crate::engine_types::AuditHmacKey {
     core.hmac_key.clone_secret()
+}
+
+fn storage_len_missing_error() -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        ffi::Error {
+            code: ffi::ErrorCode::DatabaseCorrupt,
+            extended_code: ffi::SQLITE_CORRUPT,
+        },
+        Some("persistent world vanished while computing storage_len".to_owned()),
+    )
 }
 
 fn check_preconditions(

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -112,7 +112,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
         return Err(DeleteError::NotFound);
     };
     let storage_len_before = if store::is_persistent(world_name) {
-        match world::storage_len(&core.data, world_name)
+        match world::storage_len(&core.data, &permit.world)
             .map_err(|err| classify_storage_error("storage size", &permit.world, err))?
         {
             Some(len) => len,
@@ -131,7 +131,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
 
     if let Err(err) = core
         .append_to_ledger(AuditAppendJob {
-            ledger_world: "var/log/deletes",
+            ledger_world: delete_ledger_world(),
             event_type: EventMetadataKind::DELETE_INTENT,
             target: world_name.to_owned(),
             body_sha256: body_sha256_before.clone(),
@@ -182,7 +182,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
 
     if let Err(commit_err) = core
         .append_to_ledger(AuditAppendJob {
-            ledger_world: "var/log/deletes",
+            ledger_world: delete_ledger_world(),
             event_type: EventMetadataKind::DELETE_COMMIT,
             target: world_name.to_owned(),
             body_sha256: body_sha256_before.clone(),
@@ -202,7 +202,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
         hooks.audit_commit_failed(&commit_err);
         match core
             .append_to_ledger(AuditAppendJob {
-                ledger_world: "var/log/deletes",
+                ledger_world: delete_ledger_world(),
                 event_type: EventMetadataKind::DELETE_COMMIT_FAILED,
                 target: world_name.to_owned(),
                 body_sha256: body_sha256_before,
@@ -232,6 +232,11 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
 
 fn ledger_hmac_key(core: &Core) -> crate::engine_types::AuditHmacKey {
     core.hmac_key.clone_secret()
+}
+
+fn delete_ledger_world() -> ValidatedWorldPath {
+    ValidatedWorldPath::new("var/log/deletes")
+        .expect("delete ledger world is a canonical validated path")
 }
 
 fn storage_len_missing_error() -> rusqlite::Error {

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -157,7 +157,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     core.install_tombstone(&permit.world).await;
     hooks.read_cache_drained();
 
-    let ok = core.delete_world_blocking(world_name).await;
+    let ok = core.delete_world_blocking(&permit.world).await;
     core.clear_tombstone(&permit.world);
     if !ok {
         return Err(DeleteError::DeleteFailedAfterIntent);
@@ -375,10 +375,10 @@ mod tests {
 
         let (core, dir) = test_core("delete-ledger-no-cas");
         let subject = ValidatedWorldPath::new("home/delete-ledger-no-cas").unwrap();
-        core.write_world(subject.as_str(), b"body", "text/plain", &[])
+        core.test_only_write_world(subject.as_str(), b"body", "text/plain", &[])
             .unwrap();
         assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
-        core.write_world(subject.as_str(), b"body", "application/octet-stream", &[])
+        core.test_only_write_world(subject.as_str(), b"body", "application/octet-stream", &[])
             .unwrap();
         assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
 

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -12,8 +12,10 @@ use crate::{
     engine::EngineError,
     engine_types::{ChangeVerb, Preconditions, ValidatedWorldPath},
     etag,
-    event::AuditEventKind,
-    store, world, AuditAppendJob, AuthGate, BlockingSqliteError, Core, StorageFailureClass,
+    event::EventMetadataKind,
+    store,
+    timeline::BodySha256,
+    AuditAppendJob, AuthGate, BlockingSqliteError, Core, StorageFailureClass,
 };
 
 pub(crate) struct DeleteRequest {
@@ -108,12 +110,12 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     else {
         return Err(DeleteError::NotFound);
     };
-    let body_sha256_before = world::sha256_hex(&stage.body);
+    let body_sha256_before = BodySha256::for_body(&stage.body);
 
     if let Err(err) = core
         .append_to_ledger(AuditAppendJob {
             ledger_world: "var/log/deletes",
-            event_type: AuditEventKind::DeleteIntent,
+            event_type: EventMetadataKind::DELETE_INTENT,
             target: world_name.to_owned(),
             body_sha256: body_sha256_before.clone(),
             size: 0,
@@ -164,7 +166,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
     if let Err(commit_err) = core
         .append_to_ledger(AuditAppendJob {
             ledger_world: "var/log/deletes",
-            event_type: AuditEventKind::DeleteCommit,
+            event_type: EventMetadataKind::DELETE_COMMIT,
             target: world_name.to_owned(),
             body_sha256: body_sha256_before.clone(),
             size: 0,
@@ -184,7 +186,7 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
         match core
             .append_to_ledger(AuditAppendJob {
                 ledger_world: "var/log/deletes",
-                event_type: AuditEventKind::DeleteCommitFailed,
+                event_type: EventMetadataKind::DELETE_COMMIT_FAILED,
                 target: world_name.to_owned(),
                 body_sha256: body_sha256_before,
                 size: 0,

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -154,11 +154,11 @@ pub(crate) async fn delete<H: DeleteTraceHooks + ?Sized>(
         core.durable_world_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    core.install_tombstone(world_name).await;
+    core.install_tombstone(&permit.world).await;
     hooks.read_cache_drained();
 
     let ok = core.delete_world_blocking(world_name).await;
-    core.clear_tombstone(world_name);
+    core.clear_tombstone(&permit.world);
     if !ok {
         return Err(DeleteError::DeleteFailedAfterIntent);
     }

--- a/core/src/delete_ops.rs
+++ b/core/src/delete_ops.rs
@@ -343,6 +343,7 @@ impl From<DeleteError> for EngineError {
 mod tests {
     use super::*;
     use crate::engine_types::ValidatedWorldPath;
+    use crate::test_support::test_core;
 
     #[test]
     fn delete_permit_requires_approve_and_binds_world() {
@@ -365,5 +366,52 @@ mod tests {
             authorize_delete(&world, auth::Tier::Approve),
             Err(DeleteError::AppendOnlyLedger)
         ));
+    }
+
+    #[tokio::test]
+    async fn delete_ledger_metadata_events_do_not_retain_cas_bodies() {
+        struct NoopTrace;
+        impl DeleteTraceHooks for NoopTrace {}
+
+        let (core, dir) = test_core("delete-ledger-no-cas");
+        let subject = ValidatedWorldPath::new("home/delete-ledger-no-cas").unwrap();
+        core.write_world(subject.as_str(), b"body", "text/plain", &[])
+            .unwrap();
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
+        core.write_world(subject.as_str(), b"body", "application/octet-stream", &[])
+            .unwrap();
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
+
+        let permit = authorize_delete(&subject, auth::Tier::Approve).unwrap();
+        delete(
+            &core,
+            &permit,
+            DeleteRequest {
+                preconditions: Preconditions::none(),
+                content_type: "application/octet-stream".to_owned(),
+                headers: Vec::new(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+
+        let c =
+            rusqlite::Connection::open(crate::world::world_db(&dir, "var/log/deletes")).unwrap();
+        let cas_rows: i64 = c
+            .query_row("SELECT COUNT(*) FROM cas_bodies", [], |r| r.get(0))
+            .unwrap();
+        let first_retained_seq: Option<i64> = c
+            .query_row(
+                "SELECT first_retained_seq FROM cas_state WHERE id=1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(cas_rows, 0);
+        assert_eq!(first_retained_seq, None);
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 0);
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -543,6 +543,7 @@ fn verify_all_worlds_with_names(
 mod tests {
     use super::*;
     use crate::engine_types::SecretBytes;
+    use crate::engine_types::ValidatedWorldPath;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_root(name: &str) -> PathBuf {
@@ -695,8 +696,9 @@ mod tests {
     fn build_verifies_audit_chains_before_returning_engine() {
         let root = temp_root("audit-verify");
         let key = AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap();
+        let world = ValidatedWorldPath::new("home/audit").unwrap();
         let write_result =
-            world::write_with_audit_checked(&root, "home/audit", b"body", "text/plain", &[], &key);
+            world::write_with_audit_checked(&root, &world, b"body", "text/plain", &[], &key);
         assert!(write_result.is_ok(), "fixture write should succeed");
         let db = world::world_db(&root, "home/audit");
         let conn = rusqlite::Connection::open(db).unwrap();
@@ -721,8 +723,9 @@ mod tests {
     fn build_classifies_non_chain_verify_failures_as_storage_errors() {
         let root = temp_root("audit-storage-error");
         let key = AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap();
+        let world = ValidatedWorldPath::new("home/schema").unwrap();
         let write_result =
-            world::write_with_audit_checked(&root, "home/schema", b"body", "text/plain", &[], &key);
+            world::write_with_audit_checked(&root, &world, b"body", "text/plain", &[], &key);
         assert!(write_result.is_ok(), "fixture write should succeed");
         let db = world::world_db(&root, "home/schema");
         let conn = rusqlite::Connection::open(db).unwrap();

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -695,15 +695,8 @@ mod tests {
     fn build_verifies_audit_chains_before_returning_engine() {
         let root = temp_root("audit-verify");
         let key = AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap();
-        let write_result = world::write_with_audit_checked(
-            &root,
-            "home/audit",
-            b"body",
-            "text/plain",
-            &[],
-            &key,
-            None,
-        );
+        let write_result =
+            world::write_with_audit_checked(&root, "home/audit", b"body", "text/plain", &[], &key);
         assert!(write_result.is_ok(), "fixture write should succeed");
         let db = world::world_db(&root, "home/audit");
         let conn = rusqlite::Connection::open(db).unwrap();
@@ -728,15 +721,8 @@ mod tests {
     fn build_classifies_non_chain_verify_failures_as_storage_errors() {
         let root = temp_root("audit-storage-error");
         let key = AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap();
-        let write_result = world::write_with_audit_checked(
-            &root,
-            "home/schema",
-            b"body",
-            "text/plain",
-            &[],
-            &key,
-            None,
-        );
+        let write_result =
+            world::write_with_audit_checked(&root, "home/schema", b"body", "text/plain", &[], &key);
         assert!(write_result.is_ok(), "fixture write should succeed");
         let db = world::world_db(&root, "home/schema");
         let conn = rusqlite::Connection::open(db).unwrap();

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -96,6 +96,11 @@ pub enum EngineBuildError {
     },
     /// [`EngineBuilder::key`] was never called.
     HmacKeyMissing,
+    /// Startup could not mint a process-local listen cursor epoch.
+    ListenEpochEntropy {
+        /// Human-readable failure detail (do not parse).
+        detail: String,
+    },
     /// Startup audit verification found a tampered HMAC chain.
     AuditChainCorrupted {
         /// Canonical name of the world whose chain failed verification.
@@ -125,6 +130,9 @@ impl fmt::Display for EngineBuildError {
                 None => write!(f, "data root writer lock is held: {}", path.display()),
             },
             Self::HmacKeyMissing => f.write_str("audit-chain HMAC key is missing"),
+            Self::ListenEpochEntropy { detail } => {
+                write!(f, "listen cursor epoch entropy failed: {detail}")
+            }
             Self::AuditChainCorrupted { world, detail } => {
                 write!(f, "audit chain verification failed for {world}: {detail}")
             }
@@ -353,6 +361,11 @@ impl EngineBuilder {
 
         let (events, _) = broadcast::channel(self.listen_replay_max);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let listen_epoch = crate::engine_types::SubscriptionEpoch::mint().map_err(|err| {
+            EngineBuildError::ListenEpochEntropy {
+                detail: format!("{err:?}"),
+            }
+        })?;
         let core = Arc::new(Core {
             data: self.data_root,
             tokens: self.tokens,
@@ -367,6 +380,7 @@ impl EngineBuilder {
             events,
             listen_slots: Arc::new(Semaphore::new(self.max_listen_connections)),
             listen_replay_max: self.listen_replay_max,
+            listen_epoch,
             event_log: Arc::new(StdMutex::new(VecDeque::with_capacity(
                 self.listen_replay_max,
             ))),

--- a/core/src/engine_error.rs
+++ b/core/src/engine_error.rs
@@ -72,6 +72,10 @@ pub(crate) fn write_error_to_engine(
             log_storage_error(scope, &err, "write_audit", world);
             EngineError::Storage
         }
+        world_ops::WriteError::StorageInvariant(reason) => {
+            log_storage_invariant("storage/cas", &reason, "write_audit", world);
+            EngineError::Storage
+        }
         world_ops::WriteError::AuditChainBroken {
             scope,
             break_report,
@@ -80,6 +84,40 @@ pub(crate) fn write_error_to_engine(
             EngineError::Storage
         }
         world_ops::WriteError::Internal(message) => EngineError::InternalInvariant(message),
+    }
+}
+
+fn log_storage_invariant(
+    scope: &'static str,
+    reason: &world_ops::StorageInvariantReason,
+    operation: &'static str,
+    world: Option<&str>,
+) {
+    let reason_text = match reason {
+        world_ops::StorageInvariantReason::CasBodyMismatch(body_sha256) => {
+            format!(
+                "cas body hash row contains different bytes: {}",
+                body_sha256.as_str()
+            )
+        }
+        world_ops::StorageInvariantReason::CasState(reason) => (*reason).to_owned(),
+    };
+
+    #[cfg(feature = "unstable-engine")]
+    tracing::error!(
+        scope,
+        operation,
+        world = world.unwrap_or(""),
+        reason = reason_text.as_str(),
+        "engine storage invariant violation"
+    );
+
+    #[cfg(not(feature = "unstable-engine"))]
+    match world {
+        Some(world) => {
+            eprintln!("elastik-core internal {scope} ({operation}) world={world}: {reason_text}");
+        }
+        None => eprintln!("elastik-core internal {scope} ({operation}): {reason_text}"),
     }
 }
 

--- a/core/src/engine_error.rs
+++ b/core/src/engine_error.rs
@@ -1,0 +1,189 @@
+//! Engine error conversion and diagnostics.
+
+use crate::{
+    engine::{self, EngineError},
+    world_ops, BlockingSqliteError,
+};
+
+fn storage_op_label(op: world_ops::StorageOp) -> &'static str {
+    match op {
+        world_ops::StorageOp::Read => "read",
+        world_ops::StorageOp::WriteAudit => "write_audit",
+    }
+}
+
+pub(crate) fn read_error_to_engine(
+    value: world_ops::ReadError,
+    world: Option<&str>,
+) -> EngineError {
+    match value {
+        world_ops::ReadError::Auth(gate) => EngineError::Auth(gate),
+        world_ops::ReadError::TransientStorage { scope, err } => {
+            log_storage_error(scope, &err, "read", world);
+            EngineError::TransientStorage
+        }
+        world_ops::ReadError::InsufficientStorage { scope, err } => {
+            log_storage_error(scope, &err, "read", world);
+            EngineError::InsufficientStorage
+        }
+        world_ops::ReadError::StorageRead { scope, err } => {
+            log_storage_error(scope, &err, "read", world);
+            EngineError::Storage
+        }
+        world_ops::ReadError::PermitWorldMismatch => {
+            EngineError::InternalInvariant("read permit world mismatch")
+        }
+    }
+}
+
+pub(crate) fn write_error_to_engine(
+    value: world_ops::WriteError,
+    world: Option<&str>,
+) -> EngineError {
+    match value {
+        world_ops::WriteError::Auth(gate) => EngineError::Auth(gate),
+        world_ops::WriteError::PayloadTooLarge { max } => EngineError::PayloadTooLarge { max },
+        world_ops::WriteError::PreconditionFailed { message } => {
+            EngineError::PreconditionFailed { message }
+        }
+        world_ops::WriteError::NotFound => EngineError::NotFound,
+        world_ops::WriteError::QuotaExceeded {
+            used,
+            quota,
+            projected,
+        } => EngineError::QuotaExceeded {
+            used,
+            quota,
+            projected,
+        },
+        world_ops::WriteError::TransientStorage { scope, err, op } => {
+            log_storage_error(scope, &err, storage_op_label(op), world);
+            EngineError::TransientStorage
+        }
+        world_ops::WriteError::InsufficientStorage { scope, err, op } => {
+            log_storage_error(scope, &err, storage_op_label(op), world);
+            EngineError::InsufficientStorage
+        }
+        world_ops::WriteError::StorageRead { scope, err } => {
+            log_storage_error(scope, &err, "read", world);
+            EngineError::Storage
+        }
+        world_ops::WriteError::StorageWriteAudit { scope, err } => {
+            log_storage_error(scope, &err, "write_audit", world);
+            EngineError::Storage
+        }
+        world_ops::WriteError::AuditChainBroken {
+            scope,
+            break_report,
+        } => {
+            log_audit_chain_error(scope, &break_report, "write_audit", world);
+            EngineError::Storage
+        }
+        world_ops::WriteError::Internal(message) => EngineError::InternalInvariant(message),
+    }
+}
+
+impl From<world_ops::ReadError> for EngineError {
+    fn from(value: world_ops::ReadError) -> Self {
+        read_error_to_engine(value, None)
+    }
+}
+
+impl From<world_ops::WriteError> for EngineError {
+    fn from(value: world_ops::WriteError) -> Self {
+        write_error_to_engine(value, None)
+    }
+}
+
+pub(crate) fn log_storage_error(
+    scope: &'static str,
+    err: &rusqlite::Error,
+    operation: &'static str,
+    world: Option<&str>,
+) {
+    #[cfg(feature = "unstable-engine")]
+    tracing::error!(
+        scope,
+        operation,
+        world = world.unwrap_or(""),
+        sqlite_code = ?engine::sqlite_code(err),
+        error = %err,
+        "engine storage error"
+    );
+
+    #[cfg(not(feature = "unstable-engine"))]
+    match world {
+        Some(world) => {
+            eprintln!("elastik-core internal {scope} ({operation}) world={world}: {err}");
+        }
+        None => eprintln!("elastik-core internal {scope} ({operation}): {err}"),
+    }
+}
+
+pub(crate) fn log_audit_chain_error(
+    scope: &'static str,
+    break_report: &crate::audit::VerifyBreak,
+    operation: &'static str,
+    world: Option<&str>,
+) {
+    #[cfg(feature = "unstable-engine")]
+    tracing::error!(
+        scope,
+        operation,
+        world = world.unwrap_or(""),
+        break_at = break_report.break_at,
+        expected = %break_report.expected,
+        actual = %break_report.actual,
+        "engine audit chain broken"
+    );
+
+    #[cfg(not(feature = "unstable-engine"))]
+    match world {
+        Some(world) => eprintln!(
+            "elastik-core internal {scope} ({operation}) world={world}: audit chain broken at event {}: expected {}, actual {}",
+            break_report.break_at, break_report.expected, break_report.actual
+        ),
+        None => eprintln!(
+            "elastik-core internal {scope} ({operation}): audit chain broken at event {}: expected {}, actual {}",
+            break_report.break_at, break_report.expected, break_report.actual
+        ),
+    }
+}
+
+pub(crate) fn log_blocking_storage_error(
+    scope: &'static str,
+    err: &BlockingSqliteError,
+    operation: &'static str,
+    world: Option<&str>,
+) {
+    match err {
+        BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(break_report)) => {
+            log_audit_chain_error(scope, break_report, operation, world)
+        }
+        BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
+            log_storage_error(scope, err, operation, world)
+        }
+        BlockingSqliteError::Sqlite(err) => log_storage_error(scope, err, operation, world),
+        BlockingSqliteError::Worker => {
+            #[cfg(feature = "unstable-engine")]
+            tracing::error!(
+                scope,
+                operation,
+                world = world.unwrap_or(""),
+                "engine storage worker failed"
+            );
+
+            #[cfg(not(feature = "unstable-engine"))]
+            match world {
+                Some(world) => {
+                    eprintln!(
+                        "elastik-core internal {scope} ({operation}) world={world}: sqlite worker failed"
+                    );
+                }
+                None => {
+                    eprintln!("elastik-core internal {scope} ({operation}): sqlite worker failed");
+                }
+            }
+        }
+    }
+}

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -1011,4 +1011,46 @@ mod tests {
         drop(engine);
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[tokio::test]
+    async fn verify_audit_rejects_world_db_copied_under_another_name() {
+        let root = temp_root("verify-world-target");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
+            .build()
+            .unwrap();
+        let source = ValidatedWorldPath::new("home/source-world").unwrap();
+        let copied = ValidatedWorldPath::new("home/copied-world").unwrap();
+
+        engine
+            .replace(
+                &source,
+                Representation::new(Bytes::from_static(b"same bytes"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let source_dir = crate::world::world_dir(&engine.core().data, source.as_str());
+        let copied_dir = crate::world::world_dir(&engine.core().data, copied.as_str());
+        std::fs::create_dir_all(&copied_dir).unwrap();
+        for entry in std::fs::read_dir(&source_dir).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                std::fs::copy(entry.path(), copied_dir.join(entry.file_name())).unwrap();
+            }
+        }
+
+        assert!(matches!(
+            engine.verify_audit(&copied, AccessTier::Read).unwrap(),
+            AuditVerify::Broken(break_report)
+                if break_report.expected == "target-home/copied-world"
+                    && break_report.actual == "target-home/source-world"
+        ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -1052,12 +1052,12 @@ mod tests {
         assert_eq!(tampered_head.seq, tampered_valid.events as i64);
         assert_eq!(tampered_head.hmac, tampered_valid.latest);
 
-        engine.core().install_tombstone(disk.as_str()).await;
+        engine.core().install_tombstone(&disk).await;
         assert!(matches!(
             engine.chain_head(&disk, AccessTier::Read),
             Err(EngineError::NotFound)
         ));
-        engine.core().clear_tombstone(disk.as_str());
+        engine.core().clear_tombstone(&disk);
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -830,13 +830,13 @@ mod tests {
         let usage = engine.du(AccessTier::Read).unwrap();
         assert!(usage
             .iter()
-            .any(|row| row.world == disk && row.bytes == b"hello".len()));
+            .any(|row| row.world == disk && row.bytes == b"hello".len() * 2));
         assert!(usage
             .iter()
             .any(|row| row.world == memory && row.bytes == b"hello".len()));
 
         let df = engine.df(AccessTier::Read).unwrap();
-        assert_eq!(df.storage_used, b"hello".len());
+        assert_eq!(df.storage_used, b"hello".len() * 2);
         assert_eq!(df.storage_quota, Some(64));
         assert_eq!(df.memory_used, b"hello".len());
         assert_eq!(df.worlds, 2);

--- a/core/src/engine_introspection.rs
+++ b/core/src/engine_introspection.rs
@@ -971,4 +971,44 @@ mod tests {
         drop(engine);
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[tokio::test]
+    async fn verify_audit_rejects_tampered_live_body() {
+        let root = temp_root("verify-live-body");
+        let engine = Engine::builder()
+            .data_root(root.clone())
+            .key(AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap())
+            .build()
+            .unwrap();
+        let disk = ValidatedWorldPath::new("home/live-body").unwrap();
+
+        engine
+            .replace(
+                &disk,
+                Representation::new(Bytes::from_static(b"good"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let c =
+            rusqlite::Connection::open(crate::world::world_db(&engine.core().data, disk.as_str()))
+                .unwrap();
+        c.execute(
+            "UPDATE stage_meta SET body=?1 WHERE id=1",
+            [b"bad".as_slice()],
+        )
+        .unwrap();
+        drop(c);
+
+        assert!(matches!(
+            engine.verify_audit(&disk, AccessTier::Read).unwrap(),
+            AuditVerify::Broken(break_report)
+                if break_report.actual.starts_with("live-body-sha256-")
+        ));
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -152,11 +152,11 @@ impl<'a> EngineOps<'a> {
 
     fn open_subscription(&self, permit: SubscribePermit, since: Option<u64>) -> EngineSubscription {
         let rx = self.core.events.subscribe();
-        let (lag, replay, live_floor) = replay_after(self.core, since, &permit.pattern);
+        let (interruption, replay, live_floor) = replay_after(self.core, since, &permit.pattern);
         let replay_mode = since.is_some();
         let mut initial = VecDeque::new();
-        if let Some(skipped) = lag {
-            initial.push_back(Err(SubscriptionRecvError::Lagged { skipped }));
+        if let Some(err) = interruption {
+            initial.push_back(Err(err.into()));
         }
         initial.extend(replay.into_iter().map(Ok));
         EngineSubscription::new(
@@ -353,11 +353,35 @@ struct NoopDeleteTrace;
 
 impl DeleteTraceHooks for NoopDeleteTrace {}
 
+/// Non-terminal condition surfaced before replay switches to live delivery.
+///
+/// This is deliberately narrower than [`SubscriptionRecvError`]: replay setup
+/// can report loss or a stale cursor, but it cannot honestly report `Closed`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReplayInterruption {
+    /// The ring evicted `skipped` events between the cursor and the oldest
+    /// retained event.
+    Lagged { skipped: u64 },
+    /// The cursor is from an id space ahead of this process's current counter.
+    CursorAhead { since: u64, newest: u64 },
+}
+
+impl From<ReplayInterruption> for SubscriptionRecvError {
+    fn from(value: ReplayInterruption) -> Self {
+        match value {
+            ReplayInterruption::Lagged { skipped } => Self::Lagged { skipped },
+            ReplayInterruption::CursorAhead { since, newest } => {
+                Self::CursorAhead { since, newest }
+            }
+        }
+    }
+}
+
 pub(crate) fn replay_after(
     core: &Core,
     since: Option<u64>,
     pattern: &SubscribePattern,
-) -> (Option<u64>, Vec<ChangeEvent>, u64) {
+) -> (Option<ReplayInterruption>, Vec<ChangeEvent>, u64) {
     let Some(last_id) = since else {
         return (None, Vec::new(), 0);
     };
@@ -365,6 +389,17 @@ pub(crate) fn replay_after(
         .event_log
         .lock()
         .unwrap_or_else(|poison| poison.into_inner());
+    let newest = crate::state::last_issued_event_id(&core.next_event);
+    if last_id > newest {
+        return (
+            Some(ReplayInterruption::CursorAhead {
+                since: last_id,
+                newest,
+            }),
+            Vec::new(),
+            0,
+        );
+    }
     let gap = log.front().and_then(|oldest| {
         let expected_next = last_id.saturating_add(1);
         if expected_next < oldest.id {
@@ -380,7 +415,11 @@ pub(crate) fn replay_after(
         .map(Into::into)
         .collect();
     let live_floor = replay.last().map(|change| change.id).unwrap_or(last_id);
-    (gap, replay, live_floor)
+    (
+        gap.map(|skipped| ReplayInterruption::Lagged { skipped }),
+        replay,
+        live_floor,
+    )
 }
 
 impl From<Preconditions> for etag::Preconditions {
@@ -428,7 +467,7 @@ impl From<AccessTier> for auth::Tier {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use bytes::Bytes;
 
@@ -473,11 +512,15 @@ mod tests {
                 });
             }
         }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, 12);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (gap, replay, floor) = replay_after(engine.core(), Some(5), &pattern);
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(5), &pattern);
 
-        assert_eq!(gap, Some(4));
+        assert_eq!(
+            interruption,
+            Some(ReplayInterruption::Lagged { skipped: 4 })
+        );
         assert_eq!(replay.len(), 3);
         assert_eq!(replay[0].id, 10);
         assert_eq!(replay[0].path.as_str(), "home/task/10");
@@ -499,13 +542,45 @@ mod tests {
                 etag: "hmac-max".to_string(),
             });
         }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, u64::MAX);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (gap, replay, floor) = replay_after(engine.core(), Some(u64::MAX), &pattern);
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(u64::MAX), &pattern);
 
-        assert_eq!(gap, None);
+        assert_eq!(interruption, None);
         assert!(replay.is_empty());
         assert_eq!(floor, u64::MAX);
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn replay_after_flags_cursor_ahead_of_current_process() {
+        let (engine, root) = test_engine("replay-ahead");
+        {
+            let mut log = engine.core().event_log.lock().unwrap();
+            log.push_back(event::ChangeEvent {
+                id: 1,
+                verb: ChangeVerb::Replace,
+                path: "/home/task/a".to_string(),
+                etag: "hmac-1".to_string(),
+            });
+        }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, 1);
+
+        let pattern = SubscribePattern::new("home/task/*");
+        let (interruption, replay, floor) = replay_after(engine.core(), Some(42), &pattern);
+
+        assert_eq!(
+            interruption,
+            Some(ReplayInterruption::CursorAhead {
+                since: 42,
+                newest: 1
+            })
+        );
+        assert!(replay.is_empty());
+        assert_eq!(floor, 0, "foreign cursor must not become live floor");
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);
@@ -575,6 +650,48 @@ mod tests {
         let event = subscription.recv().await.expect("replay event");
         assert_eq!(event.verb, ChangeVerb::Replace);
         assert_eq!(event.path.as_str(), "home/events/a");
+
+        drop(subscription);
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn engine_subscription_with_stale_cursor_signals_then_streams_live() {
+        let recv_budget = Duration::from_secs(10);
+        let (engine, root) = test_engine("subscribe-stale-cursor");
+        let pattern = SubscribePattern::new("home/stale/*");
+        let mut subscription = engine
+            .subscribe(&pattern, AccessTier::Anon, Some(42))
+            .expect("subscription opens with stale cursor");
+
+        let first = tokio::time::timeout(recv_budget, subscription.recv())
+            .await
+            .expect("first recv must not block");
+        assert!(matches!(
+            first,
+            Err(SubscriptionRecvError::CursorAhead {
+                since: 42,
+                newest: 0
+            })
+        ));
+
+        let world = ValidatedWorldPath::new("home/stale/a").unwrap();
+        engine
+            .replace(
+                &world,
+                Representation::new(Bytes::from_static(b"alive"), "text/plain", Vec::new()),
+                Preconditions::none(),
+                AccessTier::Write,
+            )
+            .await
+            .unwrap();
+
+        let change = tokio::time::timeout(recv_budget, subscription.recv())
+            .await
+            .expect("live recv must not block after cursor warning")
+            .expect("live event must flow after cursor warning");
+        assert_eq!(change.path.as_str(), "home/stale/a");
 
         drop(subscription);
         drop(engine);

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -157,8 +157,10 @@ impl<'a> EngineOps<'a> {
         resume: SubscriptionResume,
     ) -> EngineSubscription {
         let rx = self.core.events.subscribe();
-        let (interruption, replay, live_floor) = replay_after(self.core, resume, &permit.pattern);
-        let replay_mode = resume.is_replay();
+        let replay_plan = resume.replay_plan(&self.core.listen_epoch);
+        let replay_mode = replay_plan.is_current_replay();
+        let (interruption, replay, live_floor) =
+            replay_after(self.core, replay_plan, &permit.pattern);
         let mut initial = VecDeque::new();
         if let Some(err) = interruption {
             initial.push_back(Err(err.into()));
@@ -369,27 +371,53 @@ pub(crate) enum ReplayInterruption {
     /// retained event.
     Lagged { skipped: u64 },
     /// The cursor is from an id space ahead of this process's current counter.
-    CursorAhead { since: u64, newest: u64 },
+    CursorAhead {
+        since: u64,
+        newest: u64,
+        reset: crate::engine_types::SubscriptionCursor,
+    },
 }
 
 impl From<ReplayInterruption> for SubscriptionRecvError {
     fn from(value: ReplayInterruption) -> Self {
         match value {
             ReplayInterruption::Lagged { skipped } => Self::Lagged { skipped },
-            ReplayInterruption::CursorAhead { since, newest } => {
-                Self::CursorAhead { since, newest }
-            }
+            ReplayInterruption::CursorAhead {
+                since,
+                newest,
+                reset,
+            } => Self::CursorAhead {
+                since,
+                newest,
+                reset,
+            },
         }
     }
 }
 
 pub(crate) fn replay_after(
     core: &Core,
-    resume: SubscriptionResume,
+    replay_plan: crate::engine_types::ReplayPlan,
     pattern: &SubscribePattern,
 ) -> (Option<ReplayInterruption>, Vec<ChangeEvent>, u64) {
-    let Some(last_id) = resume.after_event_id_raw() else {
-        return (None, Vec::new(), 0);
+    let last_id = match replay_plan {
+        crate::engine_types::ReplayPlan::None => return (None, Vec::new(), 0),
+        crate::engine_types::ReplayPlan::Foreign { event_id } => {
+            let newest = crate::state::last_issued_event_id(&core.next_event);
+            return (
+                Some(ReplayInterruption::CursorAhead {
+                    since: event_id,
+                    newest,
+                    reset: crate::engine_types::SubscriptionCursor::new(
+                        core.listen_epoch.clone(),
+                        newest,
+                    ),
+                }),
+                Vec::new(),
+                0,
+            );
+        }
+        crate::engine_types::ReplayPlan::Current { event_id } => event_id,
     };
     let log = core
         .event_log
@@ -401,6 +429,10 @@ pub(crate) fn replay_after(
             Some(ReplayInterruption::CursorAhead {
                 since: last_id,
                 newest,
+                reset: crate::engine_types::SubscriptionCursor::new(
+                    core.listen_epoch.clone(),
+                    newest,
+                ),
             }),
             Vec::new(),
             0,
@@ -512,6 +544,7 @@ mod tests {
             for id in 10..=12 {
                 log.push_back(event::ChangeEvent {
                     id,
+                    listen_epoch: engine.core().listen_epoch.clone(),
                     verb: ChangeVerb::Replace,
                     path: format!("/home/task/{id}"),
                     etag: format!("hmac-{id}"),
@@ -523,7 +556,7 @@ mod tests {
         let pattern = SubscribePattern::new("home/task/*");
         let (interruption, replay, floor) = replay_after(
             engine.core(),
-            SubscriptionResume::after_event_id(5),
+            SubscriptionResume::after_event_id(5).replay_plan(&engine.core().listen_epoch),
             &pattern,
         );
 
@@ -547,6 +580,7 @@ mod tests {
             let mut log = engine.core().event_log.lock().unwrap();
             log.push_back(event::ChangeEvent {
                 id: u64::MAX,
+                listen_epoch: engine.core().listen_epoch.clone(),
                 verb: ChangeVerb::Replace,
                 path: "/home/task/max".to_string(),
                 etag: "hmac-max".to_string(),
@@ -557,7 +591,7 @@ mod tests {
         let pattern = SubscribePattern::new("home/task/*");
         let (interruption, replay, floor) = replay_after(
             engine.core(),
-            SubscriptionResume::after_event_id(u64::MAX),
+            SubscriptionResume::after_event_id(u64::MAX).replay_plan(&engine.core().listen_epoch),
             &pattern,
         );
 
@@ -576,6 +610,7 @@ mod tests {
             let mut log = engine.core().event_log.lock().unwrap();
             log.push_back(event::ChangeEvent {
                 id: 1,
+                listen_epoch: engine.core().listen_epoch.clone(),
                 verb: ChangeVerb::Replace,
                 path: "/home/task/a".to_string(),
                 etag: "hmac-1".to_string(),
@@ -586,7 +621,7 @@ mod tests {
         let pattern = SubscribePattern::new("home/task/*");
         let (interruption, replay, floor) = replay_after(
             engine.core(),
-            SubscriptionResume::after_event_id(42),
+            SubscriptionResume::after_event_id(42).replay_plan(&engine.core().listen_epoch),
             &pattern,
         );
 
@@ -594,11 +629,60 @@ mod tests {
             interruption,
             Some(ReplayInterruption::CursorAhead {
                 since: 42,
-                newest: 1
+                newest: 1,
+                reset: crate::engine_types::SubscriptionCursor::new(
+                    engine.core().listen_epoch.clone(),
+                    1,
+                ),
             })
         );
         assert!(replay.is_empty());
         assert_eq!(floor, 0, "foreign cursor must not become live floor");
+
+        drop(engine);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn replay_after_treats_legacy_decimal_cursor_as_foreign_even_when_id_exists() {
+        let (engine, root) = test_engine("replay-legacy-foreign");
+        {
+            let mut log = engine.core().event_log.lock().unwrap();
+            for id in 1..=7 {
+                log.push_back(event::ChangeEvent {
+                    id,
+                    listen_epoch: engine.core().listen_epoch.clone(),
+                    verb: ChangeVerb::Replace,
+                    path: format!("/home/task/{id}"),
+                    etag: format!("hmac-{id}"),
+                });
+            }
+        }
+        crate::state::test_only_set_event_counter(&engine.core().next_event, 7);
+
+        let pattern = SubscribePattern::new("home/task/*");
+        let (interruption, replay, floor) = replay_after(
+            engine.core(),
+            SubscriptionResume::legacy_event_id(5).replay_plan(&engine.core().listen_epoch),
+            &pattern,
+        );
+
+        assert_eq!(
+            interruption,
+            Some(ReplayInterruption::CursorAhead {
+                since: 5,
+                newest: 7,
+                reset: crate::engine_types::SubscriptionCursor::new(
+                    engine.core().listen_epoch.clone(),
+                    7,
+                ),
+            })
+        );
+        assert!(
+            replay.is_empty(),
+            "legacy decimal cursor must not replay a coincidentally matching fresh id space"
+        );
+        assert_eq!(floor, 0);
 
         drop(engine);
         let _ = std::fs::remove_dir_all(root);
@@ -698,7 +782,8 @@ mod tests {
             first,
             Err(SubscriptionRecvError::CursorAhead {
                 since: 42,
-                newest: 0
+                newest: 0,
+                ..
             })
         ));
 

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -16,7 +16,8 @@ use crate::{
     engine_error::{read_error_to_engine, write_error_to_engine},
     engine_types::{
         AccessTier, ChangeEvent, EngineSubscription, Preconditions, ReadResult, Representation,
-        SubscribePattern, SubscriptionRecvError, ValidatedWorldPath, WriteKind, WriteResult,
+        SubscribePattern, SubscriptionRecvError, SubscriptionResume, ValidatedWorldPath, WriteKind,
+        WriteResult,
     },
     etag, event, world_ops, AuthGate, Core,
 };
@@ -121,10 +122,10 @@ impl<'a> EngineOps<'a> {
         &self,
         pattern: &SubscribePattern,
         tier: auth::Tier,
-        since: Option<u64>,
+        resume: SubscriptionResume,
     ) -> Result<EngineSubscription, EngineError> {
         let permit = self.authorize_subscribe(pattern, tier)?;
-        Ok(self.open_subscription(permit, since))
+        Ok(self.open_subscription(permit, resume))
     }
 
     fn authorize_subscribe(
@@ -150,10 +151,14 @@ impl<'a> EngineOps<'a> {
         })
     }
 
-    fn open_subscription(&self, permit: SubscribePermit, since: Option<u64>) -> EngineSubscription {
+    fn open_subscription(
+        &self,
+        permit: SubscribePermit,
+        resume: SubscriptionResume,
+    ) -> EngineSubscription {
         let rx = self.core.events.subscribe();
-        let (interruption, replay, live_floor) = replay_after(self.core, since, &permit.pattern);
-        let replay_mode = since.is_some();
+        let (interruption, replay, live_floor) = replay_after(self.core, resume, &permit.pattern);
+        let replay_mode = resume.is_replay();
         let mut initial = VecDeque::new();
         if let Some(err) = interruption {
             initial.push_back(Err(err.into()));
@@ -320,11 +325,12 @@ impl Engine {
     /// reserves a subscription slot, and prepares replay state. Receiving
     /// events is async through [`EngineSubscription::recv`].
     ///
-    /// If `since` is `Some(id)`, the subscription replays every event with
-    /// `id > since` from the in-memory ring before switching to the live
-    /// stream. Replay is bounded by the configured `listen_replay_max`; if
-    /// `since` is older than the ring's floor, the first `recv` call yields
-    /// a [`crate::SubscriptionRecvError::Lagged`] error.
+    /// If `resume` is [`SubscriptionResume::after_event_id`], the subscription
+    /// replays every event after that id from the in-memory ring before
+    /// switching to the live stream. Replay is bounded by the configured
+    /// `listen_replay_max`; if the cursor is older than the ring's floor, the
+    /// first `recv` call yields a [`crate::SubscriptionRecvError::Lagged`]
+    /// error.
     ///
     /// The returned [`EngineSubscription`] holds a subscription slot until
     /// dropped; drop it promptly when finished so other subscribers can
@@ -339,9 +345,9 @@ impl Engine {
         &self,
         pattern: &SubscribePattern,
         tier: AccessTier,
-        since: Option<u64>,
+        resume: SubscriptionResume,
     ) -> Result<EngineSubscription, EngineError> {
-        EngineOps::new(self.core()).subscribe(pattern, tier.into(), since)
+        EngineOps::new(self.core()).subscribe(pattern, tier.into(), resume)
     }
 }
 
@@ -379,10 +385,10 @@ impl From<ReplayInterruption> for SubscriptionRecvError {
 
 pub(crate) fn replay_after(
     core: &Core,
-    since: Option<u64>,
+    resume: SubscriptionResume,
     pattern: &SubscribePattern,
 ) -> (Option<ReplayInterruption>, Vec<ChangeEvent>, u64) {
-    let Some(last_id) = since else {
+    let Some(last_id) = resume.after_event_id_raw() else {
         return (None, Vec::new(), 0);
     };
     let log = core
@@ -515,7 +521,11 @@ mod tests {
         crate::state::test_only_set_event_counter(&engine.core().next_event, 12);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (interruption, replay, floor) = replay_after(engine.core(), Some(5), &pattern);
+        let (interruption, replay, floor) = replay_after(
+            engine.core(),
+            SubscriptionResume::after_event_id(5),
+            &pattern,
+        );
 
         assert_eq!(
             interruption,
@@ -545,7 +555,11 @@ mod tests {
         crate::state::test_only_set_event_counter(&engine.core().next_event, u64::MAX);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (interruption, replay, floor) = replay_after(engine.core(), Some(u64::MAX), &pattern);
+        let (interruption, replay, floor) = replay_after(
+            engine.core(),
+            SubscriptionResume::after_event_id(u64::MAX),
+            &pattern,
+        );
 
         assert_eq!(interruption, None);
         assert!(replay.is_empty());
@@ -570,7 +584,11 @@ mod tests {
         crate::state::test_only_set_event_counter(&engine.core().next_event, 1);
 
         let pattern = SubscribePattern::new("home/task/*");
-        let (interruption, replay, floor) = replay_after(engine.core(), Some(42), &pattern);
+        let (interruption, replay, floor) = replay_after(
+            engine.core(),
+            SubscriptionResume::after_event_id(42),
+            &pattern,
+        );
 
         assert_eq!(
             interruption,
@@ -629,7 +647,7 @@ mod tests {
         let pattern = SubscribePattern::new("home/events/*");
 
         assert!(matches!(
-            engine.subscribe(&pattern, AccessTier::Anon, None),
+            engine.subscribe(&pattern, AccessTier::Anon, SubscriptionResume::none()),
             Err(EngineError::Auth(AuthGate::Read))
         ));
 
@@ -645,7 +663,11 @@ mod tests {
             .unwrap();
 
         let mut subscription = engine
-            .subscribe(&pattern, AccessTier::Read, Some(0))
+            .subscribe(
+                &pattern,
+                AccessTier::Read,
+                SubscriptionResume::after_event_id(0),
+            )
             .expect("read tier subscribes");
         let event = subscription.recv().await.expect("replay event");
         assert_eq!(event.verb, ChangeVerb::Replace);
@@ -662,7 +684,11 @@ mod tests {
         let (engine, root) = test_engine("subscribe-stale-cursor");
         let pattern = SubscribePattern::new("home/stale/*");
         let mut subscription = engine
-            .subscribe(&pattern, AccessTier::Anon, Some(42))
+            .subscribe(
+                &pattern,
+                AccessTier::Anon,
+                SubscriptionResume::after_event_id(42),
+            )
             .expect("subscription opens with stale cursor");
 
         let first = tokio::time::timeout(recv_budget, subscription.recv())
@@ -703,10 +729,10 @@ mod tests {
         let (engine, root) = test_engine("subscribe-cap");
         let pattern = SubscribePattern::new("*");
         let first = engine
-            .subscribe(&pattern, AccessTier::Anon, None)
+            .subscribe(&pattern, AccessTier::Anon, SubscriptionResume::none())
             .expect("first subscription consumes the sole slot");
         assert!(matches!(
-            engine.subscribe(&pattern, AccessTier::Anon, None),
+            engine.subscribe(&pattern, AccessTier::Anon, SubscriptionResume::none()),
             Err(EngineError::SubscriptionLimit)
         ));
 
@@ -728,11 +754,11 @@ mod tests {
         let pattern = SubscribePattern::new("*");
 
         assert!(matches!(
-            engine.subscribe(&pattern, AccessTier::Anon, None),
+            engine.subscribe(&pattern, AccessTier::Anon, SubscriptionResume::none()),
             Err(EngineError::Auth(AuthGate::Read))
         ));
         let subscription = engine
-            .subscribe(&pattern, AccessTier::Read, None)
+            .subscribe(&pattern, AccessTier::Read, SubscriptionResume::none())
             .expect("failed auth must not consume the only slot");
 
         drop(subscription);
@@ -745,7 +771,7 @@ mod tests {
         let (engine, root) = test_engine("subscribe-closed");
         let pattern = SubscribePattern::new("*");
         let mut subscription = engine
-            .subscribe(&pattern, AccessTier::Anon, None)
+            .subscribe(&pattern, AccessTier::Anon, SubscriptionResume::none())
             .expect("subscription opens before shutdown");
 
         engine.shutdown();
@@ -781,7 +807,11 @@ mod tests {
         }
 
         let mut subscription = engine
-            .subscribe(&pattern, AccessTier::Anon, Some(0))
+            .subscribe(
+                &pattern,
+                AccessTier::Anon,
+                SubscriptionResume::after_event_id(0),
+            )
             .expect("subscription opens before shutdown");
         engine.shutdown();
         assert_eq!(

--- a/core/src/engine_ops.rs
+++ b/core/src/engine_ops.rs
@@ -12,13 +12,16 @@ use bytes::Bytes;
 use crate::{
     auth,
     delete_ops::{self, DeleteRequest, DeleteTraceHooks},
-    engine::{self, Engine, EngineError},
+    engine::{Engine, EngineError},
+    engine_error::{read_error_to_engine, write_error_to_engine},
     engine_types::{
         AccessTier, ChangeEvent, EngineSubscription, Preconditions, ReadResult, Representation,
         SubscribePattern, SubscriptionRecvError, ValidatedWorldPath, WriteKind, WriteResult,
     },
-    etag, event, world_ops, AuthGate, BlockingSqliteError, Core,
+    etag, event, world_ops, AuthGate, Core,
 };
+
+pub(crate) use crate::engine_error::{log_blocking_storage_error, log_storage_error};
 
 pub(crate) struct EngineOps<'a> {
     core: &'a Core,
@@ -418,183 +421,6 @@ impl From<AccessTier> for auth::Tier {
             AccessTier::Read => Self::Read,
             AccessTier::Write => Self::Write,
             AccessTier::Approve => Self::Approve,
-        }
-    }
-}
-
-impl From<world_ops::ReadError> for EngineError {
-    fn from(value: world_ops::ReadError) -> Self {
-        read_error_to_engine(value, None)
-    }
-}
-
-impl From<world_ops::WriteError> for EngineError {
-    fn from(value: world_ops::WriteError) -> Self {
-        write_error_to_engine(value, None)
-    }
-}
-
-fn storage_op_label(op: world_ops::StorageOp) -> &'static str {
-    match op {
-        world_ops::StorageOp::Read => "read",
-        world_ops::StorageOp::WriteAudit => "write_audit",
-    }
-}
-
-fn read_error_to_engine(value: world_ops::ReadError, world: Option<&str>) -> EngineError {
-    match value {
-        world_ops::ReadError::Auth(gate) => EngineError::Auth(gate),
-        world_ops::ReadError::TransientStorage { scope, err } => {
-            log_storage_error(scope, &err, "read", world);
-            EngineError::TransientStorage
-        }
-        world_ops::ReadError::InsufficientStorage { scope, err } => {
-            log_storage_error(scope, &err, "read", world);
-            EngineError::InsufficientStorage
-        }
-        world_ops::ReadError::StorageRead { scope, err } => {
-            log_storage_error(scope, &err, "read", world);
-            EngineError::Storage
-        }
-        world_ops::ReadError::PermitWorldMismatch => {
-            EngineError::InternalInvariant("read permit world mismatch")
-        }
-    }
-}
-
-fn write_error_to_engine(value: world_ops::WriteError, world: Option<&str>) -> EngineError {
-    match value {
-        world_ops::WriteError::Auth(gate) => EngineError::Auth(gate),
-        world_ops::WriteError::PayloadTooLarge { max } => EngineError::PayloadTooLarge { max },
-        world_ops::WriteError::PreconditionFailed { message } => {
-            EngineError::PreconditionFailed { message }
-        }
-        world_ops::WriteError::NotFound => EngineError::NotFound,
-        world_ops::WriteError::QuotaExceeded {
-            used,
-            quota,
-            projected,
-        } => EngineError::QuotaExceeded {
-            used,
-            quota,
-            projected,
-        },
-        world_ops::WriteError::TransientStorage { scope, err, op } => {
-            log_storage_error(scope, &err, storage_op_label(op), world);
-            EngineError::TransientStorage
-        }
-        world_ops::WriteError::InsufficientStorage { scope, err, op } => {
-            log_storage_error(scope, &err, storage_op_label(op), world);
-            EngineError::InsufficientStorage
-        }
-        world_ops::WriteError::StorageRead { scope, err } => {
-            log_storage_error(scope, &err, "read", world);
-            EngineError::Storage
-        }
-        world_ops::WriteError::StorageWriteAudit { scope, err } => {
-            log_storage_error(scope, &err, "write_audit", world);
-            EngineError::Storage
-        }
-        world_ops::WriteError::AuditChainBroken {
-            scope,
-            break_report,
-        } => {
-            log_audit_chain_error(scope, &break_report, "write_audit", world);
-            EngineError::Storage
-        }
-        world_ops::WriteError::Internal(message) => EngineError::InternalInvariant(message),
-    }
-}
-
-pub(crate) fn log_storage_error(
-    scope: &'static str,
-    err: &rusqlite::Error,
-    operation: &'static str,
-    world: Option<&str>,
-) {
-    #[cfg(feature = "unstable-engine")]
-    tracing::error!(
-        scope,
-        operation,
-        world = world.unwrap_or(""),
-        sqlite_code = ?engine::sqlite_code(err),
-        error = %err,
-        "engine storage error"
-    );
-
-    #[cfg(not(feature = "unstable-engine"))]
-    match world {
-        Some(world) => {
-            eprintln!("elastik-core internal {scope} ({operation}) world={world}: {err}");
-        }
-        None => eprintln!("elastik-core internal {scope} ({operation}): {err}"),
-    }
-}
-
-pub(crate) fn log_audit_chain_error(
-    scope: &'static str,
-    break_report: &crate::audit::VerifyBreak,
-    operation: &'static str,
-    world: Option<&str>,
-) {
-    #[cfg(feature = "unstable-engine")]
-    tracing::error!(
-        scope,
-        operation,
-        world = world.unwrap_or(""),
-        break_at = break_report.break_at,
-        expected = %break_report.expected,
-        actual = %break_report.actual,
-        "engine audit chain broken"
-    );
-
-    #[cfg(not(feature = "unstable-engine"))]
-    match world {
-        Some(world) => eprintln!(
-            "elastik-core internal {scope} ({operation}) world={world}: audit chain broken at event {}: expected {}, actual {}",
-            break_report.break_at, break_report.expected, break_report.actual
-        ),
-        None => eprintln!(
-            "elastik-core internal {scope} ({operation}): audit chain broken at event {}: expected {}, actual {}",
-            break_report.break_at, break_report.expected, break_report.actual
-        ),
-    }
-}
-
-pub(crate) fn log_blocking_storage_error(
-    scope: &'static str,
-    err: &BlockingSqliteError,
-    operation: &'static str,
-    world: Option<&str>,
-) {
-    match err {
-        BlockingSqliteError::Audit(crate::audit::AuditError::ChainBroken(break_report)) => {
-            log_audit_chain_error(scope, break_report, operation, world)
-        }
-        BlockingSqliteError::Audit(crate::audit::AuditError::Storage(err)) => {
-            log_storage_error(scope, err, operation, world)
-        }
-        BlockingSqliteError::Sqlite(err) => log_storage_error(scope, err, operation, world),
-        BlockingSqliteError::Worker => {
-            #[cfg(feature = "unstable-engine")]
-            tracing::error!(
-                scope,
-                operation,
-                world = world.unwrap_or(""),
-                "engine storage worker failed"
-            );
-
-            #[cfg(not(feature = "unstable-engine"))]
-            match world {
-                Some(world) => {
-                    eprintln!(
-                        "elastik-core internal {scope} ({operation}) world={world}: sqlite worker failed"
-                    );
-                }
-                None => {
-                    eprintln!("elastik-core internal {scope} ({operation}): sqlite worker failed");
-                }
-            }
         }
     }
 }

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -329,6 +329,19 @@ pub enum SubscriptionRecvError {
         /// Number of events the receiver missed.
         skipped: u64,
     },
+    /// The subscriber's resume cursor is ahead of every id this engine process
+    /// has issued.
+    ///
+    /// Listen ids are process-local, so this usually means the cursor was
+    /// saved before an engine restart. The subscription continues live after
+    /// this error; callers must discard or rebase the stale cursor.
+    CursorAhead {
+        /// Cursor presented by the subscriber.
+        since: u64,
+        /// Newest event id issued by this engine process when the
+        /// subscription was opened.
+        newest: u64,
+    },
 }
 
 impl SecretBytes {
@@ -584,7 +597,10 @@ impl EngineSubscription {
     ///
     /// Drains the replay queue first (in increasing event id order), then
     /// switches to the live broadcast stream. If the caller passed `since` to
-    /// [`crate::Engine::subscribe`], events with id `<= since` are filtered.
+    /// [`crate::Engine::subscribe`], events with id `<= since` are filtered,
+    /// unless `since` is ahead of this process's id space; in that case
+    /// [`SubscriptionRecvError::CursorAhead`] is yielded first and no stale
+    /// floor is applied to following live events.
     ///
     /// # Errors
     /// - [`SubscriptionRecvError::Closed`] when the engine shut down or the
@@ -593,6 +609,9 @@ impl EngineSubscription {
     /// - [`SubscriptionRecvError::Lagged`] when the broadcast ring buffer
     ///   overflowed and events were lost. Recoverable: the next call resumes
     ///   with fresh events.
+    /// - [`SubscriptionRecvError::CursorAhead`] when `since` points past the
+    ///   newest id this process has issued. Recoverable: the next call resumes
+    ///   with fresh live events.
     pub async fn recv(&mut self) -> Result<ChangeEvent, SubscriptionRecvError> {
         loop {
             let state = std::mem::replace(&mut self.state, SubscriptionState::Closed);

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -78,6 +78,16 @@ pub struct InvalidWorldPath;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SubscribePattern(String);
 
+/// Checked resume cursor for an Engine subscription.
+///
+/// Protocol adapters may parse raw wire values such as `Last-Event-ID`, but
+/// core replay code only accepts this named type so a naked event id cannot be
+/// confused with a timeline sequence, audit row id, or byte offset.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SubscriptionResume {
+    after_event_id: Option<u64>,
+}
+
 /// Access tier granted to a caller after token verification.
 ///
 /// Tiers are linearly inclusive: `Approve` covers `Write`, `Write` covers
@@ -515,6 +525,30 @@ impl SubscribePattern {
     /// Returns the normalized pattern string.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl SubscriptionResume {
+    /// Starts a fresh live subscription with no replay cursor.
+    pub fn none() -> Self {
+        Self {
+            after_event_id: None,
+        }
+    }
+
+    /// Replays events after `id` before switching to live delivery.
+    pub fn after_event_id(id: u64) -> Self {
+        Self {
+            after_event_id: Some(id),
+        }
+    }
+
+    pub(crate) fn after_event_id_raw(self) -> Option<u64> {
+        self.after_event_id
+    }
+
+    pub(crate) fn is_replay(self) -> bool {
+        self.after_event_id.is_some()
     }
 }
 

--- a/core/src/engine_types.rs
+++ b/core/src/engine_types.rs
@@ -78,14 +78,54 @@ pub struct InvalidWorldPath;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SubscribePattern(String);
 
+/// Process-local id space for subscription cursors.
+///
+/// Event ids are monotonic only within one running [`crate::Engine`]. The
+/// epoch makes cursor strings opaque across restarts so adapters cannot
+/// accidentally treat a fresh process's `id=5` as the old process's `id=5`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SubscriptionEpoch(String);
+
+/// Returned when a subscription epoch string is malformed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidSubscriptionEpoch;
+
+/// Opaque resume cursor for protocol adapters.
+///
+/// Rendered as `<32 lowercase hex epoch>:<decimal event id>`. The decimal
+/// suffix is still useful for in-process ordering, but it is not a complete
+/// identity without the epoch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubscriptionCursor {
+    epoch: SubscriptionEpoch,
+    event_id: u64,
+}
+
+/// Returned when an SSE cursor string is malformed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidSubscriptionCursor;
+
 /// Checked resume cursor for an Engine subscription.
 ///
 /// Protocol adapters may parse raw wire values such as `Last-Event-ID`, but
 /// core replay code only accepts this named type so a naked event id cannot be
 /// confused with a timeline sequence, audit row id, or byte offset.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SubscriptionResume {
-    after_event_id: Option<u64>,
+    kind: SubscriptionResumeKind,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum SubscriptionResumeKind {
+    #[default]
+    None,
+    CurrentProcess {
+        event_id: u64,
+    },
+    Cursor(SubscriptionCursor),
+    LegacyDecimal {
+        event_id: u64,
+    },
 }
 
 /// Access tier granted to a caller after token verification.
@@ -251,8 +291,13 @@ pub struct WriteResult {
 #[non_exhaustive]
 pub struct ChangeEvent {
     /// Monotonically increasing event id. Use this as `since` for resumed
-    /// subscriptions.
+    /// in-process subscriptions only; wire protocols should persist
+    /// [`ChangeEvent::cursor`] instead.
     pub id: u64,
+    /// Process-local id space that produced this event id.
+    pub listen_epoch: SubscriptionEpoch,
+    /// Opaque cursor safe to render as an SSE `id`.
+    pub cursor: SubscriptionCursor,
     /// Engine mutation that produced the change.
     pub verb: ChangeVerb,
     /// Canonical world path the change applies to.
@@ -327,7 +372,7 @@ impl SubscriptionSlot {
 }
 
 /// Error returned by [`EngineSubscription::recv`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SubscriptionRecvError {
     /// The engine is shutting down or the broadcast channel was closed.
@@ -351,6 +396,9 @@ pub enum SubscriptionRecvError {
         /// Newest event id issued by this engine process when the
         /// subscription was opened.
         newest: u64,
+        /// Cursor in this process's id space that adapters may use to rebase
+        /// automatic reconnect state.
+        reset: SubscriptionCursor,
     },
 }
 
@@ -494,7 +542,7 @@ impl From<crate::event::ChangeEvent> for ChangeEvent {
         let canonical = value.path.trim_start_matches('/').to_owned();
         let path = ValidatedWorldPath::from_canonical(canonical)
             .expect("listen events are emitted only for validated world paths");
-        Self::new(value.id, value.verb, path, value.etag)
+        Self::new(value.id, value.listen_epoch, value.verb, path, value.etag)
     }
 }
 
@@ -528,27 +576,169 @@ impl SubscribePattern {
     }
 }
 
+impl SubscriptionEpoch {
+    pub(crate) fn mint() -> Result<Self, getrandom::Error> {
+        let mut bytes = [0u8; 16];
+        getrandom::getrandom(&mut bytes)?;
+        Ok(Self(hex::encode(bytes)))
+    }
+
+    /// Parses a 128-bit lowercase-hex subscription epoch.
+    ///
+    /// # Errors
+    /// Returns [`InvalidSubscriptionEpoch`] unless `raw` is exactly 32
+    /// lowercase hexadecimal characters.
+    pub fn new(raw: impl Into<String>) -> Result<Self, InvalidSubscriptionEpoch> {
+        let raw = raw.into();
+        if raw.len() != 32
+            || !raw
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(InvalidSubscriptionEpoch);
+        }
+        Ok(Self(raw))
+    }
+
+    /// Returns the lowercase-hex epoch string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SubscriptionEpoch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Display for InvalidSubscriptionEpoch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid subscription epoch")
+    }
+}
+
+impl std::error::Error for InvalidSubscriptionEpoch {}
+
+impl SubscriptionCursor {
+    pub(crate) fn new(epoch: SubscriptionEpoch, event_id: u64) -> Self {
+        Self { epoch, event_id }
+    }
+
+    /// Parses an opaque SSE event id produced by the Engine.
+    ///
+    /// # Errors
+    /// Returns [`InvalidSubscriptionCursor`] unless `raw` is
+    /// `<32 lowercase hex epoch>:<canonical decimal event id>`.
+    pub fn from_sse_id(raw: impl AsRef<str>) -> Result<Self, InvalidSubscriptionCursor> {
+        let raw = raw.as_ref();
+        let Some((epoch, event_id)) = raw.split_once(':') else {
+            return Err(InvalidSubscriptionCursor);
+        };
+        let epoch = SubscriptionEpoch::new(epoch).map_err(|_| InvalidSubscriptionCursor)?;
+        if event_id.is_empty() || !event_id.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(InvalidSubscriptionCursor);
+        }
+        let parsed = event_id
+            .parse::<u64>()
+            .map_err(|_| InvalidSubscriptionCursor)?;
+        if event_id != parsed.to_string() {
+            return Err(InvalidSubscriptionCursor);
+        }
+        Ok(Self {
+            epoch,
+            event_id: parsed,
+        })
+    }
+
+    /// Returns the epoch component of this cursor.
+    pub fn epoch(&self) -> &SubscriptionEpoch {
+        &self.epoch
+    }
+
+    /// Returns the event id component of this cursor.
+    pub fn event_id(&self) -> u64 {
+        self.event_id
+    }
+}
+
+impl fmt::Display for SubscriptionCursor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.epoch, self.event_id)
+    }
+}
+
+impl fmt::Display for InvalidSubscriptionCursor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid subscription cursor")
+    }
+}
+
+impl std::error::Error for InvalidSubscriptionCursor {}
+
 impl SubscriptionResume {
     /// Starts a fresh live subscription with no replay cursor.
     pub fn none() -> Self {
         Self {
-            after_event_id: None,
+            kind: SubscriptionResumeKind::None,
         }
     }
 
     /// Replays events after `id` before switching to live delivery.
+    ///
+    /// This constructor is for in-process callers that obtained `id` from the
+    /// same running [`crate::Engine`]. Wire adapters should persist
+    /// [`ChangeEvent::cursor`] and resume with [`SubscriptionResume::after_cursor`].
     pub fn after_event_id(id: u64) -> Self {
         Self {
-            after_event_id: Some(id),
+            kind: SubscriptionResumeKind::CurrentProcess { event_id: id },
         }
     }
 
-    pub(crate) fn after_event_id_raw(self) -> Option<u64> {
-        self.after_event_id
+    /// Replays events after an opaque cursor before switching to live delivery.
+    pub fn after_cursor(cursor: SubscriptionCursor) -> Self {
+        Self {
+            kind: SubscriptionResumeKind::Cursor(cursor),
+        }
     }
 
-    pub(crate) fn is_replay(self) -> bool {
-        self.after_event_id.is_some()
+    #[doc(hidden)]
+    pub fn legacy_event_id(id: u64) -> Self {
+        Self {
+            kind: SubscriptionResumeKind::LegacyDecimal { event_id: id },
+        }
+    }
+
+    pub(crate) fn replay_plan(&self, current_epoch: &SubscriptionEpoch) -> ReplayPlan {
+        match &self.kind {
+            SubscriptionResumeKind::None => ReplayPlan::None,
+            SubscriptionResumeKind::CurrentProcess { event_id } => ReplayPlan::Current {
+                event_id: *event_id,
+            },
+            SubscriptionResumeKind::Cursor(cursor) if cursor.epoch() == current_epoch => {
+                ReplayPlan::Current {
+                    event_id: cursor.event_id(),
+                }
+            }
+            SubscriptionResumeKind::Cursor(cursor) => ReplayPlan::Foreign {
+                event_id: cursor.event_id(),
+            },
+            SubscriptionResumeKind::LegacyDecimal { event_id } => ReplayPlan::Foreign {
+                event_id: *event_id,
+            },
+        }
+    }
+}
+
+pub(crate) enum ReplayPlan {
+    None,
+    Current { event_id: u64 },
+    Foreign { event_id: u64 },
+}
+
+impl ReplayPlan {
+    pub(crate) fn is_current_replay(&self) -> bool {
+        matches!(self, Self::Current { .. })
     }
 }
 
@@ -584,9 +774,18 @@ impl WriteResult {
 }
 
 impl ChangeEvent {
-    pub(crate) fn new(id: u64, verb: ChangeVerb, path: ValidatedWorldPath, etag: String) -> Self {
+    pub(crate) fn new(
+        id: u64,
+        listen_epoch: SubscriptionEpoch,
+        verb: ChangeVerb,
+        path: ValidatedWorldPath,
+        etag: String,
+    ) -> Self {
+        let cursor = SubscriptionCursor::new(listen_epoch.clone(), id);
         Self {
             id,
+            listen_epoch,
+            cursor,
             verb,
             path,
             etag,
@@ -762,7 +961,8 @@ impl std::error::Error for InvalidHmacKey {}
 mod tests {
     use super::{
         AuditHmacKey, EtagMatcher, InvalidHmacKey, Preconditions, Representation, SecretBytes,
-        SubscribePattern, ValidatedWorldPath, MIN_HMAC_KEY_BYTES,
+        SubscribePattern, SubscriptionCursor, SubscriptionEpoch, ValidatedWorldPath,
+        MIN_HMAC_KEY_BYTES,
     };
     use bytes::Bytes;
 
@@ -841,6 +1041,19 @@ mod tests {
             SubscribePattern::new("/home/jobs/*").as_str(),
             "/home/jobs/*"
         );
+    }
+
+    #[test]
+    fn subscription_cursor_requires_epoch_and_canonical_decimal() {
+        let cursor = SubscriptionCursor::from_sse_id("0123456789abcdef0123456789abcdef:42")
+            .expect("canonical cursor parses");
+        assert_eq!(cursor.epoch().as_str(), "0123456789abcdef0123456789abcdef");
+        assert_eq!(cursor.event_id(), 42);
+        assert_eq!(cursor.to_string(), "0123456789abcdef0123456789abcdef:42");
+
+        assert!(SubscriptionEpoch::new("0123456789abcdef0123456789abcdeF").is_err());
+        assert!(SubscriptionCursor::from_sse_id("42").is_err());
+        assert!(SubscriptionCursor::from_sse_id("0123456789abcdef0123456789abcdef:0042").is_err());
     }
 
     #[test]

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -3,7 +3,7 @@
 //! The engine owns event ids, replay matching, and the live broadcast stream;
 //! adapters choose how to render those events.
 
-use crate::engine_types::ChangeVerb;
+use crate::engine_types::{ChangeVerb, SubscriptionEpoch};
 
 /// Audit-chain event kinds the engine may append.
 ///
@@ -89,6 +89,7 @@ impl BodyEventKind {
 #[derive(Clone, Debug)]
 pub(crate) struct ChangeEvent {
     pub(crate) id: u64,
+    pub(crate) listen_epoch: SubscriptionEpoch,
     pub(crate) verb: ChangeVerb,
     pub(crate) path: String,
     pub(crate) etag: String,

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -25,6 +25,12 @@ pub(crate) enum AuditPayloadHome {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EventMetadataKind(AuditEventKind);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct BodyEventKind(AuditEventKind);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AuditEventClass {
     pub(crate) body_bearing: bool,
     pub(crate) retention_slot: bool,
@@ -58,6 +64,25 @@ impl AuditEventKind {
                 payload_home: AuditPayloadHome::EventMetadata,
             },
         }
+    }
+}
+
+impl EventMetadataKind {
+    pub(crate) const DELETE_INTENT: Self = Self(AuditEventKind::DeleteIntent);
+    pub(crate) const DELETE_COMMIT: Self = Self(AuditEventKind::DeleteCommit);
+    pub(crate) const DELETE_COMMIT_FAILED: Self = Self(AuditEventKind::DeleteCommitFailed);
+
+    pub(crate) const fn kind(self) -> AuditEventKind {
+        self.0
+    }
+}
+
+impl BodyEventKind {
+    pub(crate) const PUT: Self = Self(AuditEventKind::Put);
+    pub(crate) const APPEND: Self = Self(AuditEventKind::Append);
+
+    pub(crate) const fn kind(self) -> AuditEventKind {
+        self.0
     }
 }
 

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -25,7 +25,7 @@ use std::sync::Mutex as StdMutex;
 use rusqlite::Connection;
 
 use crate::audit;
-use crate::engine_types::AuditHmacKey;
+use crate::engine_types::{AuditHmacKey, ValidatedWorldPath};
 use crate::event::EventMetadataKind;
 use crate::timeline::BodySha256;
 use crate::world;
@@ -106,9 +106,12 @@ impl LedgerWriter {
         } else {
             audit::append_with_conn_existing
         };
+        let ledger_world = ValidatedWorldPath::new(job.ledger_world)
+            .map_err(|_| BlockingSqliteError::Sqlite(rusqlite::Error::InvalidQuery))?;
         append(
             conn,
             job.event_type,
+            &ledger_world,
             &job.target,
             &job.body_sha256,
             job.size,

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -33,7 +33,7 @@ use crate::world;
 /// One audit append's input. Owns its strings/buffers because the
 /// `spawn_blocking` closure that runs the SQL must be `'static`.
 pub(crate) struct AuditAppendJob {
-    pub(crate) ledger_world: &'static str,
+    pub(crate) ledger_world: ValidatedWorldPath,
     pub(crate) event_type: EventMetadataKind,
     pub(crate) target: String,
     pub(crate) body_sha256: BodySha256,
@@ -93,7 +93,8 @@ impl LedgerWriter {
         if guard.is_none() {
             // Lazy init. `world::open` creates the schema; safe to
             // call whether or not the ledger DB exists on disk.
-            let conn = world::open(data, job.ledger_world).map_err(BlockingSqliteError::Sqlite)?;
+            let conn = world::open(data, job.ledger_world.as_str())
+                .map_err(BlockingSqliteError::Sqlite)?;
             *guard = Some(conn);
             self.inits.fetch_add(1, Ordering::Relaxed);
         }
@@ -106,12 +107,10 @@ impl LedgerWriter {
         } else {
             audit::append_with_conn_existing
         };
-        let ledger_world = ValidatedWorldPath::new(job.ledger_world)
-            .map_err(|_| BlockingSqliteError::Sqlite(rusqlite::Error::InvalidQuery))?;
         append(
             conn,
             job.event_type,
-            &ledger_world,
+            &job.ledger_world,
             &job.target,
             &job.body_sha256,
             job.size,
@@ -148,7 +147,7 @@ mod tests {
             .append(
                 &dir,
                 AuditAppendJob {
-                    ledger_world: "var/log/deletes",
+                    ledger_world: ValidatedWorldPath::new("var/log/deletes").unwrap(),
                     event_type: EventMetadataKind::DELETE_INTENT,
                     target: "home/deleted".to_owned(),
                     body_sha256: BodySha256::for_body(b"body"),

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -26,16 +26,17 @@ use rusqlite::Connection;
 
 use crate::audit;
 use crate::engine_types::AuditHmacKey;
-use crate::event::AuditEventKind;
+use crate::event::EventMetadataKind;
+use crate::timeline::BodySha256;
 use crate::world;
 
 /// One audit append's input. Owns its strings/buffers because the
 /// `spawn_blocking` closure that runs the SQL must be `'static`.
 pub(crate) struct AuditAppendJob {
     pub(crate) ledger_world: &'static str,
-    pub(crate) event_type: AuditEventKind,
+    pub(crate) event_type: EventMetadataKind,
     pub(crate) target: String,
-    pub(crate) body_sha256: String,
+    pub(crate) body_sha256: BodySha256,
     pub(crate) size: i64,
     pub(crate) content_type: String,
     pub(crate) headers: Vec<(String, String)>,

--- a/core/src/ledger.rs
+++ b/core/src/ledger.rs
@@ -90,11 +90,9 @@ impl LedgerWriter {
         job: AuditAppendJob,
     ) -> Result<String, BlockingSqliteError> {
         let mut guard = self.conn.lock().unwrap_or_else(|p| p.into_inner());
-        let mut created_ledger = false;
         if guard.is_none() {
             // Lazy init. `world::open` creates the schema; safe to
             // call whether or not the ledger DB exists on disk.
-            created_ledger = !world::world_db(data, job.ledger_world).exists();
             let conn = world::open(data, job.ledger_world).map_err(BlockingSqliteError::Sqlite)?;
             *guard = Some(conn);
             self.inits.fetch_add(1, Ordering::Relaxed);
@@ -102,7 +100,8 @@ impl LedgerWriter {
         let Some(conn) = guard.as_mut() else {
             return Err(BlockingSqliteError::Worker);
         };
-        let append = if created_ledger {
+        let is_empty = ledger_is_empty(conn).map_err(BlockingSqliteError::Sqlite)?;
+        let append = if is_empty {
             audit::append_with_conn_genesis
         } else {
             audit::append_with_conn_existing
@@ -118,5 +117,56 @@ impl LedgerWriter {
             &job.key,
         )
         .map_err(BlockingSqliteError::Audit)
+    }
+}
+
+fn ledger_is_empty(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row("SELECT COUNT(*) FROM events", [], |r| {
+        Ok(r.get::<_, i64>(0)? == 0)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> AuditHmacKey {
+        AuditHmacKey::try_from_slice(crate::test_support::TEST_HMAC_KEY).unwrap()
+    }
+
+    #[test]
+    fn append_uses_genesis_for_existing_empty_ledger() {
+        let dir = std::env::temp_dir().join(format!("elastik-ledger-empty-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        drop(world::open(&dir, "var/log/deletes").unwrap());
+
+        let ledger = LedgerWriter::new();
+        let hmac = ledger
+            .append(
+                &dir,
+                AuditAppendJob {
+                    ledger_world: "var/log/deletes",
+                    event_type: EventMetadataKind::DELETE_INTENT,
+                    target: "home/deleted".to_owned(),
+                    body_sha256: BodySha256::for_body(b"body"),
+                    size: 0,
+                    content_type: "application/octet-stream".to_owned(),
+                    headers: Vec::new(),
+                    key: test_key(),
+                },
+            )
+            .unwrap();
+
+        let c = Connection::open(world::world_db(&dir, "var/log/deletes")).unwrap();
+        let count: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        let stored_hmac: String = c
+            .query_row("SELECT hmac FROM events WHERE id=1", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(stored_hmac, hmac);
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -106,17 +106,18 @@
 //!
 //! ## Subscribe to changes
 //!
-//! Opening a subscription is sync; receiving events is async. Pass `since` to
-//! replay recent events before switching to live delivery.
+//! Opening a subscription is sync; receiving events is async. Pass
+//! [`SubscriptionResume::after_event_id`] to replay recent events before
+//! switching to live delivery.
 //!
 //! ```no_run
 //! # #[cfg(feature = "unstable-engine")]
 //! # async fn run(engine: elastik_core::Engine) {
-//! use elastik_core::{AccessTier, SubscribePattern};
+//! use elastik_core::{AccessTier, SubscribePattern, SubscriptionResume};
 //!
 //! let pattern = SubscribePattern::new("/home/tasks/*");
 //! let mut sub = engine
-//!     .subscribe(&pattern, AccessTier::Read, None)
+//!     .subscribe(&pattern, AccessTier::Read, SubscriptionResume::none())
 //!     .expect("subscription opens");
 //!
 //! let event = sub.recv().await.expect("change event");
@@ -215,8 +216,8 @@ pub use engine_trace::{DeleteMetadata, EngineDeleteTraceHooks, EngineWriteTraceH
 pub use engine_types::{
     parse_etag_matchers, AccessTier, AuditHmacKey, ChangeEvent, ChangeVerb, EmptyKeyError,
     EngineSubscription, EtagMatcher, InvalidHmacKey, InvalidWorldPath, Preconditions, ReadResult,
-    Representation, SecretBytes, SubscribePattern, SubscriptionRecvError, ValidatedWorldPath,
-    WriteKind, WriteResult, MIN_HMAC_KEY_BYTES,
+    Representation, SecretBytes, SubscribePattern, SubscriptionRecvError, SubscriptionResume,
+    ValidatedWorldPath, WriteKind, WriteResult, MIN_HMAC_KEY_BYTES,
 };
 #[cfg(feature = "unstable-engine")]
 pub use path::{validate_world_name, NAMESPACE_PREFIXES};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -165,6 +165,7 @@ mod data_lock;
 mod defaults;
 mod delete_ops;
 mod engine;
+mod engine_error;
 mod engine_introspection;
 mod engine_ops;
 mod engine_trace;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -215,9 +215,10 @@ pub use engine_trace::{DeleteMetadata, EngineDeleteTraceHooks, EngineWriteTraceH
 #[cfg(feature = "unstable-engine")]
 pub use engine_types::{
     parse_etag_matchers, AccessTier, AuditHmacKey, ChangeEvent, ChangeVerb, EmptyKeyError,
-    EngineSubscription, EtagMatcher, InvalidHmacKey, InvalidWorldPath, Preconditions, ReadResult,
-    Representation, SecretBytes, SubscribePattern, SubscriptionRecvError, SubscriptionResume,
-    ValidatedWorldPath, WriteKind, WriteResult, MIN_HMAC_KEY_BYTES,
+    EngineSubscription, EtagMatcher, InvalidHmacKey, InvalidSubscriptionCursor,
+    InvalidSubscriptionEpoch, InvalidWorldPath, Preconditions, ReadResult, Representation,
+    SecretBytes, SubscribePattern, SubscriptionCursor, SubscriptionEpoch, SubscriptionRecvError,
+    SubscriptionResume, ValidatedWorldPath, WriteKind, WriteResult, MIN_HMAC_KEY_BYTES,
 };
 #[cfg(feature = "unstable-engine")]
 pub use path::{validate_world_name, NAMESPACE_PREFIXES};

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -1458,15 +1458,8 @@ mod tests {
         // produces a `put` event whose hmac chains to a synthetic
         // genesis (prev = ""). `WriteAuditError` doesn't derive
         // Debug, so don't .unwrap() on it -- match instead.
-        match world::write_with_audit_checked(
-            &dir,
-            world,
-            b"hello",
-            "text/plain",
-            &[],
-            &test_key(),
-            None,
-        ) {
+        match world::write_with_audit_checked(&dir, world, b"hello", "text/plain", &[], &test_key())
+        {
             Ok(_) => {}
             Err(_) => panic!("seed write_with_audit_checked failed"),
         }

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -470,7 +470,7 @@ impl ReadCache {
     ) -> rusqlite::Result<Option<crate::audit::VerifyReport>> {
         let key = key.clone_secret();
         self.with_tracked_conn(data, world, move |conn| {
-            crate::audit::verify_chain_via_conn(conn, &key)
+            crate::audit::verify_chain_via_conn(conn, world, &key)
         })
     }
 

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -1462,8 +1462,15 @@ mod tests {
         // produces a `put` event whose hmac chains to a synthetic
         // genesis (prev = ""). `WriteAuditError` doesn't derive
         // Debug, so don't .unwrap() on it -- match instead.
-        match world::write_with_audit_checked(&dir, world, b"hello", "text/plain", &[], &test_key())
-        {
+        let audited_world = crate::engine_types::ValidatedWorldPath::new(world).unwrap();
+        match world::write_with_audit_checked(
+            &dir,
+            &audited_world,
+            b"hello",
+            "text/plain",
+            &[],
+            &test_key(),
+        ) {
             Ok(_) => {}
             Err(_) => panic!("seed write_with_audit_checked failed"),
         }

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -494,25 +494,25 @@ impl ReadCache {
     where
         F: FnOnce(&mut TrackedReadConnection) -> rusqlite::Result<R>,
     {
-        let world = world.as_str();
-        let path = world::world_db(data, world);
+        let world_key = world.as_str();
+        let path = world::validated_world_db(data, world);
         let mut f = Some(f);
         let mut counted_miss = false;
         let mut counted_capped = false;
 
         for _ in 0..READ_CACHE_RETRY_BUDGET {
             // PHASE 1 -- Cache hit (any state).
-            if let Some(arc) = self.read_conns.get(world).map(|e| e.value().clone()) {
+            if let Some(arc) = self.read_conns.get(world_key).map(|e| e.value().clone()) {
                 self.touch_slot(&arc);
                 match self.invoke_via_slot(arc.clone(), &mut f)? {
                     SlotRead::Done(value) => {
-                        self.best_effort_trim_over_cap(world);
+                        self.best_effort_trim_over_cap(world_key);
                         self.metrics.read_cache_hits.fetch_add(1, Ordering::Relaxed);
                         return Ok(value);
                     }
                     SlotRead::Opening => continue,
                     SlotRead::Evicted => {
-                        self.remove_evicted_entry(world, &arc);
+                        self.remove_evicted_entry(world_key, &arc);
                         continue;
                     }
                 }
@@ -534,10 +534,10 @@ impl ReadCache {
                         .fetch_add(1, Ordering::Relaxed);
                     counted_capped = true;
                 }
-                if self.try_evict_oldest_sample(world) {
+                if self.try_evict_oldest_sample(world_key) {
                     continue;
                 }
-                return self.invoke_transient(&path, world, f.take().expect("read closure"));
+                return self.invoke_transient(&path, world_key, f.take().expect("read closure"));
             }
 
             // PHASE 3 -- Cache miss + room: slot-before-open lazy-init.
@@ -562,7 +562,7 @@ impl ReadCache {
             let new_guard = new_slot.inner.write().unwrap_or_else(|p| p.into_inner());
             let arc = self
                 .read_conns
-                .entry(world.to_string())
+                .entry(world_key.to_string())
                 .or_insert_with(move || insert_slot)
                 .value()
                 .clone();
@@ -579,7 +579,7 @@ impl ReadCache {
                             transition.fail();
                             drop(g);
                             self.read_conns
-                                .remove_if(world, |_k, v| Arc::ptr_eq(v, &arc));
+                                .remove_if(world_key, |_k, v| Arc::ptr_eq(v, &arc));
                             self.metrics
                                 .read_cache_open_fails
                                 .fetch_add(1, Ordering::Relaxed);
@@ -599,20 +599,20 @@ impl ReadCache {
             self.touch_slot(&arc);
             match self.invoke_via_slot(arc.clone(), &mut f)? {
                 SlotRead::Done(value) => {
-                    self.best_effort_trim_over_cap(world);
+                    self.best_effort_trim_over_cap(world_key);
                     return Ok(value);
                 }
                 SlotRead::Opening => {}
                 SlotRead::Evicted => {
-                    self.remove_evicted_entry(world, &arc);
+                    self.remove_evicted_entry(world_key, &arc);
                 }
             }
         }
 
-        log_read_cache_retry_budget_exhausted(world, "tracked");
+        log_read_cache_retry_budget_exhausted(world_key, "tracked");
         self.invoke_transient(
             &path,
-            world,
+            world_key,
             f.take().expect(
                 "read cache retry budget exhausted with no closure; \
                  SlotRead::Done should have returned before budget fallback",

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -825,7 +825,7 @@ mod tests {
         let dir = scratch_dir("hit");
         let world = "home/cache-hit";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"hello", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"hello", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
 
@@ -919,7 +919,7 @@ mod tests {
         let dir = scratch_dir("generation-regression-cache-hit");
         let world = "home/cached";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"hello", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"hello", "text/plain", &[]).unwrap();
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
 
         assert!(cache.cached_read_with_hmac(&dir, world).unwrap().is_some());
@@ -939,7 +939,7 @@ mod tests {
         let dir = scratch_dir("last-access");
         for w in ["home/a", "home/b"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"hello", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"hello", "text/plain", &[]).unwrap();
         }
 
         let cache = ReadCache::new(2);
@@ -993,7 +993,7 @@ mod tests {
         let dir = scratch_dir("tombstone");
         let world = "home/tomb";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"x", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"x", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
@@ -1013,7 +1013,7 @@ mod tests {
         let dir = scratch_dir("cap-evict");
         for w in ["home/a", "home/b", "home/c"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"x", "text/plain", &[]).unwrap();
         }
 
         let cache = ReadCache::new(2);
@@ -1049,7 +1049,7 @@ mod tests {
         let dir = scratch_dir("cap-transient-busy");
         for w in ["home/a", "home/b", "home/c"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"x", "text/plain", &[]).unwrap();
         }
 
         let cache = ReadCache::new(2);
@@ -1088,7 +1088,8 @@ mod tests {
         let worlds = ["home/a", "home/b", "home/c", "home/d", "home/e"];
         for (idx, w) in worlds.iter().enumerate() {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, &[b'a' + idx as u8], "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, &[b'a' + idx as u8], "text/plain", &[])
+                .unwrap();
         }
 
         let cache = ReadCache::new(1);
@@ -1127,7 +1128,8 @@ mod tests {
         let worlds = ["home/a", "home/b", "home/c", "home/d"];
         for (idx, w) in worlds.iter().enumerate() {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, &[b'a' + idx as u8], "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, &[b'a' + idx as u8], "text/plain", &[])
+                .unwrap();
         }
 
         let cache = StdArc::new(ReadCache::new(1));
@@ -1163,7 +1165,7 @@ mod tests {
         let dir = scratch_dir("cap-hit");
         for w in ["home/a", "home/b"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"x", "text/plain", &[]).unwrap();
         }
 
         let cache = ReadCache::new(2);
@@ -1198,7 +1200,8 @@ mod tests {
         let dir = scratch_dir("evicted-retry");
         let world = "home/evicted";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"still here", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"still here", "text/plain", &[])
+            .unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         cache
@@ -1231,7 +1234,7 @@ mod tests {
         let dir = scratch_dir("evict-busy");
         let world = "home/busy";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"busy", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"busy", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
@@ -1256,7 +1259,7 @@ mod tests {
         let dir = scratch_dir("evict-ready-success");
         let world = "home/idle";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"idle", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"idle", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
@@ -1281,7 +1284,7 @@ mod tests {
         let dir = scratch_dir("evict-stale-arc");
         let world = "home/stale";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"stale", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"stale", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         let _ = cache.cached_read_with_hmac(&dir, world).unwrap();
@@ -1311,7 +1314,7 @@ mod tests {
         let dir = scratch_dir("done-none-and-opening");
         let world = "home/done-none";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"x", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"x", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         cache.install_tombstone_blocking(world);
@@ -1353,7 +1356,8 @@ mod tests {
         let dir = scratch_dir("stuck-opening-budget");
         let world = "home/stuck-opening";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"still here", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"still here", "text/plain", &[])
+            .unwrap();
 
         let cache = ReadCache::new(1);
         cache
@@ -1384,7 +1388,7 @@ mod tests {
         let dir = scratch_dir("evict-skip-tombstone");
         for w in ["home/ready", "home/tomb"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"x", "text/plain", &[]).unwrap();
         }
 
         let cache = ReadCache::new(2);
@@ -1411,7 +1415,7 @@ mod tests {
         let dir = scratch_dir("evict-exclude-target");
         for w in ["home/a", "home/b", "home/c"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"x", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"x", "text/plain", &[]).unwrap();
         }
 
         let cache = ReadCache::new(3);
@@ -1515,7 +1519,8 @@ mod tests {
         let dir = StdArc::new(scratch_dir("cap-transient-concurrent"));
         for w in ["home/a", "home/b", "home/c"] {
             let _c = world::open(&dir, w).unwrap();
-            world::write(&dir, w, b"hello world", "text/plain", &[]).unwrap();
+            world::test_only_write_without_audit(&dir, w, b"hello world", "text/plain", &[])
+                .unwrap();
         }
 
         // cap=2 -> A and B fill it; C must go through transient.
@@ -1596,7 +1601,7 @@ mod tests {
         let dir = scratch_dir("cantopen-existing");
         let world = "home/locked";
         let _c = world::open(&dir, world).unwrap();
-        world::write(&dir, world, b"hello", "text/plain", &[]).unwrap();
+        world::test_only_write_without_audit(&dir, world, b"hello", "text/plain", &[]).unwrap();
 
         // chmod 000 the universe.db so SQLite returns CANTOPEN even
         // though the file is genuinely on disk.

--- a/core/src/read_cache.rs
+++ b/core/src/read_cache.rs
@@ -759,9 +759,14 @@ impl ReadCache {
 
     /// Sync version. delete callers wrap this in `spawn_blocking` so
     /// the drain wait doesn't stall a Tokio worker.
-    pub(crate) fn install_tombstone_blocking(&self, world: &str) {
+    pub(crate) fn install_tombstone_blocking(
+        &self,
+        world: &crate::engine_types::ValidatedWorldPath,
+    ) {
         let new_tombstone = self.new_slot(SlotState::Tombstone);
-        let prev = self.read_conns.insert(world.to_string(), new_tombstone);
+        let prev = self
+            .read_conns
+            .insert(world.as_str().to_owned(), new_tombstone);
         if let Some(prev_slot) = prev {
             let mut g = prev_slot.inner.write().unwrap_or_else(|p| p.into_inner());
             let old = std::mem::replace(&mut *g, SlotState::Tombstone);
@@ -774,8 +779,8 @@ impl ReadCache {
     /// Called on BOTH success and failure (Bug 20): on failure, the
     /// world is still on disk; the next read should lazy-init a
     /// fresh slot rather than seeing a phantom 404.
-    pub(crate) fn clear_tombstone(&self, world: &str) {
-        self.read_conns.remove(world);
+    pub(crate) fn clear_tombstone(&self, world: &crate::engine_types::ValidatedWorldPath) {
+        self.read_conns.remove(world.as_str());
     }
 
     /// Snapshot accessor for `/proc/pool`; exposes count only, never slots.
@@ -1007,11 +1012,11 @@ mod tests {
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
         let _ = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
-        cache.install_tombstone_blocking(world);
+        cache.install_tombstone_blocking(&v(world));
         let r = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(r.is_none());
 
-        cache.clear_tombstone(world);
+        cache.clear_tombstone(&v(world));
         let r2 = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(r2.is_some());
 
@@ -1352,7 +1357,7 @@ mod tests {
         world::test_only_write_without_audit(&dir, world, b"x", "text/plain", &[]).unwrap();
 
         let cache = ReadCache::new(DEFAULT_READ_CACHE_MAX_ENTRIES);
-        cache.install_tombstone_blocking(world);
+        cache.install_tombstone_blocking(&v(world));
         let tombstone = cache.cached_read_with_hmac(&dir, &v(world)).unwrap();
         assert!(tombstone.is_none());
         assert_eq!(
@@ -1428,7 +1433,7 @@ mod tests {
 
         let cache = ReadCache::new(2);
         let _ = cache.cached_read_with_hmac(&dir, &v("home/ready")).unwrap();
-        cache.install_tombstone_blocking("home/tomb");
+        cache.install_tombstone_blocking(&v("home/tomb"));
 
         assert!(
             cache.try_evict_oldest_sample("home/new"),
@@ -1528,13 +1533,13 @@ mod tests {
         assert!(matches!(r2, Some(crate::audit::VerifyReport::Valid(_))));
 
         // Tombstone short-circuits verify (delete intent).
-        cache.install_tombstone_blocking(world);
+        cache.install_tombstone_blocking(&v(world));
         let r3 = cache.cached_verify_chain(&dir, &v(world), &key).unwrap();
         assert!(r3.is_none());
 
         // After clear_tombstone the next verify re-opens through
         // Phase 3 lazy-init.
-        cache.clear_tombstone(world);
+        cache.clear_tombstone(&v(world));
         let r4 = cache.cached_verify_chain(&dir, &v(world), &key).unwrap();
         assert!(matches!(r4, Some(crate::audit::VerifyReport::Valid(_))));
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -57,6 +57,17 @@ fn next_event_id(counter: &EventCounter) -> u64 {
     counter.fetch_add(1, Ordering::Relaxed) + 1
 }
 
+/// Newest event id this process has issued, or 0 before the first event.
+///
+/// Listen ids are process-local: the counter resets on every engine start.
+/// A resume cursor greater than this value must come from another process
+/// lifetime and cannot be used as a live-stream floor.
+#[cfg(target_has_atomic = "64")]
+#[inline]
+pub(crate) fn last_issued_event_id(counter: &EventCounter) -> u64 {
+    counter.load(Ordering::Relaxed)
+}
+
 #[cfg(not(target_has_atomic = "64"))]
 #[inline]
 fn next_event_id(counter: &EventCounter) -> u64 {
@@ -65,6 +76,35 @@ fn next_event_id(counter: &EventCounter) -> u64 {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     *next = next.saturating_add(1);
     *next
+}
+
+/// Newest event id this process has issued, or 0 before the first event.
+///
+/// Listen ids are process-local: the counter resets on every engine start.
+/// A resume cursor greater than this value must come from another process
+/// lifetime and cannot be used as a live-stream floor.
+#[cfg(not(target_has_atomic = "64"))]
+#[inline]
+pub(crate) fn last_issued_event_id(counter: &EventCounter) -> u64 {
+    *counter
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Test-only counter minting bypass. Production ids advance only through
+/// `next_event_id`.
+#[cfg(test)]
+pub(crate) fn test_only_set_event_counter(counter: &EventCounter, value: u64) {
+    #[cfg(target_has_atomic = "64")]
+    {
+        counter.store(value, Ordering::Relaxed);
+    }
+    #[cfg(not(target_has_atomic = "64"))]
+    {
+        *counter
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = value;
+    }
 }
 
 pub(crate) struct StorageReservationError {

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -226,12 +226,12 @@ impl Core {
     /// `world`'s DB -- `delete_world_blocking` is safe to call.
     /// Memory worlds: no-op. The blocking drain runs inside
     /// `spawn_blocking` so it doesn't stall a Tokio worker.
-    pub(crate) async fn install_tombstone(&self, world: &str) {
-        if store::is_memory_world(world) {
+    pub(crate) async fn install_tombstone(&self, world: &ValidatedWorldPath) {
+        if store::is_memory_world(world.as_str()) {
             return;
         }
         let cache = self.read_cache.clone();
-        let world = world.to_string();
+        let world = world.clone();
         let _ = tokio::task::spawn_blocking(move || cache.install_tombstone_blocking(&world)).await;
     }
 
@@ -239,8 +239,8 @@ impl Core {
     /// Called on BOTH success and failure (Bug 20): on failure the
     /// world is still on disk, and the next read must lazy-init a
     /// fresh slot rather than seeing a phantom 404.
-    pub(crate) fn clear_tombstone(&self, world: &str) {
-        if store::is_memory_world(world) {
+    pub(crate) fn clear_tombstone(&self, world: &ValidatedWorldPath) {
+        if store::is_memory_world(world.as_str()) {
             return;
         }
         self.read_cache.clear_tombstone(world);

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -258,7 +258,7 @@ impl Core {
             self.mem.write(world, body, content_type, headers);
             Ok(())
         } else {
-            let current_len = world::body_len(&self.data, world)?;
+            let current_len = world::storage_len(&self.data, world)?;
             world::write_with_audit(
                 &self.data,
                 world,
@@ -268,10 +268,11 @@ impl Core {
                 &self.hmac_key,
             )?;
             let prev = current_len.unwrap_or(0);
+            let new_len = world::storage_len(&self.data, world)?.unwrap_or(0);
             let _ = self.storage_body_bytes.fetch_update(
                 Ordering::Relaxed,
                 Ordering::Relaxed,
-                |used| Some(used.saturating_sub(prev).saturating_add(body.len())),
+                |used| Some(used.saturating_sub(prev).saturating_add(new_len)),
             );
             if current_len.is_none() {
                 self.durable_world_count.fetch_add(1, Ordering::Relaxed);
@@ -336,17 +337,20 @@ impl Core {
     }
 
     /// Atomic reservation: check the quota and reserve `new_len - prev_len`
-    /// in a single CAS step. Replaces the old "snapshot then write then
+    /// in a single CAS step. `new_len` includes current durable body bytes
+    /// plus any candidate retained CAS body bytes for this write.
+    /// Replaces the old "snapshot then write then
     /// adjust" pattern, which raced under per-world locking when two
     /// concurrent writes on different worlds both observed usage below
     /// quota and only afterwards pushed it past.
     ///
     /// Caller must hold `acquire_world_lock(world)` so that `prev_len`
-    /// reflects the world's true current body length (cannot change
+    /// reflects the world's true current accounted length (cannot change
     /// underneath us). On success the global counter has already been
-    /// updated; on success of the subsequent storage write, no further
-    /// counter change is needed. On failure of the storage write, call
-    /// `rollback_storage_reservation` to credit back.
+    /// updated; on success of the subsequent storage write, refund any
+    /// pessimistically reserved CAS bytes that were already present. On
+    /// failure of the storage write, call `rollback_storage_reservation` to
+    /// credit back the whole reservation.
     ///
     /// `prev_len` is 0 for new worlds and for append (where the existing
     /// bytes stay and we only add `new_len` new).

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -348,7 +348,7 @@ impl Core {
         } else {
             let data = self.data.clone();
             let world = world.clone();
-            tokio::task::spawn_blocking(move || world::delete(&data, world.as_str()))
+            tokio::task::spawn_blocking(move || world::delete(&data, &world))
                 .await
                 .unwrap_or(false)
         }

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -288,7 +288,7 @@ impl Core {
     /// 80+ unit tests that build small fixture worlds before exercising
     /// handler paths.
     #[cfg(test)]
-    pub(crate) fn write_world(
+    pub(crate) fn test_only_write_world(
         &self,
         world: &str,
         body: &[u8],
@@ -342,13 +342,13 @@ impl Core {
         }
     }
 
-    pub(crate) async fn delete_world_blocking(&self, world: &str) -> bool {
-        if store::is_memory_world(world) {
-            self.mem.delete(world)
+    pub(crate) async fn delete_world_blocking(&self, world: &ValidatedWorldPath) -> bool {
+        if store::is_memory_world(world.as_str()) {
+            self.mem.delete(world.as_str())
         } else {
             let data = self.data.clone();
-            let world = world.to_string();
-            tokio::task::spawn_blocking(move || world::delete(&data, &world))
+            let world = world.clone();
+            tokio::task::spawn_blocking(move || world::delete(&data, world.as_str()))
                 .await
                 .unwrap_or(false)
         }

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::AtomicU64;
 use dashmap::DashMap;
 use tokio::sync::{broadcast, watch, Mutex, OwnedMutexGuard, Semaphore};
 
-use crate::engine_types::{AuditHmacKey, ValidatedWorldPath};
+use crate::engine_types::{AuditHmacKey, SubscriptionEpoch, ValidatedWorldPath};
 use crate::ledger::LedgerWriter;
 pub(crate) use crate::ledger::{AuditAppendJob, BlockingSqliteError};
 use crate::read_cache::ReadCache;
@@ -127,6 +127,7 @@ pub(crate) struct Core {
     pub(crate) events: broadcast::Sender<event::ChangeEvent>,
     pub(crate) listen_slots: Arc<Semaphore>,
     pub(crate) listen_replay_max: usize,
+    pub(crate) listen_epoch: SubscriptionEpoch,
     pub(crate) event_log: Arc<StdMutex<VecDeque<event::ChangeEvent>>>,
     pub(crate) shutdown: watch::Receiver<bool>,
     /// Listen ids stay u64-monotonic because replay uses `>` comparisons
@@ -299,10 +300,10 @@ impl Core {
             self.mem.write(world, body, content_type, headers);
             Ok(())
         } else {
-            let current_len = world::storage_len(&self.data, world)?;
             let world_path = ValidatedWorldPath::new(world).map_err(|_| {
                 world::WriteAuditError::StorageInvariant("invalid fixture world path")
             })?;
+            let current_len = world::storage_len(&self.data, &world_path)?;
             world::write_with_audit(
                 &self.data,
                 &world_path,
@@ -312,7 +313,7 @@ impl Core {
                 &self.hmac_key,
             )?;
             let prev = current_len.unwrap_or(0);
-            let new_len = world::storage_len(&self.data, world)?.unwrap_or(0);
+            let new_len = world::storage_len(&self.data, &world_path)?.unwrap_or(0);
             let _ = self.storage_body_bytes.fetch_update(
                 Ordering::Relaxed,
                 Ordering::Relaxed,
@@ -363,6 +364,7 @@ impl Core {
         let id = next_event_id(&self.next_event);
         let change = event::ChangeEvent {
             id,
+            listen_epoch: self.listen_epoch.clone(),
             verb,
             path: format!("/{}", world.as_str()),
             etag: etag.to_owned(),

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -259,9 +259,12 @@ impl Core {
             Ok(())
         } else {
             let current_len = world::storage_len(&self.data, world)?;
+            let world_path = ValidatedWorldPath::new(world).map_err(|_| {
+                world::WriteAuditError::StorageInvariant("invalid fixture world path")
+            })?;
             world::write_with_audit(
                 &self.data,
-                world,
+                &world_path,
                 body,
                 content_type,
                 headers,

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -285,6 +285,7 @@ pub fn list_all(data_root: &Path, mem: &MemoryStore) -> rusqlite::Result<Vec<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine_types::ValidatedWorldPath;
     use crate::{audit, test_support::test_core};
 
     #[test]
@@ -341,9 +342,10 @@ mod tests {
     #[test]
     fn disk_worlds_create_sqlite_files_and_audit_chain_when_using_audit_path() {
         let (core, dir) = test_core("disk-world");
+        let world_path = ValidatedWorldPath::new("home/report").unwrap();
         let h = world::write_with_audit(
             &core.data,
-            "home/report",
+            &world_path,
             b"final",
             "text/plain; charset=utf-8",
             &[],

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -49,7 +49,7 @@ pub struct MemoryStore {
 /// write would push the total memory store size past `max_total_bytes`.
 /// The check happens under the same mutex as the write so concurrent
 /// writers cannot both pass a stale snapshot and then both commit
-/// (mirror of the durable `WriteAuditError::Quota` path).
+/// (durable quota is reserved before SQLite write transactions).
 pub struct MemoryQuotaError {
     /// Pre-write total bytes across all memory worlds. Currently the
     /// callers only need `quota` for payload-cap mapping, but `used` and
@@ -136,6 +136,7 @@ impl MemoryStore {
         e.body_hash = after.clone();
         Some(AppendResult {
             body_sha256_after: after,
+            cas_body_inserted: false,
         })
     }
 
@@ -207,6 +208,7 @@ impl MemoryStore {
         entry.body_hash = after.clone();
         Ok(Some(AppendResult {
             body_sha256_after: after,
+            cas_body_inserted: false,
         }))
     }
 

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn worlds_store_content_type_not_private_extensions() {
         let (core, dir) = test_core("content-type");
-        core.write_world("home/pdf", b"%PDF-1.7", "application/pdf", &[])
+        core.test_only_write_world("home/pdf", b"%PDF-1.7", "application/pdf", &[])
             .unwrap();
 
         let stage = core.read_world(&world_path("home/pdf")).unwrap().unwrap();
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn memory_worlds_do_not_create_sqlite_files_or_audit_chain() {
         let (core, dir) = test_core("memory-world");
-        core.write_world(
+        core.test_only_write_world(
             "tmp/scratch",
             b"draft",
             "text/plain; charset=utf-8",

--- a/core/src/test_support.rs
+++ b/core/src/test_support.rs
@@ -12,7 +12,7 @@ use crate::{
         DEFAULT_LISTEN_REPLAY_MAX, DEFAULT_MAX_LISTEN_CONNECTIONS, DEFAULT_MAX_MEMORY_BYTES,
         DEFAULT_MAX_WORLD_BYTES,
     },
-    engine_types::AuditHmacKey,
+    engine_types::{AuditHmacKey, SubscriptionEpoch},
     store, Core,
 };
 
@@ -57,6 +57,7 @@ pub(crate) fn test_core_with_read_cache_max(
                 events,
                 listen_slots: Arc::new(Semaphore::new(DEFAULT_MAX_LISTEN_CONNECTIONS)),
                 listen_replay_max: DEFAULT_LISTEN_REPLAY_MAX,
+                listen_epoch: SubscriptionEpoch::mint().unwrap(),
                 event_log: Arc::new(StdMutex::new(VecDeque::with_capacity(
                     DEFAULT_LISTEN_REPLAY_MAX,
                 ))),

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -184,6 +184,10 @@ impl TimelineSeq {
 }
 
 impl BodySha256 {
+    pub(crate) fn for_body(body: &[u8]) -> Self {
+        Self(crate::world::sha256_hex(body))
+    }
+
     pub(crate) fn new(raw: impl Into<String>) -> Result<Self, InvalidBodySha256> {
         let raw = raw.into();
         if raw.len() != BODY_SHA256_HEX_LEN {

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -14,18 +14,16 @@
 //!
 //! Renames vs pre-v5: `stage_html` -> `body`. Drops: `pending_js`,
 //! `js_result`, `state`. v5.2 adds CAS retention tables. No migrator:
-//! world dirs from older binaries fail loudly on the first missing or stale
-//! schema surface; wipe `data/` to upgrade.
+//! stale world dirs fail loudly; wipe `data/` to upgrade.
 //!
-//! `state` is gone on purpose: `/lib/*` is inert storage now; lifecycle
-//! belongs to whatever SDK or endpoint app loads the source.
-//!
-//! `meta_headers` is the current X-Meta-* header view. `event_headers`
-//! is the historical per-write view. The event chain stores structured
-//! audit facts, never JSON blobs.
+//! `meta_headers` is current metadata; `event_headers` is historical.
+//! The event chain stores structured audit facts, never JSON blobs.
 
 use crate::{
-    audit, engine_types::AuditHmacKey, event::BodyEventKind, timeline::BodySha256,
+    audit,
+    engine_types::{AuditHmacKey, ValidatedWorldPath},
+    event::BodyEventKind,
+    timeline::BodySha256,
     world_generation, world_schema,
 };
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
@@ -333,7 +331,7 @@ pub fn test_only_write_without_audit(
 #[cfg(test)]
 pub fn write_with_audit(
     data_root: &Path,
-    world: &str,
+    world: &ValidatedWorldPath,
     body: &[u8],
     content_type: &str,
     headers: &[(String, String)],
@@ -345,14 +343,15 @@ pub fn write_with_audit(
 
 pub fn write_with_audit_checked(
     data_root: &Path,
-    world: &str,
+    world: &ValidatedWorldPath,
     body: &[u8],
     content_type: &str,
     headers: &[(String, String)],
     key: &AuditHmacKey,
 ) -> Result<WriteAuditResult, WriteAuditError> {
-    let existed = world_db(data_root, world).exists();
-    let mut c = open(data_root, world)?;
+    let world_name = world.as_str();
+    let existed = world_db(data_root, world_name).exists();
+    let mut c = open(data_root, world_name)?;
     let tx = c.transaction()?;
     let previous_len = tx.query_row(
         "SELECT CASE WHEN typeof(body) = 'blob' THEN length(body) END FROM stage_meta WHERE id=1",
@@ -430,17 +429,18 @@ fn test_only_append_without_audit(
 
 pub fn append_with_audit(
     data_root: &Path,
-    world: &str,
+    world: &ValidatedWorldPath,
     body: &[u8],
     content_type: &str,
     headers: &[(String, String)],
     key: &AuditHmacKey,
 ) -> Result<Option<(AppendResult, String)>, WriteAuditError> {
-    let path = world_db(data_root, world);
+    let world_name = world.as_str();
+    let path = world_db(data_root, world_name);
     if !path.exists() {
         return Ok(None);
     }
-    let mut c = open(data_root, world)?;
+    let mut c = open(data_root, world_name)?;
     let tx = c.transaction()?;
     let audit_tx = verify_appendable_world_tx(&tx, key, true)?;
     let current = tx.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
@@ -510,6 +510,10 @@ mod tests {
         std::env::temp_dir().join(format!("elastik-world-test-{name}-{}", std::process::id()))
     }
 
+    fn validated(world: &str) -> ValidatedWorldPath {
+        ValidatedWorldPath::new(world).unwrap()
+    }
+
     fn force_text_body(data_root: &Path, world: &str, text: &str) {
         let c = Connection::open(world_db(data_root, world)).unwrap();
         c.execute(
@@ -565,7 +569,8 @@ mod tests {
         let body = b"retained body";
         let body_hash = sha256_hex(body);
 
-        let hmac = write_with_audit(&root, "home/cas", body, "text/plain", &[], &key).unwrap();
+        let hmac =
+            write_with_audit(&root, &validated("home/cas"), body, "text/plain", &[], &key).unwrap();
 
         let c = Connection::open(world_db(&root, "home/cas")).unwrap();
         let retained: Vec<u8> = c
@@ -601,11 +606,25 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         let key = test_key();
 
-        write_with_audit(&root, "home/cas-append", b"one", "text/plain", &[], &key).unwrap();
-        let (result, _) =
-            append_with_audit(&root, "home/cas-append", b"two", "text/plain", &[], &key)
-                .unwrap()
-                .unwrap();
+        write_with_audit(
+            &root,
+            &validated("home/cas-append"),
+            b"one",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap();
+        let (result, _) = append_with_audit(
+            &root,
+            &validated("home/cas-append"),
+            b"two",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap()
+        .unwrap();
 
         let full_body = b"onetwo";
         let full_hash = sha256_hex(full_body);
@@ -644,7 +663,7 @@ mod tests {
 
         write_with_audit(
             &root,
-            "home/cas-idempotent",
+            &validated("home/cas-idempotent"),
             b"same",
             "text/plain",
             &[],
@@ -653,7 +672,7 @@ mod tests {
         .unwrap();
         write_with_audit(
             &root,
-            "home/cas-idempotent",
+            &validated("home/cas-idempotent"),
             b"same",
             "application/octet-stream",
             &[],
@@ -693,7 +712,7 @@ mod tests {
 
         write_with_audit(
             &root,
-            "home/cas-mismatch",
+            &validated("home/cas-mismatch"),
             old_body,
             "text/plain",
             &[],
@@ -711,7 +730,7 @@ mod tests {
 
         let _err = write_with_audit(
             &root,
-            "home/cas-mismatch",
+            &validated("home/cas-mismatch"),
             new_body,
             "text/plain",
             &[],
@@ -748,7 +767,7 @@ mod tests {
 
         write_with_audit(
             &root,
-            "home/cas-append-mismatch",
+            &validated("home/cas-append-mismatch"),
             b"one",
             "text/plain",
             &[],
@@ -767,7 +786,7 @@ mod tests {
 
         let _err = match append_with_audit(
             &root,
-            "home/cas-append-mismatch",
+            &validated("home/cas-append-mismatch"),
             b"two",
             "text/plain",
             &[],
@@ -803,7 +822,7 @@ mod tests {
 
         let err = write_with_audit(
             &root,
-            "home/cas-floor",
+            &validated("home/cas-floor"),
             b"one",
             "text/plain",
             &[],
@@ -963,7 +982,7 @@ mod tests {
         force_text_body(&root, "home/audited", "\u{00e9}");
         assert!(append_with_audit(
             &root,
-            "home/audited",
+            &validated("home/audited"),
             b"!",
             "text/plain; charset=utf-8",
             &[],
@@ -979,14 +998,30 @@ mod tests {
         let root = test_root("tampered-audit-chain");
         let _ = std::fs::remove_dir_all(&root);
         let key = test_key();
-        write_with_audit(&root, "home/tamper", b"one", "text/plain", &[], &key).unwrap();
+        write_with_audit(
+            &root,
+            &validated("home/tamper"),
+            b"one",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap();
         {
             let c = Connection::open(world_db(&root, "home/tamper")).unwrap();
             c.execute("UPDATE events SET hmac='bad' WHERE id=1", [])
                 .unwrap();
         }
 
-        assert!(write_with_audit(&root, "home/tamper", b"two", "text/plain", &[], &key,).is_err());
+        assert!(write_with_audit(
+            &root,
+            &validated("home/tamper"),
+            b"two",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .is_err());
 
         let c = Connection::open(world_db(&root, "home/tamper")).unwrap();
         let count: i64 = c
@@ -1002,7 +1037,15 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         drop(open(&root, "home/retry").unwrap());
 
-        write_with_audit(&root, "home/retry", b"one", "text/plain", &[], &test_key()).unwrap();
+        write_with_audit(
+            &root,
+            &validated("home/retry"),
+            b"one",
+            "text/plain",
+            &[],
+            &test_key(),
+        )
+        .unwrap();
 
         let c = Connection::open(world_db(&root, "home/retry")).unwrap();
         let count: i64 = c
@@ -1022,9 +1065,15 @@ mod tests {
                 .unwrap();
         }
 
-        assert!(
-            write_with_audit(&root, "home/orphan", b"two", "text/plain", &[], &test_key()).is_err()
-        );
+        assert!(write_with_audit(
+            &root,
+            &validated("home/orphan"),
+            b"two",
+            "text/plain",
+            &[],
+            &test_key(),
+        )
+        .is_err());
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -1033,16 +1082,30 @@ mod tests {
         let root = test_root("missing-audit-table");
         let _ = std::fs::remove_dir_all(&root);
         let key = test_key();
-        write_with_audit(&root, "home/drop-events", b"one", "text/plain", &[], &key).unwrap();
+        write_with_audit(
+            &root,
+            &validated("home/drop-events"),
+            b"one",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap();
         {
             let c = Connection::open(world_db(&root, "home/drop-events")).unwrap();
             c.execute("DROP TABLE events", []).unwrap();
         }
 
         assert!(open(&root, "home/drop-events").is_err());
-        assert!(
-            write_with_audit(&root, "home/drop-events", b"two", "text/plain", &[], &key,).is_err()
-        );
+        assert!(write_with_audit(
+            &root,
+            &validated("home/drop-events"),
+            b"two",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .is_err());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -303,7 +303,7 @@ pub fn read_with_hmac_via_conn(
 /// `write_with_audit_checked` (which signs the chain). Kept for the
 /// fixtures used by `Core::write_world`.
 #[cfg(test)]
-pub fn write(
+pub fn test_only_write_without_audit(
     data_root: &Path,
     world: &str,
     body: &[u8],
@@ -398,7 +398,11 @@ pub fn write_with_audit_checked(
 /// go through `append_with_audit`.
 #[cfg(test)]
 #[allow(dead_code)]
-fn append(data_root: &Path, world: &str, body: &[u8]) -> rusqlite::Result<Option<AppendResult>> {
+fn test_only_append_without_audit(
+    data_root: &Path,
+    world: &str,
+    body: &[u8],
+) -> rusqlite::Result<Option<AppendResult>> {
     let path = world_db(data_root, world);
     if !path.exists() {
         return Ok(None);
@@ -922,7 +926,7 @@ mod tests {
         let root = test_root("text-body-corruption");
         let _ = std::fs::remove_dir_all(&root);
 
-        write(
+        test_only_write_without_audit(
             &root,
             "home/plain",
             b"seed",
@@ -946,9 +950,9 @@ mod tests {
             let mut tracked = crate::read_cache::test_only_wrap_raw_connection(conn);
             assert!(read_with_hmac_via_conn(&mut tracked).is_err());
         }
-        assert!(append(&root, "home/plain", b"!").is_err());
+        assert!(test_only_append_without_audit(&root, "home/plain", b"!").is_err());
 
-        write(
+        test_only_write_without_audit(
             &root,
             "home/audited",
             b"seed",
@@ -1077,7 +1081,7 @@ mod tests {
             let dir = scratch_dir("open-existing-warm");
             let world = "home/bench";
             let _c = open(&dir, world).unwrap();
-            write(&dir, world, b"hello world", "text/plain", &[]).unwrap();
+            test_only_write_without_audit(&dir, world, b"hello world", "text/plain", &[]).unwrap();
 
             let n = 10_000;
             let start = Instant::now();
@@ -1109,7 +1113,7 @@ mod tests {
             let dir = scratch_dir("open-full-warm");
             let world = "home/bench";
             let _c = open(&dir, world).unwrap();
-            write(&dir, world, b"hello world", "text/plain", &[]).unwrap();
+            test_only_write_without_audit(&dir, world, b"hello world", "text/plain", &[]).unwrap();
 
             let n = 10_000;
             let start = Instant::now();

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -186,21 +186,8 @@ pub struct WriteAuditResult {
 pub enum WriteAuditError {
     Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
-    CasBodyMismatch {
-        body_sha256: BodySha256,
-    },
+    CasBodyMismatch { body_sha256: BodySha256 },
     StorageInvariant(&'static str),
-    /// Returned only if the caller passes a `quota` argument to
-    /// `write_with_audit_checked`. The active path passes `None` and
-    /// enforces quota via `Core::reserve_storage` instead, so this variant
-    /// is currently unreachable in production. Kept for diagnostic clarity
-    /// and possible test fixtures.
-    #[allow(dead_code)]
-    Quota {
-        used: usize,
-        quota: usize,
-        projected: usize,
-    },
 }
 
 impl From<rusqlite::Error> for WriteAuditError {
@@ -352,7 +339,7 @@ pub fn write_with_audit(
     headers: &[(String, String)],
     key: &AuditHmacKey,
 ) -> Result<String, WriteAuditError> {
-    write_with_audit_checked(data_root, world, body, content_type, headers, key, None)
+    write_with_audit_checked(data_root, world, body, content_type, headers, key)
         .map(|result| result.hmac)
 }
 
@@ -363,21 +350,8 @@ pub fn write_with_audit_checked(
     content_type: &str,
     headers: &[(String, String)],
     key: &AuditHmacKey,
-    quota: Option<(usize, usize)>,
 ) -> Result<WriteAuditResult, WriteAuditError> {
     let existed = world_db(data_root, world).exists();
-    if !existed {
-        if let Some((used, quota)) = quota {
-            let projected = used.saturating_add(body.len());
-            if projected > quota {
-                return Err(WriteAuditError::Quota {
-                    used,
-                    quota,
-                    projected,
-                });
-            }
-        }
-    }
     let mut c = open(data_root, world)?;
     let tx = c.transaction()?;
     let previous_len = tx.query_row(
@@ -385,16 +359,6 @@ pub fn write_with_audit_checked(
         [],
         |r| Ok(r.get::<_, i64>(0)?.max(0) as usize),
     )?;
-    if let Some((used, quota)) = quota {
-        let projected = used.saturating_sub(previous_len).saturating_add(body.len());
-        if projected > quota {
-            return Err(WriteAuditError::Quota {
-                used,
-                quota,
-                projected,
-            });
-        }
-    }
     let audit_tx = verify_appendable_world_tx(&tx, key, existed)?;
     let retained = cas::retain_body_tx(&tx, world, body)?;
     tx.execute(

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -74,6 +74,14 @@ pub fn world_db(data_root: &Path, world: &str) -> PathBuf {
     world_dir(data_root, world).join("universe.db")
 }
 
+pub fn validated_world_dir(data_root: &Path, world: &ValidatedWorldPath) -> PathBuf {
+    world_dir(data_root, world.as_str())
+}
+
+pub fn validated_world_db(data_root: &Path, world: &ValidatedWorldPath) -> PathBuf {
+    validated_world_dir(data_root, world).join("universe.db")
+}
+
 pub fn sha256_hex(bytes: &[u8]) -> String {
     let mut h = Sha256::new();
     h.update(bytes);
@@ -87,6 +95,12 @@ pub fn open(data_root: &Path, world: &str) -> rusqlite::Result<Connection> {
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OpenedWorldKind {
+    Created,
+    Existing,
+}
+
 fn open_with_generation_minter<F>(
     data_root: &Path,
     world: &str,
@@ -95,9 +109,34 @@ fn open_with_generation_minter<F>(
 where
     F: FnOnce() -> rusqlite::Result<world_generation::MintedWorldGeneration>,
 {
+    open_with_generation_minter_and_kind(data_root, world, mint_generation).map(|(conn, _)| conn)
+}
+
+fn open_validated_for_audit(
+    data_root: &Path,
+    world: &ValidatedWorldPath,
+) -> rusqlite::Result<(Connection, OpenedWorldKind)> {
+    open_with_generation_minter_and_kind(data_root, world.as_str(), || {
+        world_generation::WorldGeneration::mint().map_err(mint_generation_error)
+    })
+}
+
+fn open_with_generation_minter_and_kind<F>(
+    data_root: &Path,
+    world: &str,
+    mint_generation: F,
+) -> rusqlite::Result<(Connection, OpenedWorldKind)>
+where
+    F: FnOnce() -> rusqlite::Result<world_generation::MintedWorldGeneration>,
+{
     let dir = world_dir(data_root, world);
     let db = world_db(data_root, world);
     let db_existed = db.exists();
+    let opened = if db_existed {
+        OpenedWorldKind::Existing
+    } else {
+        OpenedWorldKind::Created
+    };
     let generation = if db_existed {
         None
     } else {
@@ -120,7 +159,7 @@ where
         let generation = generation.ok_or_else(missing_minted_generation_error)?;
         world_schema::create(schema, generation)?;
     }
-    Ok(c)
+    Ok((c, opened))
 }
 
 fn mint_generation_error(err: world_generation::MintWorldGenerationError) -> rusqlite::Error {
@@ -154,10 +193,22 @@ fn create_dir_error(err: std::io::Error) -> rusqlite::Error {
 /// a missing world must not resurrect it.
 pub fn open_existing(data_root: &Path, world: &str) -> rusqlite::Result<Option<Connection>> {
     let path = world_db(data_root, world);
+    open_existing_path(&path)
+}
+
+pub fn open_existing_validated(
+    data_root: &Path,
+    world: &ValidatedWorldPath,
+) -> rusqlite::Result<Option<Connection>> {
+    let path = validated_world_db(data_root, world);
+    open_existing_path(&path)
+}
+
+fn open_existing_path(path: &Path) -> rusqlite::Result<Option<Connection>> {
     if !path.exists() {
         return Ok(None);
     }
-    let c = match Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+    let c = match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
         Ok(c) => c,
         Err(e) => {
             if !path.exists() {
@@ -167,6 +218,34 @@ pub fn open_existing(data_root: &Path, world: &str) -> rusqlite::Result<Option<C
         }
     };
     c.busy_timeout(Duration::from_millis(5000))?;
+    world_schema::verify(&c)?;
+    Ok(Some(c))
+}
+
+fn open_existing_validated_for_write(
+    data_root: &Path,
+    world: &ValidatedWorldPath,
+) -> rusqlite::Result<Option<Connection>> {
+    let path = validated_world_db(data_root, world);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let c = match Connection::open(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            if !path.exists() {
+                return Ok(None);
+            }
+            return Err(e);
+        }
+    };
+    c.busy_timeout(Duration::from_millis(5000))?;
+    c.execute_batch(
+        r#"
+        PRAGMA journal_mode=WAL;
+        PRAGMA synchronous=FULL;
+        "#,
+    )?;
     world_schema::verify(&c)?;
     Ok(Some(c))
 }
@@ -370,16 +449,14 @@ pub fn write_with_audit_checked(
     headers: &[(String, String)],
     key: &AuditHmacKey,
 ) -> Result<WriteAuditResult, WriteAuditError> {
-    let world_name = world.as_str();
-    let existed = world_db(data_root, world_name).exists();
-    let mut c = open(data_root, world_name)?;
+    let (mut c, opened) = open_validated_for_audit(data_root, world)?;
     let tx = c.transaction()?;
     let previous_len = tx.query_row(
         "SELECT CASE WHEN typeof(body) = 'blob' THEN length(body) END FROM stage_meta WHERE id=1",
         [],
         |r| Ok(r.get::<_, i64>(0)?.max(0) as usize),
     )?;
-    let audit_tx = verify_appendable_world_tx(&tx, world, key, existed)?;
+    let audit_tx = verify_appendable_world_tx(&tx, world, key, opened)?;
     let retained = cas::retain_body_tx(&tx, world, body)?;
     tx.execute(
         r#"UPDATE stage_meta
@@ -408,7 +485,7 @@ pub fn write_with_audit_checked(
         hmac: row.hmac().to_owned(),
         cas_body_inserted: retained.inserted(),
         previous_len,
-        existed,
+        existed: matches!(opened, OpenedWorldKind::Existing),
     })
 }
 
@@ -456,14 +533,15 @@ pub fn append_with_audit(
     headers: &[(String, String)],
     key: &AuditHmacKey,
 ) -> Result<Option<(AppendResult, String)>, WriteAuditError> {
-    let world_name = world.as_str();
-    let path = world_db(data_root, world_name);
+    let path = validated_world_db(data_root, world);
     if !path.exists() {
         return Ok(None);
     }
-    let mut c = open(data_root, world_name)?;
+    let Some(mut c) = open_existing_validated_for_write(data_root, world)? else {
+        return Ok(None);
+    };
     let tx = c.transaction()?;
-    let audit_tx = verify_appendable_world_tx(&tx, world, key, true)?;
+    let audit_tx = verify_appendable_world_tx(&tx, world, key, OpenedWorldKind::Existing)?;
     let current = tx.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
         r.get::<_, Vec<u8>>(0)
     })?;
@@ -498,14 +576,41 @@ fn verify_appendable_world_tx<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
     world: &ValidatedWorldPath,
     key: &'key AuditHmacKey,
-    existed_before_open: bool,
+    opened: OpenedWorldKind,
 ) -> Result<audit::VerifiedAuditTx<'tx, 'conn, 'key>, WriteAuditError> {
-    if !existed_before_open || is_empty_bootstrap_tx(tx)? {
-        Ok(audit::verify_appendable_tx_genesis_checked(tx, world, key)?)
-    } else {
-        Ok(audit::verify_appendable_tx_existing_checked(
+    match audit_chain_opening(tx, opened)? {
+        AuditChainOpening::Genesis(_proof) => {
+            Ok(audit::verify_appendable_tx_genesis_checked(tx, world, key)?)
+        }
+        AuditChainOpening::Existing => Ok(audit::verify_appendable_tx_existing_checked(
             tx, world, key,
-        )?)
+        )?),
+    }
+}
+
+struct GenesisAuditProof {
+    _private: (),
+}
+
+enum AuditChainOpening {
+    Genesis(GenesisAuditProof),
+    Existing,
+}
+
+fn audit_chain_opening(
+    tx: &Transaction<'_>,
+    opened: OpenedWorldKind,
+) -> Result<AuditChainOpening, WriteAuditError> {
+    match opened {
+        OpenedWorldKind::Created => Ok(AuditChainOpening::Genesis(GenesisAuditProof {
+            _private: (),
+        })),
+        OpenedWorldKind::Existing if is_empty_bootstrap_tx(tx)? => {
+            Ok(AuditChainOpening::Genesis(GenesisAuditProof {
+                _private: (),
+            }))
+        }
+        OpenedWorldKind::Existing => Ok(AuditChainOpening::Existing),
     }
 }
 

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -192,6 +192,7 @@ fn create_dir_error(err: std::io::Error) -> rusqlite::Error {
 /// Open an existing world's universe.db without creating directories,
 /// files, or schema. Audit verification uses this path because probing
 /// a missing world must not resurrect it.
+#[cfg(test)]
 pub fn open_existing(data_root: &Path, world: &str) -> rusqlite::Result<Option<Connection>> {
     let path = world_db(data_root, world);
     open_existing_path(&path)
@@ -301,8 +302,11 @@ impl From<audit::AuditError> for WriteAuditError {
     }
 }
 
-pub fn metadata(data_root: &Path, world: &str) -> rusqlite::Result<Option<WorldMetadata>> {
-    let Some(c) = open_existing(data_root, world)? else {
+pub fn metadata(
+    data_root: &Path,
+    world: &ValidatedWorldPath,
+) -> rusqlite::Result<Option<WorldMetadata>> {
+    let Some(c) = open_existing_validated(data_root, world)? else {
         return Ok(None);
     };
     let (body_len, content_type) = c.query_row(
@@ -323,8 +327,8 @@ pub fn metadata(data_root: &Path, world: &str) -> rusqlite::Result<Option<WorldM
     Ok(Some((body_len, content_type, headers)))
 }
 
-pub fn body_len(data_root: &Path, world: &str) -> rusqlite::Result<Option<usize>> {
-    let Some(c) = open_existing(data_root, world)? else {
+pub fn body_len(data_root: &Path, world: &ValidatedWorldPath) -> rusqlite::Result<Option<usize>> {
+    let Some(c) = open_existing_validated(data_root, world)? else {
         return Ok(None);
     };
     c.query_row(
@@ -338,7 +342,13 @@ pub fn body_len(data_root: &Path, world: &str) -> rusqlite::Result<Option<usize>
 pub fn sizes(data_root: &Path) -> rusqlite::Result<Vec<(String, usize)>> {
     let mut out = Vec::new();
     for world in list(data_root)? {
-        if let Some(size) = storage_len(data_root, &world)? {
+        let world_path = ValidatedWorldPath::new(world.clone()).map_err(|_| {
+            rusqlite::Error::SqliteFailure(
+                ffi::Error::new(ffi::SQLITE_CORRUPT),
+                Some("disk world name failed validation".to_owned()),
+            )
+        })?;
+        if let Some(size) = storage_len(data_root, &world_path)? {
             out.push((world, size));
         }
     }
@@ -1112,8 +1122,9 @@ mod tests {
         .unwrap();
         force_text_body(&root, "home/plain", "\u{00e9}");
 
-        assert!(body_len(&root, "home/plain").is_err());
-        assert!(metadata(&root, "home/plain").is_err());
+        let world = ValidatedWorldPath::new("home/plain").unwrap();
+        assert!(body_len(&root, &world).is_err());
+        assert!(metadata(&root, &world).is_err());
         assert!(sizes(&root).is_err());
         // Read path goes through ReadCache now. Wrap the bare
         // Connection via the test-only helper exported from

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -398,7 +398,7 @@ pub fn write_with_audit_checked(
             stmt.execute(params![name, value])?;
         }
     }
-    let h = audit::append_body_tx_row(
+    let row = audit::append_body_tx_row(
         &audit_tx,
         BodyEventKind::PUT,
         world,
@@ -409,7 +409,7 @@ pub fn write_with_audit_checked(
     )?;
     tx.commit()?;
     Ok(WriteAuditResult {
-        hmac: h,
+        hmac: row.hmac().to_owned(),
         previous_len,
         existed,
     })
@@ -474,7 +474,7 @@ pub fn append_with_audit(
            WHERE id=1"#,
         params![new_body],
     )?;
-    let h = audit::append_body_tx_row(
+    let row = audit::append_body_tx_row(
         &audit_tx,
         BodyEventKind::APPEND,
         world,
@@ -488,7 +488,7 @@ pub fn append_with_audit(
         AppendResult {
             body_sha256_after: after,
         },
-        h,
+        row.hmac().to_owned(),
     )))
 }
 

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -37,9 +37,10 @@ pub use cas::{
     append_body_len_if_missing as append_cas_body_len_if_missing,
     body_len_if_missing as cas_body_len_if_missing, storage_len,
 };
+pub(crate) use files::delete;
 #[cfg(test)]
 use files::open_checkpoint_conn;
-pub use files::{delete, list, list_with_prefix, list_with_prefix_bounded};
+pub use files::{list, list_with_prefix, list_with_prefix_bounded};
 
 // Encode chars that confuse Windows / POSIX filesystems. Decoded form
 // is the canonical world key; encoded form is the on-disk dir name.

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -13,7 +13,7 @@
 //! ```
 //!
 //! Renames vs pre-v5: `stage_html` -> `body`. Drops: `pending_js`,
-//! `js_result`, `state`. v5.2 adds the inert CAS tables. No migrator:
+//! `js_result`, `state`. v5.2 adds CAS retention tables. No migrator:
 //! world dirs from older binaries fail loudly on the first missing or stale
 //! schema surface; wipe `data/` to upgrade.
 //!
@@ -35,8 +35,14 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+mod cas;
 mod files;
 
+pub(crate) use cas::RetainedCasBody;
+pub use cas::{
+    append_body_len_if_missing as append_cas_body_len_if_missing,
+    body_len_if_missing as cas_body_len_if_missing, storage_len,
+};
 #[cfg(test)]
 use files::open_checkpoint_conn;
 pub use files::{delete, list, list_with_prefix, list_with_prefix_bounded};
@@ -157,10 +163,12 @@ pub type WorldMetadata = (usize, String, MetaHeaders);
 
 pub struct AppendResult {
     pub body_sha256_after: String,
+    pub(crate) cas_body_inserted: bool,
 }
 
 pub struct WriteAuditResult {
     pub hmac: String,
+    pub(crate) cas_body_inserted: bool,
     /// Body length before this write. Populated for callers that may want
     /// it (e.g. counter accounting). Currently unused by the production
     /// code path because `Core::reserve_storage` reads `previous_len`
@@ -178,6 +186,10 @@ pub struct WriteAuditResult {
 pub enum WriteAuditError {
     Audit(audit::AuditError),
     Sqlite(rusqlite::Error),
+    CasBodyMismatch {
+        body_sha256: BodySha256,
+    },
+    StorageInvariant(&'static str),
     /// Returned only if the caller passes a `quota` argument to
     /// `write_with_audit_checked`. The active path passes `None` and
     /// enforces quota via `Core::reserve_storage` instead, so this variant
@@ -240,7 +252,7 @@ pub fn body_len(data_root: &Path, world: &str) -> rusqlite::Result<Option<usize>
 pub fn sizes(data_root: &Path) -> rusqlite::Result<Vec<(String, usize)>> {
     let mut out = Vec::new();
     for world in list(data_root)? {
-        if let Some(size) = body_len(data_root, &world)? {
+        if let Some(size) = storage_len(data_root, &world)? {
             out.push((world, size));
         }
     }
@@ -384,6 +396,7 @@ pub fn write_with_audit_checked(
         }
     }
     let audit_tx = verify_appendable_world_tx(&tx, key, existed)?;
+    let retained = cas::retain_body_tx(&tx, world, body)?;
     tx.execute(
         r#"UPDATE stage_meta
            SET body=?,
@@ -398,18 +411,18 @@ pub fn write_with_audit_checked(
             stmt.execute(params![name, value])?;
         }
     }
-    let row = audit::append_body_tx_row(
+    let row = audit::append_retained_body_tx_row(
         &audit_tx,
         BodyEventKind::PUT,
-        world,
-        &BodySha256::for_body(body),
-        body.len() as i64,
+        &retained,
         content_type,
         headers,
     )?;
+    cas::mark_retention_started_tx(&tx, row.id())?;
     tx.commit()?;
     Ok(WriteAuditResult {
         hmac: row.hmac().to_owned(),
+        cas_body_inserted: retained.inserted(),
         previous_len,
         existed,
     })
@@ -443,6 +456,7 @@ fn append(data_root: &Path, world: &str, body: &[u8]) -> rusqlite::Result<Option
     tx.commit()?;
     Ok(Some(AppendResult {
         body_sha256_after: after,
+        cas_body_inserted: false,
     }))
 }
 
@@ -466,27 +480,26 @@ pub fn append_with_audit(
     })?;
     let mut new_body = current;
     new_body.extend_from_slice(body);
-    let after = sha256_hex(&new_body);
-    let size_after = new_body.len();
+    let retained = cas::retain_body_tx(&tx, world, &new_body)?;
     tx.execute(
         r#"UPDATE stage_meta
            SET body=?
            WHERE id=1"#,
         params![new_body],
     )?;
-    let row = audit::append_body_tx_row(
+    let row = audit::append_retained_body_tx_row(
         &audit_tx,
         BodyEventKind::APPEND,
-        world,
-        &BodySha256::new(after.clone()).map_err(|_| rusqlite::Error::InvalidQuery)?,
-        size_after as i64,
+        &retained,
         content_type,
         headers,
     )?;
+    cas::mark_retention_started_tx(&tx, row.id())?;
     tx.commit()?;
     Ok(Some((
         AppendResult {
-            body_sha256_after: after,
+            body_sha256_after: retained.body_sha256().as_str().to_owned(),
+            cas_body_inserted: retained.inserted(),
         },
         row.hmac().to_owned(),
     )))
@@ -574,6 +587,131 @@ mod tests {
             "#,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn audited_write_retains_cas_body_and_starts_floor() {
+        let root = test_root("cas-retain-write");
+        let _ = std::fs::remove_dir_all(&root);
+        let key = test_key();
+        let body = b"retained body";
+        let body_hash = sha256_hex(body);
+
+        let hmac = write_with_audit(&root, "home/cas", body, "text/plain", &[], &key).unwrap();
+
+        let c = Connection::open(world_db(&root, "home/cas")).unwrap();
+        let retained: Vec<u8> = c
+            .query_row(
+                "SELECT body FROM cas_bodies WHERE body_sha256=?1",
+                params![body_hash],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let first_retained_seq: i64 = c
+            .query_row(
+                "SELECT first_retained_seq FROM cas_state WHERE id=1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let (event_hmac, event_hash): (String, String) = c
+            .query_row("SELECT hmac, body_sha256 FROM events WHERE id=1", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+
+        assert_eq!(retained, body);
+        assert_eq!(first_retained_seq, 1);
+        assert_eq!(event_hmac, hmac);
+        assert_eq!(event_hash, body_hash);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_append_retains_full_body_without_moving_floor() {
+        let root = test_root("cas-retain-append");
+        let _ = std::fs::remove_dir_all(&root);
+        let key = test_key();
+
+        write_with_audit(&root, "home/cas-append", b"one", "text/plain", &[], &key).unwrap();
+        let (result, _) =
+            append_with_audit(&root, "home/cas-append", b"two", "text/plain", &[], &key)
+                .unwrap()
+                .unwrap();
+
+        let full_body = b"onetwo";
+        let full_hash = sha256_hex(full_body);
+        assert_eq!(result.body_sha256_after, full_hash);
+
+        let c = Connection::open(world_db(&root, "home/cas-append")).unwrap();
+        let retained: Vec<u8> = c
+            .query_row(
+                "SELECT body FROM cas_bodies WHERE body_sha256=?1",
+                params![full_hash],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let first_retained_seq: i64 = c
+            .query_row(
+                "SELECT first_retained_seq FROM cas_state WHERE id=1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let cas_rows: i64 = c
+            .query_row("SELECT COUNT(*) FROM cas_bodies", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(retained, full_body);
+        assert_eq!(first_retained_seq, 1);
+        assert_eq!(cas_rows, 2);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_write_reuses_same_cas_body_without_moving_floor() {
+        let root = test_root("cas-idempotent");
+        let _ = std::fs::remove_dir_all(&root);
+        let key = test_key();
+
+        write_with_audit(
+            &root,
+            "home/cas-idempotent",
+            b"same",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap();
+        write_with_audit(
+            &root,
+            "home/cas-idempotent",
+            b"same",
+            "application/octet-stream",
+            &[],
+            &key,
+        )
+        .unwrap();
+
+        let c = Connection::open(world_db(&root, "home/cas-idempotent")).unwrap();
+        let cas_rows: i64 = c
+            .query_row("SELECT COUNT(*) FROM cas_bodies", [], |r| r.get(0))
+            .unwrap();
+        let events: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        let first_retained_seq: i64 = c
+            .query_row(
+                "SELECT first_retained_seq FROM cas_state WHERE id=1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(cas_rows, 1);
+        assert_eq!(events, 2);
+        assert_eq!(first_retained_seq, 1);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -13,11 +13,7 @@
 //! ```
 //!
 //! Renames vs pre-v5: `stage_html` -> `body`. Drops: `pending_js`,
-//! `js_result`, `state`. v5.2 adds CAS retention tables. No migrator:
-//! stale world dirs fail loudly; wipe `data/` to upgrade.
-//!
-//! `meta_headers` is current metadata; `event_headers` is historical.
-//! The event chain stores structured audit facts, never JSON blobs.
+//! `js_result`, `state`. v5.2 adds CAS tables; stale dirs fail loudly.
 
 use crate::{
     audit,
@@ -358,7 +354,7 @@ pub fn write_with_audit_checked(
         [],
         |r| Ok(r.get::<_, i64>(0)?.max(0) as usize),
     )?;
-    let audit_tx = verify_appendable_world_tx(&tx, key, existed)?;
+    let audit_tx = verify_appendable_world_tx(&tx, world, key, existed)?;
     let retained = cas::retain_body_tx(&tx, world, body)?;
     tx.execute(
         r#"UPDATE stage_meta
@@ -442,7 +438,7 @@ pub fn append_with_audit(
     }
     let mut c = open(data_root, world_name)?;
     let tx = c.transaction()?;
-    let audit_tx = verify_appendable_world_tx(&tx, key, true)?;
+    let audit_tx = verify_appendable_world_tx(&tx, world, key, true)?;
     let current = tx.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| {
         r.get::<_, Vec<u8>>(0)
     })?;
@@ -475,13 +471,16 @@ pub fn append_with_audit(
 
 fn verify_appendable_world_tx<'tx, 'conn, 'key>(
     tx: &'tx Transaction<'conn>,
+    world: &ValidatedWorldPath,
     key: &'key AuditHmacKey,
     existed_before_open: bool,
 ) -> Result<audit::VerifiedAuditTx<'tx, 'conn, 'key>, WriteAuditError> {
     if !existed_before_open || is_empty_bootstrap_tx(tx)? {
-        Ok(audit::verify_appendable_tx_genesis_checked(tx, key)?)
+        Ok(audit::verify_appendable_tx_genesis_checked(tx, world, key)?)
     } else {
-        Ok(audit::verify_appendable_tx_existing_checked(tx, key)?)
+        Ok(audit::verify_appendable_tx_existing_checked(
+            tx, world, key,
+        )?)
     }
 }
 

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -25,7 +25,8 @@
 //! audit facts, never JSON blobs.
 
 use crate::{
-    audit, engine_types::AuditHmacKey, event::AuditEventKind, world_generation, world_schema,
+    audit, engine_types::AuditHmacKey, event::BodyEventKind, timeline::BodySha256,
+    world_generation, world_schema,
 };
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rusqlite::{ffi, params, Connection, OpenFlags, Transaction};
@@ -397,11 +398,11 @@ pub fn write_with_audit_checked(
             stmt.execute(params![name, value])?;
         }
     }
-    let h = audit::append_tx(
+    let h = audit::append_body_tx_row(
         &audit_tx,
-        AuditEventKind::Put,
+        BodyEventKind::PUT,
         world,
-        &sha256_hex(body),
+        &BodySha256::for_body(body),
         body.len() as i64,
         content_type,
         headers,
@@ -473,11 +474,11 @@ pub fn append_with_audit(
            WHERE id=1"#,
         params![new_body],
     )?;
-    let h = audit::append_tx(
+    let h = audit::append_body_tx_row(
         &audit_tx,
-        AuditEventKind::Append,
+        BodyEventKind::APPEND,
         world,
-        &after,
+        &BodySha256::new(after.clone()).map_err(|_| rusqlite::Error::InvalidQuery)?,
         size_after as i64,
         content_type,
         headers,

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -679,6 +679,149 @@ mod tests {
     }
 
     #[test]
+    fn audited_write_rejects_cas_mismatch_before_event_commit() {
+        let root = test_root("cas-mismatch");
+        let _ = std::fs::remove_dir_all(&root);
+        let key = test_key();
+        let old_body = b"old-value";
+        let new_body = b"new-value";
+        let new_body_hash = sha256_hex(new_body);
+
+        write_with_audit(
+            &root,
+            "home/cas-mismatch",
+            old_body,
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap();
+        {
+            let c = Connection::open(world_db(&root, "home/cas-mismatch")).unwrap();
+            c.execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, x'00')",
+                params![new_body_hash],
+            )
+            .unwrap();
+        }
+
+        let _err = write_with_audit(
+            &root,
+            "home/cas-mismatch",
+            new_body,
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap_err();
+
+        let c = Connection::open(world_db(&root, "home/cas-mismatch")).unwrap();
+        let events: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        let stage_body: Vec<u8> = c
+            .query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| r.get(0))
+            .unwrap();
+        let first_retained_seq: i64 = c
+            .query_row(
+                "SELECT first_retained_seq FROM cas_state WHERE id=1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(events, 1);
+        assert_eq!(stage_body, old_body);
+        assert_eq!(first_retained_seq, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_append_rejects_cas_mismatch_before_event_commit() {
+        let root = test_root("cas-append-mismatch");
+        let _ = std::fs::remove_dir_all(&root);
+        let key = test_key();
+
+        write_with_audit(
+            &root,
+            "home/cas-append-mismatch",
+            b"one",
+            "text/plain",
+            &[],
+            &key,
+        )
+        .unwrap();
+        let next_hash = sha256_hex(b"onetwo");
+        {
+            let c = Connection::open(world_db(&root, "home/cas-append-mismatch")).unwrap();
+            c.execute(
+                "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, x'00')",
+                params![next_hash],
+            )
+            .unwrap();
+        }
+
+        let _err = match append_with_audit(
+            &root,
+            "home/cas-append-mismatch",
+            b"two",
+            "text/plain",
+            &[],
+            &key,
+        ) {
+            Ok(_) => panic!("corrupt CAS body row must reject append"),
+            Err(err) => err,
+        };
+
+        let c = Connection::open(world_db(&root, "home/cas-append-mismatch")).unwrap();
+        let events: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        let body: Vec<u8> = c
+            .query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(events, 1);
+        assert_eq!(body, b"one");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn audited_write_rejects_cas_floor_ahead_of_event() {
+        let root = test_root("cas-floor-ahead");
+        let _ = std::fs::remove_dir_all(&root);
+        drop(open(&root, "home/cas-floor").unwrap());
+        {
+            let c = Connection::open(world_db(&root, "home/cas-floor")).unwrap();
+            c.execute("UPDATE cas_state SET first_retained_seq=999 WHERE id=1", [])
+                .unwrap();
+        }
+
+        let err = write_with_audit(
+            &root,
+            "home/cas-floor",
+            b"one",
+            "text/plain",
+            &[],
+            &test_key(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            WriteAuditError::Audit(audit::AuditError::ChainBroken(break_report))
+                if break_report.actual == "missing-retention-floor-event"
+        ));
+
+        let c = Connection::open(world_db(&root, "home/cas-floor")).unwrap();
+        let events: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+
+        assert_eq!(events, 0);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn disk_names_do_not_alias_literal_percent_with_encoded_slash() {
         assert_ne!(disk_name("home/a%2Fb"), disk_name("home/a/b"));
     }

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -38,6 +38,12 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+mod files;
+
+#[cfg(test)]
+use files::open_checkpoint_conn;
+pub use files::{delete, list, list_with_prefix, list_with_prefix_bounded};
+
 // Encode chars that confuse Windows / POSIX filesystems. Decoded form
 // is the canonical world key; encoded form is the on-disk dir name.
 //
@@ -512,166 +518,6 @@ fn is_empty_bootstrap_tx(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
         |r| r.get(0),
     )?;
     Ok(events == 0 && event_headers == 0 && meta_headers == 0 && body_len == 0)
-}
-
-pub fn delete(data_root: &Path, world: &str) -> bool {
-    let dir = world_dir(data_root, world);
-    if !dir.exists() {
-        return false;
-    }
-
-    // Windows + SQLite WAL: -wal / -shm files stay locked briefly after
-    // the connection drops. Naive remove_dir_all may return Ok while
-    // leaving stragglers, or fail outright. Flush WAL via checkpoint,
-    // then retry the remove.
-    release_wal_files(data_root, world);
-
-    let mut delay = std::time::Duration::from_millis(30);
-    for attempt in 0..20 {
-        match std::fs::remove_dir_all(&dir) {
-            Ok(()) => {
-                if !dir.exists() {
-                    return true;
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
-            Err(_) => {}
-        }
-        if attempt == 19 {
-            break;
-        }
-        std::thread::sleep(delay);
-        delay = std::cmp::min(delay * 2, std::time::Duration::from_millis(500));
-    }
-    !dir.exists()
-}
-
-fn release_wal_files(data_root: &Path, world: &str) {
-    match open_checkpoint_conn(data_root, world) {
-        Ok(Some(c)) => {
-            if let Err(err) = c.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
-                log_wal_release_error(world, "checkpoint", &err);
-            }
-            drop(c);
-        }
-        Ok(None) => {}
-        Err(err) => log_wal_release_error(world, "open", &err),
-    }
-    for suffix in ["-wal", "-shm"] {
-        let _ = std::fs::remove_file(
-            data_root
-                .join(disk_name(world))
-                .join(format!("universe.db{suffix}")),
-        );
-    }
-    std::thread::sleep(Duration::from_millis(10));
-}
-
-fn open_checkpoint_conn(data_root: &Path, world: &str) -> rusqlite::Result<Option<Connection>> {
-    let path = world_db(data_root, world);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let c = match Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_WRITE) {
-        Ok(c) => c,
-        Err(e) => {
-            if !path.exists() {
-                return Ok(None);
-            }
-            return Err(e);
-        }
-    };
-    c.busy_timeout(Duration::from_millis(5000))?;
-    world_schema::verify(&c)?;
-    Ok(Some(c))
-}
-
-fn log_wal_release_error(world: &str, phase: &str, err: &rusqlite::Error) {
-    #[cfg(feature = "unstable-engine")]
-    tracing::warn!(
-        world,
-        phase,
-        error = %err,
-        "delete skipped wal checkpoint before physical remove"
-    );
-
-    #[cfg(not(feature = "unstable-engine"))]
-    eprintln!("elastik-core internal delete wal checkpoint {phase} failed for {world}: {err}");
-}
-
-/// List all sqlite-backed world keys by scanning the data dir.
-/// Returns canonical (decoded) names.
-pub fn list(data_root: &Path) -> rusqlite::Result<Vec<String>> {
-    list_matching(data_root, |_| true)
-}
-
-/// List sqlite-backed world keys with a canonical prefix.
-pub fn list_with_prefix(data_root: &Path, prefix: &str) -> rusqlite::Result<Vec<String>> {
-    list_matching(data_root, |world| world.starts_with(prefix))
-}
-
-/// List sqlite-backed world keys with a canonical prefix, returning `None`
-/// before materializing more than `max` matches.
-pub fn list_with_prefix_bounded(
-    data_root: &Path,
-    prefix: &str,
-    max: usize,
-) -> rusqlite::Result<Option<Vec<String>>> {
-    list_matching_bounded(data_root, |world| world.starts_with(prefix), max)
-}
-
-fn list_matching(
-    data_root: &Path,
-    mut keep: impl FnMut(&str) -> bool,
-) -> rusqlite::Result<Vec<String>> {
-    let mut out = Vec::new();
-    let rd = std::fs::read_dir(data_root).map_err(create_dir_error)?;
-    for entry in rd {
-        let entry = entry.map_err(create_dir_error)?;
-        let Ok(name) = entry.file_name().into_string() else {
-            continue;
-        };
-        if !entry.path().join("universe.db").exists() {
-            continue;
-        }
-        let decoded = percent_encoding::percent_decode_str(&name)
-            .decode_utf8_lossy()
-            .into_owned();
-        if keep(&decoded) {
-            out.push(decoded);
-        }
-    }
-    out.sort();
-    Ok(out)
-}
-
-fn list_matching_bounded(
-    data_root: &Path,
-    mut keep: impl FnMut(&str) -> bool,
-    max: usize,
-) -> rusqlite::Result<Option<Vec<String>>> {
-    let mut out = Vec::new();
-    let rd = std::fs::read_dir(data_root).map_err(create_dir_error)?;
-    for entry in rd {
-        let entry = entry.map_err(create_dir_error)?;
-        let Ok(name) = entry.file_name().into_string() else {
-            continue;
-        };
-        if !entry.path().join("universe.db").exists() {
-            continue;
-        }
-        let decoded = percent_encoding::percent_decode_str(&name)
-            .decode_utf8_lossy()
-            .into_owned();
-        if keep(&decoded) {
-            if out.len() >= max {
-                return Ok(None);
-            }
-            out.push(decoded);
-        }
-    }
-    out.sort();
-    Ok(Some(out))
 }
 
 #[cfg(test)]

--- a/core/src/world.rs
+++ b/core/src/world.rs
@@ -17,12 +17,8 @@
 //! world dirs from older binaries fail loudly on the first missing or stale
 //! schema surface; wipe `data/` to upgrade.
 //!
-//! `state` is gone on purpose. The old `pending|active|disabled`
-//! triple was a hook for an in-core plugin runtime that no longer
-//! exists. `/lib/*` is inert storage in the new architecture, and
-//! lifecycle (if any) belongs to whatever SDK / endpoint app loads
-//! the source. Keeping the column would falsely suggest core decides
-//! when a plugin runs.
+//! `state` is gone on purpose: `/lib/*` is inert storage now; lifecycle
+//! belongs to whatever SDK or endpoint app loads the source.
 //!
 //! `meta_headers` is the current X-Meta-* header view. `event_headers`
 //! is the historical per-write view. The event chain stores structured

--- a/core/src/world/cas.rs
+++ b/core/src/world/cas.rs
@@ -9,7 +9,7 @@ use crate::{
     timeline::{BodySha256, TimelineSeq},
 };
 
-use super::{open_existing, WriteAuditError};
+use super::{open_existing_validated, WriteAuditError};
 
 pub(crate) struct RetainedCasBody {
     target: ValidatedWorldPath,
@@ -113,8 +113,11 @@ pub(super) fn mark_retention_started_tx(
     Ok(())
 }
 
-pub fn storage_len(data_root: &Path, world: &str) -> rusqlite::Result<Option<usize>> {
-    let Some(c) = open_existing(data_root, world)? else {
+pub fn storage_len(
+    data_root: &Path,
+    world: &ValidatedWorldPath,
+) -> rusqlite::Result<Option<usize>> {
+    let Some(c) = open_existing_validated(data_root, world)? else {
         return Ok(None);
     };
     let current_len: i64 = c.query_row(
@@ -135,8 +138,12 @@ pub fn storage_len(data_root: &Path, world: &str) -> rusqlite::Result<Option<usi
     ))
 }
 
-pub fn body_len_if_missing(data_root: &Path, world: &str, body: &[u8]) -> rusqlite::Result<usize> {
-    let Some(c) = open_existing(data_root, world)? else {
+pub fn body_len_if_missing(
+    data_root: &Path,
+    world: &ValidatedWorldPath,
+    body: &[u8],
+) -> rusqlite::Result<usize> {
+    let Some(c) = open_existing_validated(data_root, world)? else {
         return Ok(body.len());
     };
     missing_body_len(&c, body)
@@ -144,10 +151,10 @@ pub fn body_len_if_missing(data_root: &Path, world: &str, body: &[u8]) -> rusqli
 
 pub fn append_body_len_if_missing(
     data_root: &Path,
-    world: &str,
+    world: &ValidatedWorldPath,
     append_body: &[u8],
 ) -> rusqlite::Result<Option<usize>> {
-    let Some(c) = open_existing(data_root, world)? else {
+    let Some(c) = open_existing_validated(data_root, world)? else {
         return Ok(None);
     };
     let mut body: Vec<u8> =

--- a/core/src/world/cas.rs
+++ b/core/src/world/cas.rs
@@ -1,0 +1,181 @@
+//! CAS body retention for one world's SQLite file.
+
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use std::path::Path;
+
+use crate::{
+    event::AuditEventKind,
+    timeline::{BodySha256, TimelineSeq},
+};
+
+use super::{open_existing, WriteAuditError};
+
+pub(crate) struct RetainedCasBody {
+    target: String,
+    body_sha256: BodySha256,
+    size: i64,
+    inserted: bool,
+}
+
+impl RetainedCasBody {
+    pub(crate) fn target(&self) -> &str {
+        &self.target
+    }
+
+    pub(crate) fn body_sha256(&self) -> &BodySha256 {
+        &self.body_sha256
+    }
+
+    pub(crate) fn size(&self) -> i64 {
+        self.size
+    }
+
+    pub(crate) fn inserted(&self) -> bool {
+        self.inserted
+    }
+}
+
+pub(super) fn retain_body_tx(
+    tx: &Transaction<'_>,
+    target: &str,
+    body: &[u8],
+) -> Result<RetainedCasBody, WriteAuditError> {
+    let body_sha256 = BodySha256::for_body(body);
+    let size = i64::try_from(body.len())
+        .map_err(|_| WriteAuditError::StorageInvariant("body length does not fit i64"))?;
+    let inserted = tx.execute(
+        r#"INSERT INTO cas_bodies(body_sha256, body)
+           VALUES(?1, ?2)
+           ON CONFLICT(body_sha256) DO NOTHING"#,
+        params![body_sha256.as_str(), body],
+    )? == 1;
+    let stored: Vec<u8> = tx.query_row(
+        "SELECT body FROM cas_bodies WHERE body_sha256=?1",
+        params![body_sha256.as_str()],
+        |r| r.get(0),
+    )?;
+    if stored != body {
+        return Err(WriteAuditError::CasBodyMismatch { body_sha256 });
+    }
+    Ok(RetainedCasBody {
+        target: target.to_owned(),
+        body_sha256,
+        size,
+        inserted,
+    })
+}
+
+pub(super) fn mark_retention_started_tx(
+    tx: &Transaction<'_>,
+    event_id: TimelineSeq,
+) -> Result<(), WriteAuditError> {
+    let floor = tx
+        .query_row(
+            "SELECT first_retained_seq FROM cas_state WHERE id=1",
+            [],
+            |r| r.get::<_, Option<i64>>(0),
+        )
+        .optional()?
+        .ok_or(WriteAuditError::StorageInvariant(
+            "cas_state singleton row missing",
+        ))?;
+    if let Some(floor) = floor {
+        let floor = TimelineSeq::new(floor).map_err(|_| {
+            WriteAuditError::StorageInvariant("cas_state first_retained_seq invalid")
+        })?;
+        if floor != first_body_event_seq_tx(tx)? {
+            return Err(WriteAuditError::StorageInvariant(
+                "cas_state first_retained_seq does not match first body event",
+            ));
+        }
+        if floor > event_id {
+            return Err(WriteAuditError::StorageInvariant(
+                "cas_state first_retained_seq is ahead of event row",
+            ));
+        }
+        return Ok(());
+    }
+    if first_body_event_seq_tx(tx)? != event_id {
+        return Err(WriteAuditError::StorageInvariant(
+            "cas retention cannot start after existing body events",
+        ));
+    }
+    let changed = tx.execute(
+        "UPDATE cas_state SET first_retained_seq=?1 WHERE id=1",
+        params![event_id.get()],
+    )?;
+    if changed != 1 {
+        return Err(WriteAuditError::StorageInvariant(
+            "cas_state singleton row missing",
+        ));
+    }
+    Ok(())
+}
+
+pub fn storage_len(data_root: &Path, world: &str) -> rusqlite::Result<Option<usize>> {
+    let Some(c) = open_existing(data_root, world)? else {
+        return Ok(None);
+    };
+    let current_len: i64 = c.query_row(
+        "SELECT CASE WHEN typeof(body) = 'blob' THEN length(body) END FROM stage_meta WHERE id=1",
+        [],
+        |r| r.get(0),
+    )?;
+    let retained_len: i64 = c.query_row(
+        r#"SELECT COALESCE(SUM(
+               CASE WHEN typeof(body)='blob' THEN length(body) END
+           ), 0)
+           FROM cas_bodies"#,
+        [],
+        |r| r.get(0),
+    )?;
+    Ok(Some(
+        (current_len.max(0) as usize).saturating_add(retained_len.max(0) as usize),
+    ))
+}
+
+pub fn body_len_if_missing(data_root: &Path, world: &str, body: &[u8]) -> rusqlite::Result<usize> {
+    let Some(c) = open_existing(data_root, world)? else {
+        return Ok(body.len());
+    };
+    missing_body_len(&c, body)
+}
+
+pub fn append_body_len_if_missing(
+    data_root: &Path,
+    world: &str,
+    append_body: &[u8],
+) -> rusqlite::Result<Option<usize>> {
+    let Some(c) = open_existing(data_root, world)? else {
+        return Ok(None);
+    };
+    let mut body: Vec<u8> =
+        c.query_row("SELECT body FROM stage_meta WHERE id=1", [], |r| r.get(0))?;
+    body.extend_from_slice(append_body);
+    Ok(Some(missing_body_len(&c, &body)?))
+}
+
+fn first_body_event_seq_tx(tx: &Transaction<'_>) -> Result<TimelineSeq, WriteAuditError> {
+    let seq: i64 = tx.query_row(
+        "SELECT id FROM events WHERE event_type IN (?1, ?2) ORDER BY id ASC LIMIT 1",
+        params![
+            AuditEventKind::Put.as_str(),
+            AuditEventKind::Append.as_str()
+        ],
+        |r| r.get(0),
+    )?;
+    TimelineSeq::new(seq).map_err(|_| WriteAuditError::StorageInvariant("body event id invalid"))
+}
+
+fn missing_body_len(c: &Connection, body: &[u8]) -> rusqlite::Result<usize> {
+    let body_sha256 = BodySha256::for_body(body);
+    let exists = c
+        .query_row(
+            "SELECT 1 FROM cas_bodies WHERE body_sha256=?1",
+            params![body_sha256.as_str()],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    Ok(if exists { 0 } else { body.len() })
+}

--- a/core/src/world/cas.rs
+++ b/core/src/world/cas.rs
@@ -4,6 +4,7 @@ use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use std::path::Path;
 
 use crate::{
+    engine_types::ValidatedWorldPath,
     event::AuditEventKind,
     timeline::{BodySha256, TimelineSeq},
 };
@@ -11,14 +12,14 @@ use crate::{
 use super::{open_existing, WriteAuditError};
 
 pub(crate) struct RetainedCasBody {
-    target: String,
+    target: ValidatedWorldPath,
     body_sha256: BodySha256,
     size: i64,
     inserted: bool,
 }
 
 impl RetainedCasBody {
-    pub(crate) fn target(&self) -> &str {
+    pub(crate) fn target(&self) -> &ValidatedWorldPath {
         &self.target
     }
 
@@ -37,7 +38,7 @@ impl RetainedCasBody {
 
 pub(super) fn retain_body_tx(
     tx: &Transaction<'_>,
-    target: &str,
+    target: &ValidatedWorldPath,
     body: &[u8],
 ) -> Result<RetainedCasBody, WriteAuditError> {
     let body_sha256 = BodySha256::for_body(body);
@@ -58,7 +59,7 @@ pub(super) fn retain_body_tx(
         return Err(WriteAuditError::CasBodyMismatch { body_sha256 });
     }
     Ok(RetainedCasBody {
-        target: target.to_owned(),
+        target: target.clone(),
         body_sha256,
         size,
         inserted,

--- a/core/src/world/files.rs
+++ b/core/src/world/files.rs
@@ -1,0 +1,169 @@
+//! Filesystem operations for world directories.
+
+use percent_encoding::percent_decode_str;
+use rusqlite::{Connection, OpenFlags};
+use std::path::Path;
+use std::time::Duration;
+
+use crate::world_schema;
+
+use super::{create_dir_error, disk_name, world_db, world_dir};
+
+pub fn delete(data_root: &Path, world: &str) -> bool {
+    let dir = world_dir(data_root, world);
+    if !dir.exists() {
+        return false;
+    }
+
+    // Windows + SQLite WAL: -wal / -shm files stay locked briefly after
+    // the connection drops. Naive remove_dir_all may return Ok while
+    // leaving stragglers, or fail outright. Flush WAL via checkpoint,
+    // then retry the remove.
+    release_wal_files(data_root, world);
+
+    let mut delay = Duration::from_millis(30);
+    for attempt in 0..20 {
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => {
+                if !dir.exists() {
+                    return true;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
+            Err(_) => {}
+        }
+        if attempt == 19 {
+            break;
+        }
+        std::thread::sleep(delay);
+        delay = std::cmp::min(delay * 2, Duration::from_millis(500));
+    }
+    !dir.exists()
+}
+
+/// List all sqlite-backed world keys by scanning the data dir.
+/// Returns canonical (decoded) names.
+pub fn list(data_root: &Path) -> rusqlite::Result<Vec<String>> {
+    list_matching(data_root, |_| true)
+}
+
+/// List sqlite-backed world keys with a canonical prefix.
+pub fn list_with_prefix(data_root: &Path, prefix: &str) -> rusqlite::Result<Vec<String>> {
+    list_matching(data_root, |world| world.starts_with(prefix))
+}
+
+/// List sqlite-backed world keys with a canonical prefix, returning `None`
+/// before materializing more than `max` matches.
+pub fn list_with_prefix_bounded(
+    data_root: &Path,
+    prefix: &str,
+    max: usize,
+) -> rusqlite::Result<Option<Vec<String>>> {
+    list_matching_bounded(data_root, |world| world.starts_with(prefix), max)
+}
+
+fn release_wal_files(data_root: &Path, world: &str) {
+    match open_checkpoint_conn(data_root, world) {
+        Ok(Some(c)) => {
+            if let Err(err) = c.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+                log_wal_release_error(world, "checkpoint", &err);
+            }
+            drop(c);
+        }
+        Ok(None) => {}
+        Err(err) => log_wal_release_error(world, "open", &err),
+    }
+    for suffix in ["-wal", "-shm"] {
+        let _ = std::fs::remove_file(
+            data_root
+                .join(disk_name(world))
+                .join(format!("universe.db{suffix}")),
+        );
+    }
+    std::thread::sleep(Duration::from_millis(10));
+}
+
+pub(super) fn open_checkpoint_conn(
+    data_root: &Path,
+    world: &str,
+) -> rusqlite::Result<Option<Connection>> {
+    let path = world_db(data_root, world);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let c = match Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_WRITE) {
+        Ok(c) => c,
+        Err(e) => {
+            if !path.exists() {
+                return Ok(None);
+            }
+            return Err(e);
+        }
+    };
+    c.busy_timeout(Duration::from_millis(5000))?;
+    world_schema::verify(&c)?;
+    Ok(Some(c))
+}
+
+fn log_wal_release_error(world: &str, phase: &str, err: &rusqlite::Error) {
+    #[cfg(feature = "unstable-engine")]
+    tracing::warn!(
+        world,
+        phase,
+        error = %err,
+        "delete skipped wal checkpoint before physical remove"
+    );
+
+    #[cfg(not(feature = "unstable-engine"))]
+    eprintln!("elastik-core internal delete wal checkpoint {phase} failed for {world}: {err}");
+}
+
+fn list_matching(
+    data_root: &Path,
+    mut keep: impl FnMut(&str) -> bool,
+) -> rusqlite::Result<Vec<String>> {
+    let mut out = Vec::new();
+    let rd = std::fs::read_dir(data_root).map_err(create_dir_error)?;
+    for entry in rd {
+        let entry = entry.map_err(create_dir_error)?;
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if !entry.path().join("universe.db").exists() {
+            continue;
+        }
+        let decoded = percent_decode_str(&name).decode_utf8_lossy().into_owned();
+        if keep(&decoded) {
+            out.push(decoded);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn list_matching_bounded(
+    data_root: &Path,
+    mut keep: impl FnMut(&str) -> bool,
+    max: usize,
+) -> rusqlite::Result<Option<Vec<String>>> {
+    let mut out = Vec::new();
+    let rd = std::fs::read_dir(data_root).map_err(create_dir_error)?;
+    for entry in rd {
+        let entry = entry.map_err(create_dir_error)?;
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if !entry.path().join("universe.db").exists() {
+            continue;
+        }
+        let decoded = percent_decode_str(&name).decode_utf8_lossy().into_owned();
+        if keep(&decoded) {
+            if out.len() >= max {
+                return Ok(None);
+            }
+            out.push(decoded);
+        }
+    }
+    out.sort();
+    Ok(Some(out))
+}

--- a/core/src/world/files.rs
+++ b/core/src/world/files.rs
@@ -5,11 +5,12 @@ use rusqlite::{Connection, OpenFlags};
 use std::path::Path;
 use std::time::Duration;
 
-use crate::world_schema;
+use crate::{engine_types::ValidatedWorldPath, world_schema};
 
 use super::{create_dir_error, disk_name, world_db, world_dir};
 
-pub fn delete(data_root: &Path, world: &str) -> bool {
+pub(crate) fn delete(data_root: &Path, world: &ValidatedWorldPath) -> bool {
+    let world = world.as_str();
     let dir = world_dir(data_root, world);
     if !dir.exists() {
         return false;

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -16,7 +16,9 @@ use bytes::Bytes;
 use crate::{
     audit, auth, can_read, can_write,
     engine_types::{ChangeVerb, ValidatedWorldPath},
-    etag, needs_write_approve, store, world, AuthGate, Core, StorageFailureClass,
+    etag, needs_write_approve, store,
+    timeline::BodySha256,
+    world, AuthGate, Core, StorageFailureClass,
 };
 
 #[derive(Debug)]
@@ -122,12 +124,19 @@ pub(crate) enum WriteError {
         scope: &'static str,
         err: rusqlite::Error,
     },
+    StorageInvariant(StorageInvariantReason),
     AuditChainBroken {
         #[allow(dead_code)]
         scope: &'static str,
         break_report: audit::VerifyBreak,
     },
     Internal(&'static str),
+}
+
+#[derive(Debug)]
+pub(crate) enum StorageInvariantReason {
+    CasBodyMismatch(BodySha256),
+    CasState(&'static str),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -223,7 +232,10 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
         if let Some(quota) = core.max_storage_bytes {
             hooks.quota_check(core.storage_body_bytes.load(Ordering::Relaxed), quota);
         }
-        if let Err(quota) = core.reserve_storage(prev_len, req.body.len()) {
+        let cas_candidate_len = world::cas_body_len_if_missing(&core.data, world, &req.body)
+            .map_err(|err| classify_write_storage_error("storage/cas", err, StorageOp::Read))?;
+        let reserve_new_len = req.body.len().saturating_add(cas_candidate_len);
+        if let Err(quota) = core.reserve_storage(prev_len, reserve_new_len) {
             return Err(WriteError::QuotaExceeded {
                 used: quota.used,
                 quota: quota.quota,
@@ -240,25 +252,40 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
             None,
         ) {
             Ok(result) => {
+                if !result.cas_body_inserted {
+                    core.rollback_storage_reservation(0, cas_candidate_len);
+                }
                 if !existed {
                     core.durable_world_count.fetch_add(1, Ordering::Relaxed);
                 }
                 (existed, etag::hmac_etag(&result.hmac))
             }
             Err(world::WriteAuditError::Quota { .. }) => {
-                core.rollback_storage_reservation(prev_len, req.body.len());
+                core.rollback_storage_reservation(prev_len, reserve_new_len);
                 return Err(WriteError::Internal("unexpected quota error"));
             }
             Err(world::WriteAuditError::Audit(err)) => {
-                core.rollback_storage_reservation(prev_len, req.body.len());
+                core.rollback_storage_reservation(prev_len, reserve_new_len);
                 return Err(classify_write_audit_error("storage/audit", err));
             }
             Err(world::WriteAuditError::Sqlite(err)) => {
-                core.rollback_storage_reservation(prev_len, req.body.len());
+                core.rollback_storage_reservation(prev_len, reserve_new_len);
                 return Err(classify_write_storage_error(
                     "storage/audit",
                     err,
                     StorageOp::WriteAudit,
+                ));
+            }
+            Err(world::WriteAuditError::CasBodyMismatch { body_sha256 }) => {
+                core.rollback_storage_reservation(prev_len, reserve_new_len);
+                return Err(WriteError::StorageInvariant(
+                    StorageInvariantReason::CasBodyMismatch(body_sha256),
+                ));
+            }
+            Err(world::WriteAuditError::StorageInvariant(reason)) => {
+                core.rollback_storage_reservation(prev_len, reserve_new_len);
+                return Err(WriteError::StorageInvariant(
+                    StorageInvariantReason::CasState(reason),
                 ));
             }
         }
@@ -326,7 +353,11 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
         if let Some(quota) = core.max_storage_bytes {
             hooks.quota_check(core.storage_body_bytes.load(Ordering::Relaxed), quota);
         }
-        if let Err(quota) = core.reserve_storage(0, req.body.len()) {
+        let cas_candidate_len = world::append_cas_body_len_if_missing(&core.data, world, &req.body)
+            .map_err(|err| classify_write_storage_error("storage/cas", err, StorageOp::Read))?
+            .ok_or(WriteError::NotFound)?;
+        let reserve_new_len = req.body.len().saturating_add(cas_candidate_len);
+        if let Err(quota) = core.reserve_storage(0, reserve_new_len) {
             return Err(WriteError::QuotaExceeded {
                 used: quota.used,
                 quota: quota.quota,
@@ -341,17 +372,22 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
             &stored_headers,
             &core.hmac_key,
         ) {
-            Ok(Some((_result, h))) => etag::hmac_etag(&h),
+            Ok(Some((result, h))) => {
+                if !result.cas_body_inserted {
+                    core.rollback_storage_reservation(0, cas_candidate_len);
+                }
+                etag::hmac_etag(&h)
+            }
             Ok(None) => {
-                core.rollback_storage_reservation(0, req.body.len());
+                core.rollback_storage_reservation(0, reserve_new_len);
                 return Err(WriteError::NotFound);
             }
             Err(world::WriteAuditError::Audit(err)) => {
-                core.rollback_storage_reservation(0, req.body.len());
+                core.rollback_storage_reservation(0, reserve_new_len);
                 return Err(classify_write_audit_error("storage/audit", err));
             }
             Err(world::WriteAuditError::Sqlite(err)) => {
-                core.rollback_storage_reservation(0, req.body.len());
+                core.rollback_storage_reservation(0, reserve_new_len);
                 return Err(classify_write_storage_error(
                     "storage/audit",
                     err,
@@ -359,8 +395,20 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
                 ));
             }
             Err(world::WriteAuditError::Quota { .. }) => {
-                core.rollback_storage_reservation(0, req.body.len());
+                core.rollback_storage_reservation(0, reserve_new_len);
                 return Err(WriteError::Internal("unexpected quota error"));
+            }
+            Err(world::WriteAuditError::CasBodyMismatch { body_sha256 }) => {
+                core.rollback_storage_reservation(0, reserve_new_len);
+                return Err(WriteError::StorageInvariant(
+                    StorageInvariantReason::CasBodyMismatch(body_sha256),
+                ));
+            }
+            Err(world::WriteAuditError::StorageInvariant(reason)) => {
+                core.rollback_storage_reservation(0, reserve_new_len);
+                return Err(WriteError::StorageInvariant(
+                    StorageInvariantReason::CasState(reason),
+                ));
             }
         }
     } else {
@@ -529,6 +577,73 @@ mod tests {
         );
 
         drop(holder);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn durable_quota_counts_retained_cas_bodies() {
+        struct NoopTrace;
+        impl WriteTraceHooks for NoopTrace {}
+
+        let (mut core, dir) = test_core("quota-counts-cas");
+        core.max_storage_bytes = Some(8);
+        let world = world_path("home/quota-cas");
+        let permit = authorize_write(&world, auth::Tier::Write).unwrap();
+
+        replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"aaaa"),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
+
+        replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"aaaa"),
+                content_type: "application/octet-stream".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
+
+        let err = replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"bbbb"),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WriteError::QuotaExceeded { projected: 12, .. }
+        ));
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 8);
+        assert_eq!(
+            core.read_world("home/quota-cas").unwrap().unwrap().body,
+            b"aaaa"
+        );
+
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -225,7 +225,7 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
     check_write_preconditions(core, world_path, &req.preconditions)?;
 
     let (existed, etag) = if store::is_persistent(world) {
-        let prev_len_opt = world::body_len(&core.data, world).map_err(|err| {
+        let prev_len_opt = world::body_len(&core.data, world_path).map_err(|err| {
             classify_write_storage_error("storage metadata", err, StorageOp::Read)
         })?;
         let existed = prev_len_opt.is_some();
@@ -233,8 +233,9 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
         if let Some(quota) = core.max_storage_bytes {
             hooks.quota_check(core.storage_body_bytes.load(Ordering::Relaxed), quota);
         }
-        let cas_candidate_len = world::cas_body_len_if_missing(&core.data, world, &req.body)
-            .map_err(|err| classify_write_storage_error("storage/cas", err, StorageOp::Read))?;
+        let cas_candidate_len =
+            world::cas_body_len_if_missing(&core.data, world_path, &req.body)
+                .map_err(|err| classify_write_storage_error("storage/cas", err, StorageOp::Read))?;
         let reserve_new_len = req.body.len().saturating_add(cas_candidate_len);
         if let Err(quota) = core.reserve_storage(prev_len, reserve_new_len) {
             return Err(WriteError::QuotaExceeded {
@@ -330,7 +331,7 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
     let Some((body_len, content_type, stored_headers)) = (if store::is_memory_world(world) {
         core.mem.metadata(world)
     } else {
-        world::metadata(&core.data, world)
+        world::metadata(&core.data, world_path)
             .map_err(|err| classify_write_storage_error("storage metadata", err, StorageOp::Read))?
     }) else {
         return Err(WriteError::NotFound);
@@ -350,9 +351,10 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
         if let Some(quota) = core.max_storage_bytes {
             hooks.quota_check(core.storage_body_bytes.load(Ordering::Relaxed), quota);
         }
-        let cas_candidate_len = world::append_cas_body_len_if_missing(&core.data, world, &req.body)
-            .map_err(|err| classify_write_storage_error("storage/cas", err, StorageOp::Read))?
-            .ok_or(WriteError::NotFound)?;
+        let cas_candidate_len =
+            world::append_cas_body_len_if_missing(&core.data, world_path, &req.body)
+                .map_err(|err| classify_write_storage_error("storage/cas", err, StorageOp::Read))?
+                .ok_or(WriteError::NotFound)?;
         let reserve_new_len = req.body.len().saturating_add(cas_candidate_len);
         if let Err(quota) = core.reserve_storage(0, reserve_new_len) {
             return Err(WriteError::QuotaExceeded {

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -638,6 +638,190 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
+    #[tokio::test]
+    async fn replace_cas_mismatch_rolls_back_storage_reservation() {
+        struct NoopTrace;
+        impl WriteTraceHooks for NoopTrace {}
+
+        let (core, dir) = test_core("replace-cas-mismatch-accounting");
+        let world = world_path("home/replace-cas-mismatch");
+        let permit = authorize_write(&world, auth::Tier::Write).unwrap();
+        replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"old"),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+        let before = core.storage_body_bytes.load(Ordering::Relaxed);
+        assert_eq!(before, 6);
+        let c = rusqlite::Connection::open(world::world_db(&dir, world.as_str())).unwrap();
+        c.execute_batch(
+            r#"CREATE TRIGGER corrupt_new_cas_body
+               AFTER INSERT ON cas_bodies
+               BEGIN
+                   UPDATE cas_bodies SET body=x'00' WHERE body_sha256=NEW.body_sha256;
+               END"#,
+        )
+        .unwrap();
+
+        let err = replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"new"),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WriteError::StorageInvariant(StorageInvariantReason::CasBodyMismatch(_))
+        ));
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), before);
+        assert_eq!(
+            core.read_world("home/replace-cas-mismatch")
+                .unwrap()
+                .unwrap()
+                .body,
+            b"old"
+        );
+        let events: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(events, 1);
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn append_cas_mismatch_rolls_back_storage_reservation() {
+        struct NoopTrace;
+        impl WriteTraceHooks for NoopTrace {}
+
+        let (core, dir) = test_core("append-cas-mismatch-accounting");
+        let world = world_path("home/append-cas-mismatch");
+        let permit = authorize_write(&world, auth::Tier::Write).unwrap();
+        replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"one"),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+        let before = core.storage_body_bytes.load(Ordering::Relaxed);
+        assert_eq!(before, 6);
+        let c = rusqlite::Connection::open(world::world_db(&dir, world.as_str())).unwrap();
+        c.execute_batch(
+            r#"CREATE TRIGGER corrupt_appended_cas_body
+               AFTER INSERT ON cas_bodies
+               BEGIN
+                   UPDATE cas_bodies SET body=x'00' WHERE body_sha256=NEW.body_sha256;
+               END"#,
+        )
+        .unwrap();
+
+        let err = append_write(
+            &core,
+            &permit,
+            AppendRequest {
+                body: Bytes::from_static(b"two"),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WriteError::StorageInvariant(StorageInvariantReason::CasBodyMismatch(_))
+        ));
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), before);
+        assert_eq!(
+            core.read_world("home/append-cas-mismatch")
+                .unwrap()
+                .unwrap()
+                .body,
+            b"one"
+        );
+        let events: i64 = c
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(events, 1);
+        drop(c);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn append_quota_counts_retained_full_body() {
+        struct NoopTrace;
+        impl WriteTraceHooks for NoopTrace {}
+
+        let (mut core, dir) = test_core("append-quota-counts-retained");
+        core.max_storage_bytes = Some(9);
+        let world = world_path("home/append-quota");
+        let permit = authorize_write(&world, auth::Tier::Write).unwrap();
+        replace_write(
+            &core,
+            &permit,
+            ReplaceRequest {
+                body: Bytes::from_static(b"aa"),
+                content_type: "text/plain".to_owned(),
+                headers: Vec::new(),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap();
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 4);
+
+        let err = append_write(
+            &core,
+            &permit,
+            AppendRequest {
+                body: Bytes::from_static(b"bb"),
+                preconditions: etag::Preconditions::default(),
+            },
+            &NoopTrace,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WriteError::QuotaExceeded {
+                quota: 9,
+                projected: 10,
+                ..
+            }
+        ));
+        assert_eq!(core.storage_body_bytes.load(Ordering::Relaxed), 4);
+        assert_eq!(
+            core.read_world("home/append-quota").unwrap().unwrap().body,
+            b"aa"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
     #[test]
     fn write_permit_preserves_path_based_approve_gate() {
         assert!(matches!(

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -244,7 +244,7 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
         }
         match world::write_with_audit_checked(
             &core.data,
-            world,
+            &permit.world,
             &req.body,
             &req.content_type,
             &req.headers,
@@ -361,7 +361,7 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
         }
         match world::append_with_audit(
             &core.data,
-            world,
+            &permit.world,
             &req.body,
             &content_type,
             &stored_headers,

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -221,7 +221,7 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
 
     let _write_guard = core.acquire_world_lock(world).await;
     hooks.lock_acquired();
-    core.clear_tombstone(world);
+    core.clear_tombstone(world_path);
     check_write_preconditions(core, world_path, &req.preconditions)?;
 
     let (existed, etag) = if store::is_persistent(world) {
@@ -324,7 +324,7 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
     let world = world_path.as_str();
     let _write_guard = core.acquire_world_lock(world).await;
     hooks.lock_acquired();
-    core.clear_tombstone(world);
+    core.clear_tombstone(world_path);
     check_write_preconditions(core, world_path, &req.preconditions)?;
 
     let Some((body_len, content_type, stored_headers)) = (if store::is_memory_world(world) {

--- a/core/src/world_ops.rs
+++ b/core/src/world_ops.rs
@@ -249,7 +249,6 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
             &req.content_type,
             &req.headers,
             &core.hmac_key,
-            None,
         ) {
             Ok(result) => {
                 if !result.cas_body_inserted {
@@ -259,10 +258,6 @@ pub(crate) async fn replace_write<H: WriteTraceHooks + ?Sized>(
                     core.durable_world_count.fetch_add(1, Ordering::Relaxed);
                 }
                 (existed, etag::hmac_etag(&result.hmac))
-            }
-            Err(world::WriteAuditError::Quota { .. }) => {
-                core.rollback_storage_reservation(prev_len, reserve_new_len);
-                return Err(WriteError::Internal("unexpected quota error"));
             }
             Err(world::WriteAuditError::Audit(err)) => {
                 core.rollback_storage_reservation(prev_len, reserve_new_len);
@@ -393,10 +388,6 @@ pub(crate) async fn append_write<H: WriteTraceHooks + ?Sized>(
                     err,
                     StorageOp::WriteAudit,
                 ));
-            }
-            Err(world::WriteAuditError::Quota { .. }) => {
-                core.rollback_storage_reservation(0, reserve_new_len);
-                return Err(WriteError::Internal("unexpected quota error"));
             }
             Err(world::WriteAuditError::CasBodyMismatch { body_sha256 }) => {
                 core.rollback_storage_reservation(0, reserve_new_len);

--- a/core/src/world_schema.rs
+++ b/core/src/world_schema.rs
@@ -2,6 +2,7 @@
 
 use crate::world_generation::{MintedWorldGeneration, WorldGeneration};
 use rusqlite::{ffi, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
 
 const CAS_BODIES_TABLE_SQL: &str = r#"
 CREATE TABLE cas_bodies(
@@ -234,19 +235,14 @@ fn is_sql_word_char(ch: char) -> bool {
 
 fn verify_cas_body_rows(c: &Connection) -> rusqlite::Result<()> {
     let mut stmt = c.prepare(
-        "SELECT body_sha256, typeof(body_sha256), typeof(body), length(body) FROM cas_bodies",
+        "SELECT body_sha256, typeof(body_sha256), typeof(body), length(body), body FROM cas_bodies",
     )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, Option<i64>>(3)?,
-        ))
-    })?;
-
-    for row in rows {
-        let (hash, hash_type, body_type, body_len) = row?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let hash: String = row.get(0)?;
+        let hash_type: String = row.get(1)?;
+        let body_type: String = row.get(2)?;
+        let body_len: Option<i64> = row.get(3)?;
         if hash_type != "text" || !is_lower_hex_sha256(&hash) {
             return Err(schema_error(
                 "cas_bodies.body_sha256 must be 64-byte lower hex TEXT".to_owned(),
@@ -255,9 +251,21 @@ fn verify_cas_body_rows(c: &Connection) -> rusqlite::Result<()> {
         if body_type != "blob" || body_len.is_none() {
             return Err(schema_error("cas_bodies.body must be BLOB".to_owned()));
         }
+        let body: Vec<u8> = row.get(4)?;
+        if sha256_hex(&body) != hash {
+            return Err(schema_error(
+                "cas_bodies.body does not match body_sha256".to_owned(),
+            ));
+        }
     }
 
     Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex::encode(h.finalize())
 }
 
 fn is_lower_hex_sha256(value: &str) -> bool {
@@ -587,6 +595,21 @@ mod tests {
         let err = verify(&c).unwrap_err();
 
         assert!(err.to_string().contains("cas_bodies.body_sha256"));
+    }
+
+    #[test]
+    fn verify_rejects_cas_body_hash_mismatch() {
+        let c = Connection::open_in_memory().unwrap();
+        create_valid_schema(&c);
+        c.execute(
+            "INSERT INTO cas_bodies(body_sha256, body) VALUES(?1, ?2)",
+            rusqlite::params![sha256_hex(b"expected"), b"different".as_slice()],
+        )
+        .unwrap();
+
+        let err = verify(&c).unwrap_err();
+
+        assert!(err.to_string().contains("does not match body_sha256"));
     }
 
     #[test]

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -41,3 +41,32 @@ Run on `stack/22r19-audit-verify-world-target` after retargeting #359 to
 
 GitHub CI must still be treated as authoritative for remote checks when it
 finishes; queued checks are not green checks.
+
+## Reopened QA Addendum
+
+Planck the 2nd re-reviewed the reopened stack and found two remaining P3
+type-seal holes:
+
+- raw physical delete helper exposure through `world::delete` /
+  `world/files.rs`;
+- raw subscription resume cursors flowing as `Option<u64>` across Core and FFI.
+
+Fixes landed at the lowest affected layers:
+
+- `world/files.rs::delete` now requires `&ValidatedWorldPath`, and `world.rs`
+  no longer exposes the physical delete helper as a raw world-name API.
+- `Core::delete_world_blocking` calls the sealed `world::delete(&data, &world)`
+  path.
+- `SubscriptionResume` is now the Core proof type for replay state, with
+  `none()` and `after_event_id(...)` constructors.
+- `Engine::subscribe`, `EngineOps::subscribe`, `open_subscription`, replay
+  internals, HTTP listen, and FFI no longer use raw `Option<u64>` cursors at the
+  Core boundary.
+- FFI exposes `FfiSubscriptionResume` instead of a raw `since` argument.
+
+Upper-stack test call sites were repaired where they first appeared (`22r27`
+and `22r40`). A follow-up clippy hygiene fix kept `SubscriptionResume` out of
+CoAP production imports and test-local only.
+
+This addendum still does not claim GitHub CI is green. The live source of truth
+after push remains GitHub CI.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -1,0 +1,43 @@
+# Stack 22 Cascade Repair Ledger
+
+This ledger exists because `stack/22r19-audit-verify-world-target` was a hidden
+base for upper Stack 22 PRs. The repair exposes that base as PR #359 instead of
+letting later PRs depend on an untracked branch.
+
+## Drain Boundary
+
+- #330 through #335 have been merged into `master` with merge commits.
+- `master` has the same tree as the former `stack/21-cas-schema` base.
+- #359 is based on `master` and keeps `stack/22r19-audit-verify-world-target`
+  as the first visible Stack 22 layer.
+- #336 through #357 remain draft and depend on the #359 head branch chain.
+
+## Exception Scope
+
+This is a stack-topology repair exception, not permission to add unrelated
+feature scope. The exception allows a larger-than-normal PR only because this
+branch already existed and already sat under reviewed upper-stack work.
+
+The exception does not waive:
+
+- type-seal requirements for internal APIs;
+- no-rebase/no-squash stack handling;
+- subagent QA before advancing;
+- local validation;
+- keeping dependent stack branches alive while PRs still use them as bases.
+
+## Current Local Gates
+
+Run on `stack/22r19-audit-verify-world-target` after retargeting #359 to
+`master`:
+
+- `cargo fmt --manifest-path core/Cargo.toml -- --check`
+- `cargo clippy --manifest-path core/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path core/Cargo.toml`
+- `cargo fmt --manifest-path bin/Cargo.toml -- --check`
+- `cargo clippy --manifest-path bin/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path bin/Cargo.toml`
+- `git diff --check origin/master..origin/stack/22r19-audit-verify-world-target`
+
+GitHub CI must still be treated as authoritative for remote checks when it
+finishes; queued checks are not green checks.

--- a/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
+++ b/design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md
@@ -70,3 +70,34 @@ CoAP production imports and test-local only.
 
 This addendum still does not claim GitHub CI is green. The live source of truth
 after push remains GitHub CI.
+
+## Post-Push CI Addendum
+
+After pushing the reopened QA fixes, live GitHub CI found two stack-local
+compile/smoke failures:
+
+- #342 / `22r26`: FFI artifact smoke still called
+  `engine.subscribe("home/*", e.FfiAccessTier.READ, None)` after the FFI
+  boundary changed to `FfiSubscriptionResume`.
+- #352 / `22r36`: the SSE mismatch test still passed raw `None` to
+  `Engine::subscribe` after the Core boundary changed to `SubscriptionResume`.
+
+Fixes landed at the lowest affected layers:
+
+- `22r19`: `.github/workflows/ffi-artifacts.yml` and
+  `.github/workflows/release.yml` now pass
+  `e.FfiSubscriptionResume(after_event_id=None)` in their smoke scripts.
+- `22r29`: `sse_change_event_drops_mismatched_timeline_address` now passes
+  `SubscriptionResume::none()`.
+
+Focused validation:
+
+- `22r29`: `cargo test --manifest-path bin/Cargo.toml --no-run` passed.
+- `22r36`: `cargo test --manifest-path bin/Cargo.toml --no-run` passed.
+- Stack-wide source scans found no raw subscribe-resume shapes in Core/bin/FFI
+  code and no old workflow smoke call.
+- Adjacent branch ancestry from `22r19` through `22r41`: pass.
+- Pre-push fast gates passed before the repair branches were pushed again.
+
+This addendum still does not claim GitHub CI is green. The live source of truth
+after push remains GitHub CI.

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -125,7 +125,7 @@ engine.delete("home/plain-doc", none, FfiAccessTier.APPROVE)
 sub = engine.subscribe(
     "home/*",
     FfiAccessTier.READ,
-    FfiSubscriptionResume(after_event_id=None),
+    FfiSubscriptionResume(after_cursor=None, after_event_id=None),
 )
 
 engine.replace("home/sub-doc", FfiRepresentation(

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -20,7 +20,7 @@ crate are sibling adapters.
   headers in the Engine delete audit ledger; plain `delete()` remains the
   empty-metadata convenience wrapper
 - `engine.worlds`, `du`, `df`, `pool`, `audit_verify` — typed introspection
-- `engine.subscribe(pattern, tier, since)` — blocking `FfiSubscription.next(timeout_ms)`
+- `engine.subscribe(pattern, tier, resume)` — blocking `FfiSubscription.next(timeout_ms)`
   receiver with explicit `close()` for deterministic slot release in
   garbage-collected languages; `close()` wakes a currently blocked `next()`
   instead of waiting for the timeout window
@@ -49,7 +49,7 @@ open Engine:
 from elastik_ffi import (
     FfiAccessTier, FfiEngine, FfiEngineConfig, FfiError,
     FfiDeleteMetadata, FfiHeader, FfiPreconditions, FfiRepresentation,
-    FfiSubscriptionNextKind,
+    FfiSubscriptionNextKind, FfiSubscriptionResume,
 )
 
 engine = FfiEngine.open(FfiEngineConfig(
@@ -122,7 +122,11 @@ engine.delete("home/plain-doc", none, FfiAccessTier.APPROVE)
 ### Subscription
 
 ```python
-sub = engine.subscribe("home/*", FfiAccessTier.READ, None)
+sub = engine.subscribe(
+    "home/*",
+    FfiAccessTier.READ,
+    FfiSubscriptionResume(after_event_id=None),
+)
 
 engine.replace("home/sub-doc", FfiRepresentation(
     body=b"update",

--- a/ffi/STACK.md
+++ b/ffi/STACK.md
@@ -27,7 +27,7 @@ HTTP server, routes, status codes, or `/proc/*` paths.
      names.
 
 4. **Subscribe Receiver**
-   - Bind `subscribe(pattern, tier, since) -> FfiSubscription`.
+   - Bind `subscribe(pattern, tier, resume) -> FfiSubscription`.
    - Expose `next(timeout_ms) -> FfiSubscriptionNext` with typed `Event`,
      `Timeout`, `Lagged`, `Closed`, and `Unknown` states.
    - Translate core event method strings into Engine verbs

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -324,11 +324,15 @@ impl FfiSubscription {
                 kind: FfiSubscriptionNextKind::Closed,
                 event: None,
                 skipped: None,
+                since: None,
+                newest: None,
             },
             Err(_) => FfiSubscriptionNext {
                 kind: FfiSubscriptionNextKind::Timeout,
                 event: None,
                 skipped: None,
+                since: None,
+                newest: None,
             },
         }
     }
@@ -409,6 +413,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Event,
                 event: Some(event.into()),
                 skipped: None,
+                since: None,
+                newest: None,
             },
             false,
         ),
@@ -417,6 +423,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Lagged,
                 event: None,
                 skipped: Some(skipped),
+                since: None,
+                newest: None,
             },
             false,
         ),
@@ -425,22 +433,28 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Closed,
                 event: None,
                 skipped: None,
+                since: None,
+                newest: None,
             },
             true,
         ),
-        Err(SubscriptionRecvError::CursorAhead { .. }) => (
+        Err(SubscriptionRecvError::CursorAhead { since, newest }) => (
             FfiSubscriptionNext {
-                kind: FfiSubscriptionNextKind::Unknown,
+                kind: FfiSubscriptionNextKind::CursorAhead,
                 event: None,
                 skipped: None,
+                since: Some(since),
+                newest: Some(newest),
             },
-            true,
+            false,
         ),
         Err(_) => (
             FfiSubscriptionNext {
                 kind: FfiSubscriptionNextKind::Unknown,
                 event: None,
                 skipped: None,
+                since: None,
+                newest: None,
             },
             true,
         ),
@@ -834,6 +848,39 @@ mod tests {
         let event = live.event.expect("live event");
         assert_eq!(event.verb, FfiChangeVerb::Append);
         assert_eq!(event.path, "home/events/a");
+    }
+
+    #[test]
+    fn subscription_next_reports_cursor_ahead_then_keeps_live_stream_open() {
+        let engine = test_engine("subscribe-cursor-ahead");
+        let subscription = engine
+            .subscribe("home/stale/*".to_owned(), FfiAccessTier::Read, Some(42))
+            .expect("subscription opens");
+
+        let reset = subscription.next(1_000);
+        assert_eq!(reset.kind, FfiSubscriptionNextKind::CursorAhead);
+        assert_eq!(reset.since, Some(42));
+        assert_eq!(reset.newest, Some(0));
+        assert!(reset.event.is_none());
+        assert!(reset.skipped.is_none());
+
+        engine
+            .replace(
+                "home/stale/a".to_owned(),
+                small_representation(b"live"),
+                FfiPreconditions {
+                    if_match: Vec::new(),
+                    if_none_match: Vec::new(),
+                },
+                FfiAccessTier::Write,
+            )
+            .expect("write after cursor reset succeeds");
+
+        let live = subscription.next(1_000);
+        assert_eq!(live.kind, FfiSubscriptionNextKind::Event);
+        let event = live.event.expect("live event");
+        assert_eq!(event.verb, FfiChangeVerb::Replace);
+        assert_eq!(event.path, "home/stale/a");
     }
 
     #[test]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, time::Duration};
 
 use elastik_core::{
     AuditHmacKey, ChangeEvent, Engine, EngineDeleteTraceHooks, SubscribePattern,
-    SubscriptionRecvError, ValidatedWorldPath,
+    SubscriptionRecvError, SubscriptionResume, ValidatedWorldPath,
 };
 use tokio::{
     runtime::{Builder as RuntimeBuilder, Runtime},
@@ -270,9 +270,8 @@ impl FfiEngine {
         resume: FfiSubscriptionResume,
     ) -> Result<Arc<FfiSubscription>, FfiError> {
         let pattern = SubscribePattern::new(pattern);
-        let mut subscription = self
-            .engine
-            .subscribe(&pattern, tier.try_into()?, resume.into())?;
+        let resume = SubscriptionResume::try_from(resume)?;
+        let mut subscription = self.engine.subscribe(&pattern, tier.try_into()?, resume)?;
         let (events_tx, events_rx) = mpsc::channel(FFI_SUBSCRIPTION_BUFFER);
         let (cancel, mut cancel_rx) = watch::channel(false);
         let pump = self.runtime.spawn(async move {
@@ -328,6 +327,7 @@ impl FfiSubscription {
                 skipped: None,
                 cursor_after_event_id: None,
                 newest_event_id: None,
+                reset_cursor: None,
             },
             Err(_) => FfiSubscriptionNext {
                 kind: FfiSubscriptionNextKind::Timeout,
@@ -335,6 +335,7 @@ impl FfiSubscription {
                 skipped: None,
                 cursor_after_event_id: None,
                 newest_event_id: None,
+                reset_cursor: None,
             },
         }
     }
@@ -417,6 +418,7 @@ fn subscription_next_from_recv(
                 skipped: None,
                 cursor_after_event_id: None,
                 newest_event_id: None,
+                reset_cursor: None,
             },
             false,
         ),
@@ -427,6 +429,7 @@ fn subscription_next_from_recv(
                 skipped: Some(skipped),
                 cursor_after_event_id: None,
                 newest_event_id: None,
+                reset_cursor: None,
             },
             false,
         ),
@@ -437,16 +440,22 @@ fn subscription_next_from_recv(
                 skipped: None,
                 cursor_after_event_id: None,
                 newest_event_id: None,
+                reset_cursor: None,
             },
             true,
         ),
-        Err(SubscriptionRecvError::CursorAhead { since, newest }) => (
+        Err(SubscriptionRecvError::CursorAhead {
+            since,
+            newest,
+            reset,
+        }) => (
             FfiSubscriptionNext {
                 kind: FfiSubscriptionNextKind::CursorAhead,
                 event: None,
                 skipped: None,
                 cursor_after_event_id: Some(since),
                 newest_event_id: Some(newest),
+                reset_cursor: Some(reset.to_string()),
             },
             false,
         ),
@@ -457,6 +466,7 @@ fn subscription_next_from_recv(
                 skipped: None,
                 cursor_after_event_id: None,
                 newest_event_id: None,
+                reset_cursor: None,
             },
             true,
         ),
@@ -568,6 +578,8 @@ mod tests {
     fn change_event_uses_engine_verb_enum() {
         let event = FfiChangeEvent {
             id: 1,
+            cursor: "0123456789abcdef0123456789abcdef:1".to_owned(),
+            listen_epoch: "0123456789abcdef0123456789abcdef".to_owned(),
             verb: FfiChangeVerb::Replace,
             path: "home/doc".to_owned(),
             etag: "abc".to_owned(),
@@ -811,6 +823,13 @@ mod tests {
             if_match: Vec::new(),
             if_none_match: Vec::new(),
         };
+        let initial_subscription = engine
+            .subscribe(
+                "home/events/*".to_owned(),
+                FfiAccessTier::Read,
+                resume_none(),
+            )
+            .expect("initial subscription opens");
         engine
             .replace(
                 "home/events/a".to_owned(),
@@ -823,19 +842,33 @@ mod tests {
                 FfiAccessTier::Write,
             )
             .expect("first write succeeds");
+        let first = initial_subscription.next(1_000);
+        assert_eq!(first.kind, FfiSubscriptionNextKind::Event);
+        let first_cursor = first.event.expect("first live event").cursor;
+        initial_subscription.close();
+
+        engine
+            .append(
+                "home/events/a".to_owned(),
+                b" replay".to_vec(),
+                none.clone(),
+                FfiAccessTier::Write,
+            )
+            .expect("second write succeeds");
 
         let subscription = engine
             .subscribe(
                 "home/events/*".to_owned(),
                 FfiAccessTier::Read,
-                resume_after(0),
+                resume_after_cursor(first_cursor),
             )
             .expect("subscription opens");
         let replay = subscription.next(1_000);
         assert_eq!(replay.kind, FfiSubscriptionNextKind::Event);
         let event = replay.event.expect("replay event");
-        assert_eq!(event.verb, FfiChangeVerb::Replace);
+        assert_eq!(event.verb, FfiChangeVerb::Append);
         assert_eq!(event.path, "home/events/a");
+        assert_eq!(event.cursor, format!("{}:{}", event.listen_epoch, event.id));
 
         let timeout = subscription.next(1);
         assert_eq!(timeout.kind, FfiSubscriptionNextKind::Timeout);
@@ -871,6 +904,8 @@ mod tests {
         assert_eq!(reset.kind, FfiSubscriptionNextKind::CursorAhead);
         assert_eq!(reset.cursor_after_event_id, Some(42));
         assert_eq!(reset.newest_event_id, Some(0));
+        let reset_cursor = reset.reset_cursor.as_ref().expect("reset cursor");
+        assert!(reset_cursor.ends_with(":0"));
         assert!(reset.event.is_none());
         assert!(reset.skipped.is_none());
 
@@ -1158,13 +1193,22 @@ mod tests {
 
     fn resume_none() -> FfiSubscriptionResume {
         FfiSubscriptionResume {
+            after_cursor: None,
             after_event_id: None,
         }
     }
 
     fn resume_after(id: u64) -> FfiSubscriptionResume {
         FfiSubscriptionResume {
+            after_cursor: None,
             after_event_id: Some(id),
+        }
+    }
+
+    fn resume_after_cursor(cursor: String) -> FfiSubscriptionResume {
+        FfiSubscriptionResume {
+            after_cursor: Some(cursor),
+            after_event_id: None,
         }
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -267,10 +267,12 @@ impl FfiEngine {
         &self,
         pattern: String,
         tier: FfiAccessTier,
-        since: Option<u64>,
+        resume: FfiSubscriptionResume,
     ) -> Result<Arc<FfiSubscription>, FfiError> {
         let pattern = SubscribePattern::new(pattern);
-        let mut subscription = self.engine.subscribe(&pattern, tier.try_into()?, since)?;
+        let mut subscription = self
+            .engine
+            .subscribe(&pattern, tier.try_into()?, resume.into())?;
         let (events_tx, events_rx) = mpsc::channel(FFI_SUBSCRIPTION_BUFFER);
         let (cancel, mut cancel_rx) = watch::channel(false);
         let pump = self.runtime.spawn(async move {
@@ -324,15 +326,15 @@ impl FfiSubscription {
                 kind: FfiSubscriptionNextKind::Closed,
                 event: None,
                 skipped: None,
-                since: None,
-                newest: None,
+                cursor_after_event_id: None,
+                newest_event_id: None,
             },
             Err(_) => FfiSubscriptionNext {
                 kind: FfiSubscriptionNextKind::Timeout,
                 event: None,
                 skipped: None,
-                since: None,
-                newest: None,
+                cursor_after_event_id: None,
+                newest_event_id: None,
             },
         }
     }
@@ -413,8 +415,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Event,
                 event: Some(event.into()),
                 skipped: None,
-                since: None,
-                newest: None,
+                cursor_after_event_id: None,
+                newest_event_id: None,
             },
             false,
         ),
@@ -423,8 +425,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Lagged,
                 event: None,
                 skipped: Some(skipped),
-                since: None,
-                newest: None,
+                cursor_after_event_id: None,
+                newest_event_id: None,
             },
             false,
         ),
@@ -433,8 +435,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Closed,
                 event: None,
                 skipped: None,
-                since: None,
-                newest: None,
+                cursor_after_event_id: None,
+                newest_event_id: None,
             },
             true,
         ),
@@ -443,8 +445,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::CursorAhead,
                 event: None,
                 skipped: None,
-                since: Some(since),
-                newest: Some(newest),
+                cursor_after_event_id: Some(since),
+                newest_event_id: Some(newest),
             },
             false,
         ),
@@ -453,8 +455,8 @@ fn subscription_next_from_recv(
                 kind: FfiSubscriptionNextKind::Unknown,
                 event: None,
                 skipped: None,
-                since: None,
-                newest: None,
+                cursor_after_event_id: None,
+                newest_event_id: None,
             },
             true,
         ),
@@ -823,7 +825,11 @@ mod tests {
             .expect("first write succeeds");
 
         let subscription = engine
-            .subscribe("home/events/*".to_owned(), FfiAccessTier::Read, Some(0))
+            .subscribe(
+                "home/events/*".to_owned(),
+                FfiAccessTier::Read,
+                resume_after(0),
+            )
             .expect("subscription opens");
         let replay = subscription.next(1_000);
         assert_eq!(replay.kind, FfiSubscriptionNextKind::Event);
@@ -854,13 +860,17 @@ mod tests {
     fn subscription_next_reports_cursor_ahead_then_keeps_live_stream_open() {
         let engine = test_engine("subscribe-cursor-ahead");
         let subscription = engine
-            .subscribe("home/stale/*".to_owned(), FfiAccessTier::Read, Some(42))
+            .subscribe(
+                "home/stale/*".to_owned(),
+                FfiAccessTier::Read,
+                resume_after(42),
+            )
             .expect("subscription opens");
 
         let reset = subscription.next(1_000);
         assert_eq!(reset.kind, FfiSubscriptionNextKind::CursorAhead);
-        assert_eq!(reset.since, Some(42));
-        assert_eq!(reset.newest, Some(0));
+        assert_eq!(reset.cursor_after_event_id, Some(42));
+        assert_eq!(reset.newest_event_id, Some(0));
         assert!(reset.event.is_none());
         assert!(reset.skipped.is_none());
 
@@ -887,7 +897,7 @@ mod tests {
     fn subscription_next_reports_closed_after_shutdown() {
         let engine = test_engine("subscribe-closed");
         let subscription = engine
-            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .subscribe("*".to_owned(), FfiAccessTier::Read, resume_none())
             .expect("subscription opens");
         engine.shutdown();
 
@@ -914,11 +924,11 @@ mod tests {
         .expect("engine opens");
 
         let subscription = engine
-            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .subscribe("*".to_owned(), FfiAccessTier::Read, resume_none())
             .expect("first subscription opens");
         assert!(
             engine
-                .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+                .subscribe("*".to_owned(), FfiAccessTier::Read, resume_none())
                 .is_err(),
             "listen slot cap should be held while subscription is open"
         );
@@ -928,7 +938,7 @@ mod tests {
         assert_eq!(closed.kind, FfiSubscriptionNextKind::Closed);
 
         let replacement = engine
-            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .subscribe("*".to_owned(), FfiAccessTier::Read, resume_none())
             .expect("explicit close releases listen slot");
         replacement.close();
     }
@@ -937,7 +947,7 @@ mod tests {
     fn subscription_close_wakes_blocking_next() {
         let engine = test_engine("subscribe-close-wakes-blocking-next");
         let subscription = engine
-            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .subscribe("*".to_owned(), FfiAccessTier::Read, resume_none())
             .expect("subscription opens");
         let (started_tx, started_rx) = std_mpsc::channel();
         let waiting = Arc::clone(&subscription);
@@ -961,7 +971,7 @@ mod tests {
     fn subscription_next_survives_engine_handle_drop() {
         let engine = test_engine("subscribe-drop-engine");
         let subscription = engine
-            .subscribe("*".to_owned(), FfiAccessTier::Read, None)
+            .subscribe("*".to_owned(), FfiAccessTier::Read, resume_none())
             .expect("subscription opens");
 
         drop(engine);
@@ -1143,6 +1153,18 @@ mod tests {
             body: body.to_vec(),
             content_type: "text/plain".to_owned(),
             headers: Vec::new(),
+        }
+    }
+
+    fn resume_none() -> FfiSubscriptionResume {
+        FfiSubscriptionResume {
+            after_event_id: None,
+        }
+    }
+
+    fn resume_after(id: u64) -> FfiSubscriptionResume {
+        FfiSubscriptionResume {
+            after_event_id: Some(id),
         }
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -428,6 +428,14 @@ fn subscription_next_from_recv(
             },
             true,
         ),
+        Err(SubscriptionRecvError::CursorAhead { .. }) => (
+            FfiSubscriptionNext {
+                kind: FfiSubscriptionNextKind::Unknown,
+                event: None,
+                skipped: None,
+            },
+            true,
+        ),
         Err(_) => (
             FfiSubscriptionNext {
                 kind: FfiSubscriptionNextKind::Unknown,

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt};
 use elastik_core::{
     is_valid_token, AccessTier, AuditVerify, AuthGate, ChangeEvent, ChangeVerb, DeleteMetadata,
     DfSnapshot, EngineBuildError, EngineError, EtagMatcher, PoolSnapshot, Preconditions,
-    ReadResult, Representation, WorldUsage, WriteKind, WriteResult,
+    ReadResult, Representation, SubscriptionResume, WorldUsage, WriteKind, WriteResult,
 };
 
 /// Engine construction options for the FFI adapter.
@@ -159,6 +159,16 @@ pub struct FfiChangeEvent {
     pub etag: String,
 }
 
+/// Resume cursor for a subscription opened through FFI.
+///
+/// Foreign callers pass raw integers at the ABI edge, but the adapter converts
+/// this record into the core [`SubscriptionResume`] proof before calling the
+/// Engine.
+#[derive(Clone, Copy, Debug, Default, uniffi::Record)]
+pub struct FfiSubscriptionResume {
+    pub after_event_id: Option<u64>,
+}
+
 /// Result kind returned by `FfiSubscription.next`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
 pub enum FfiSubscriptionNextKind {
@@ -178,8 +188,8 @@ pub struct FfiSubscriptionNext {
     pub kind: FfiSubscriptionNextKind,
     pub event: Option<FfiChangeEvent>,
     pub skipped: Option<u64>,
-    pub since: Option<u64>,
-    pub newest: Option<u64>,
+    pub cursor_after_event_id: Option<u64>,
+    pub newest_event_id: Option<u64>,
 }
 
 /// Per-world body byte usage DTO.
@@ -497,6 +507,15 @@ impl From<ChangeEvent> for FfiChangeEvent {
             path: value.path.to_string(),
             etag: value.etag,
         }
+    }
+}
+
+impl From<FfiSubscriptionResume> for SubscriptionResume {
+    fn from(value: FfiSubscriptionResume) -> Self {
+        value
+            .after_event_id
+            .map(SubscriptionResume::after_event_id)
+            .unwrap_or_else(SubscriptionResume::none)
     }
 }
 

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, fmt};
 use elastik_core::{
     is_valid_token, AccessTier, AuditVerify, AuthGate, ChangeEvent, ChangeVerb, DeleteMetadata,
     DfSnapshot, EngineBuildError, EngineError, EtagMatcher, PoolSnapshot, Preconditions,
-    ReadResult, Representation, SubscriptionResume, WorldUsage, WriteKind, WriteResult,
+    ReadResult, Representation, SubscriptionCursor, SubscriptionResume, WorldUsage, WriteKind,
+    WriteResult,
 };
 
 /// Engine construction options for the FFI adapter.
@@ -154,6 +155,8 @@ pub enum FfiChangeVerb {
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct FfiChangeEvent {
     pub id: u64,
+    pub cursor: String,
+    pub listen_epoch: String,
     pub verb: FfiChangeVerb,
     pub path: String,
     pub etag: String,
@@ -164,8 +167,9 @@ pub struct FfiChangeEvent {
 /// Foreign callers pass raw integers at the ABI edge, but the adapter converts
 /// this record into the core [`SubscriptionResume`] proof before calling the
 /// Engine.
-#[derive(Clone, Copy, Debug, Default, uniffi::Record)]
+#[derive(Clone, Debug, Default, uniffi::Record)]
 pub struct FfiSubscriptionResume {
+    pub after_cursor: Option<String>,
     pub after_event_id: Option<u64>,
 }
 
@@ -190,6 +194,7 @@ pub struct FfiSubscriptionNext {
     pub skipped: Option<u64>,
     pub cursor_after_event_id: Option<u64>,
     pub newest_event_id: Option<u64>,
+    pub reset_cursor: Option<String>,
 }
 
 /// Per-world body byte usage DTO.
@@ -503,6 +508,8 @@ impl From<ChangeEvent> for FfiChangeEvent {
     fn from(value: ChangeEvent) -> Self {
         Self {
             id: value.id,
+            cursor: value.cursor.to_string(),
+            listen_epoch: value.listen_epoch.to_string(),
             verb: value.verb.into(),
             path: value.path.to_string(),
             etag: value.etag,
@@ -510,12 +517,23 @@ impl From<ChangeEvent> for FfiChangeEvent {
     }
 }
 
-impl From<FfiSubscriptionResume> for SubscriptionResume {
-    fn from(value: FfiSubscriptionResume) -> Self {
-        value
-            .after_event_id
-            .map(SubscriptionResume::after_event_id)
-            .unwrap_or_else(SubscriptionResume::none)
+impl TryFrom<FfiSubscriptionResume> for SubscriptionResume {
+    type Error = FfiError;
+
+    fn try_from(value: FfiSubscriptionResume) -> Result<Self, Self::Error> {
+        match (value.after_cursor, value.after_event_id) {
+            (None, None) => Ok(Self::none()),
+            (Some(raw), None) => SubscriptionCursor::from_sse_id(&raw)
+                .map(Self::after_cursor)
+                .map_err(|err| FfiError::InvalidConfig {
+                    message: format!("{err}: {raw}"),
+                }),
+            (None, Some(id)) => Ok(Self::legacy_event_id(id)),
+            (Some(_), Some(_)) => Err(FfiError::InvalidConfig {
+                message: "subscription resume must set after_cursor or after_event_id, not both"
+                    .to_owned(),
+            }),
+        }
     }
 }
 

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -165,6 +165,7 @@ pub enum FfiSubscriptionNextKind {
     Event,
     Timeout,
     Lagged,
+    CursorAhead,
     Closed,
     /// The Engine returned a subscription state this FFI binding does not yet
     /// recognize. Treat as indeterminate and upgrade the binding.
@@ -177,6 +178,8 @@ pub struct FfiSubscriptionNext {
     pub kind: FfiSubscriptionNextKind,
     pub event: Option<FfiChangeEvent>,
     pub skipped: Option<u64>,
+    pub since: Option<u64>,
+    pub newest: Option<u64>,
 }
 
 /// Per-world body byte usage DTO.

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -105,14 +105,16 @@ def world_url(base: str, path: str) -> str:
 
 def sse_cursor_parts(raw: str) -> tuple[str, int]:
     if ":" not in raw:
-        raise AssertionError(f"invalid SSE cursor: {raw!r}")
+        raise AssertionError(f"SSE id must be an opaque epoch cursor: {raw!r}")
     epoch, seq = raw.split(":", 1)
-    if not epoch:
+    if len(epoch) != 32 or any(ch not in "0123456789abcdef" for ch in epoch):
         raise AssertionError(f"invalid SSE cursor epoch: {raw!r}")
-    try:
-        return epoch, int(seq)
-    except ValueError as exc:
-        raise AssertionError(f"invalid SSE cursor sequence: {raw!r}") from exc
+    if not seq or any(ch not in "0123456789" for ch in seq):
+        raise AssertionError(f"invalid SSE cursor sequence: {raw!r}")
+    seq_value = int(seq)
+    if seq != str(seq_value) or seq_value > 0xFFFFFFFFFFFFFFFF:
+        raise AssertionError(f"invalid SSE cursor sequence: {raw!r}")
+    return epoch, seq_value
 
 
 def expect_error(fn, status: int, check: Check, name: str) -> None:
@@ -1296,10 +1298,13 @@ def main() -> int:
             replay_done = threading.Event()
             writer.put("/home/sdk/listen/b", b"payload-2")
 
+            ev_id = ev.get("id")
+            ev_epoch, ev_seq = sse_cursor_parts(ev_id or "")
+
             def consume_replay() -> None:
                 for event in reader.listen(
                     "/home/sdk/listen/*",
-                    last_event_id=ev.get("id"),
+                    last_event_id=ev_id,
                 ):
                     replay_events.append(event)
                     replay_done.set()
@@ -1310,8 +1315,7 @@ def main() -> int:
             check(replay_done.wait(5), "Last-Event-ID replays missed SSE event")
             replay = replay_events[0]
             check(replay.get("path") == "/home/sdk/listen/b", "replayed SSE event path")
-            ev_epoch, ev_seq = sse_cursor_parts(ev.get("id", "0"))
-            replay_epoch, replay_seq = sse_cursor_parts(replay.get("id", "0"))
+            replay_epoch, replay_seq = sse_cursor_parts(replay.get("id", ""))
             check(replay_epoch == ev_epoch, "replayed SSE cursor keeps listen epoch")
             check(replay_seq > ev_seq, "replayed SSE cursor advances")
 

--- a/sdk/tests/e2e_blackbox.py
+++ b/sdk/tests/e2e_blackbox.py
@@ -103,6 +103,18 @@ def world_url(base: str, path: str) -> str:
     return base.rstrip("/") + "/" + urllib.parse.quote(path.lstrip("/"), safe="/")
 
 
+def sse_cursor_parts(raw: str) -> tuple[str, int]:
+    if ":" not in raw:
+        raise AssertionError(f"invalid SSE cursor: {raw!r}")
+    epoch, seq = raw.split(":", 1)
+    if not epoch:
+        raise AssertionError(f"invalid SSE cursor epoch: {raw!r}")
+    try:
+        return epoch, int(seq)
+    except ValueError as exc:
+        raise AssertionError(f"invalid SSE cursor sequence: {raw!r}") from exc
+
+
 def expect_error(fn, status: int, check: Check, name: str) -> None:
     import elastik
 
@@ -1298,7 +1310,10 @@ def main() -> int:
             check(replay_done.wait(5), "Last-Event-ID replays missed SSE event")
             replay = replay_events[0]
             check(replay.get("path") == "/home/sdk/listen/b", "replayed SSE event path")
-            check(int(replay.get("id", "0")) > int(ev.get("id", "0")), "replayed SSE id advances")
+            ev_epoch, ev_seq = sse_cursor_parts(ev.get("id", "0"))
+            replay_epoch, replay_seq = sse_cursor_parts(replay.get("id", "0"))
+            check(replay_epoch == ev_epoch, "replayed SSE cursor keeps listen epoch")
+            check(replay_seq > ev_seq, "replayed SSE cursor advances")
 
             elastik.clear_routes()
             elastik.clear_lifecycle_hooks()


### PR DESCRIPTION
## Stack repair note

This PR exposes the previously hidden Stack 22 base branch used by #336.

Base: `master` (after #330-#335 drained through `stack/21-cas-schema`)
Head: `stack/22r19-audit-verify-world-target`

Why this exists:
- #336 was already based on `stack/22r19-audit-verify-world-target`.
- That branch had no GitHub PR, so the stack had a hidden base gap.
- This PR makes that base visible for review and CI instead of letting upper layers depend on an untracked branch.

Scope:
- Audit append/files/error extraction groundwork.
- CAS retained-body verification/accounting groundwork.
- Audit target binding and live-body verification hardening.
- AGENTS stack-repair exception text.

Process caveat:
This is a repair PR for an already-existing hidden base. It is larger than normal single-layer policy and should be reviewed as stack-topology repair, not as permission to add new feature scope above it.

Validation:
- #330-#335 have been merged into `master`; `master` tree matches the former `stack/21-cas-schema` base.
- Existing upper-stack CI on #336 already built against this base.
- Current stack-tip validation is recorded in `design_notes/STACK-22-CASCADE-REPAIR-LEDGER.md` on the top repair branch.

## CI repair ledger

Commit `74925fe` is a test-only repair for the SDK blackbox replay check.

What changed:
- `sdk/tests/e2e_blackbox.py` stopped treating SSE `id` as an integer.
- The test now parses the server-emitted `epoch:seq` cursor shape and checks same epoch plus advancing sequence.

Local validation:
- `python sdk/tests/e2e_blackbox.py` -> `PASS sdk e2e blackbox: 234 checks`.
- Pre-push hook passed Rust format, clippy, Rust tests, version consistency, supply-chain quick audit, SDK smoke, header policy scan, JS syntax, and whitespace check.
- `git diff --check` clean.

Fresh review round:
- Popper/precondition: CLEAN P0-P2.
- Mencius/type-seal: CLEAN P0-P2.
- Poincare/topology: CLEAN P0-P2.
- Bacon/QA: CLEAN P0-P2 and safe to commit.

## Canonical cursor follow-up

Commit `d039199` tightens that same SDK blackbox helper to match the Rust cursor contract exactly.

What changed:
- The helper now requires `<32 lowercase hex epoch>:<canonical decimal event id>`.
- It rejects empty, non-digit, non-canonical, and `u64`-overflow sequence suffixes instead of relying on Python `int()`.
- The replay test parses the emitted id before use and sends the original opaque cursor string as `Last-Event-ID`.

Validation:
- `python sdk/tests/e2e_blackbox.py --no-build` on #359 head -> 234 checks passed.
- Pre-push fast gates passed when pushing `d039199`.
- The fix was propagated through `stack/22r20` through `stack/22r41` by merge cascade, not rebase/squash.

Fresh review/adjudication:
- Mencius/Popper found the Python `int()` acceptance gap as a real P2; fixed by `d039199`.
- A later disputed P2 claimed bare decimal `Last-Event-ID` should be rejected. Two independent verifiers judged it false-positive: emitted SSE ids are opaque `epoch:seq`, while bare decimal `Last-Event-ID` is intentional legacy input and core maps it to foreign/stale replay semantics, not current-process replay.
- Final process QA on committed state: CLEAN P0-P2; remote CI was still pending at the time of review with no observed failures.